### PR TITLE
[DOCS]Includes SIEM index file

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -12,3 +12,5 @@ include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 include::sensor-full-disk-access.asciidoc[]
+
+include::siem/index.asciidoc[]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -13,4 +13,5 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 include::sensor-full-disk-access.asciidoc[]
 
-include::siem/index.asciidoc[]
+// Temporary fix of section levels
+include::siem/index.asciidoc[leveloffset=+1]

--- a/docs/siem/index.asciidoc
+++ b/docs/siem/index.asciidoc
@@ -5,7 +5,8 @@
 :ml-dir:       {stack-docs-root}/docs/en/stack/ml
 :sn: ServiceNow
 
-= SIEM Guide
+// Removed for merging with unified security docs
+// = SIEM Guide
 
 include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 


### PR DESCRIPTION
Includes the SIEM index file, so SIEM docs are built and tested when PRs for 7.9 are opened.

[Preview](https://security-docs_20.docs-preview.app.elstc.co/guide/en/security/current/index.html)