### PR TITLE
Change links to refactored Beats getting started docs

### DIFF
--- a/docs/siem/installation.asciidoc
+++ b/docs/siem/installation.asciidoc
@@ -84,17 +84,16 @@ If your data source isn't in the list, or you want to install {beats} the old
 fashioned way:
 
 * *{filebeat} and {filebeat} modules.* See the
-{filebeat-ref}/filebeat-modules-quickstart.html[{filebeat} modules quick start]
+{filebeat-ref}/filebeat-installation-configuration.html[{filebeat} quick start]
 and enable modules for the events you want to collect. If there is no module
 for the events you want to collect, see the
-{filebeat-ref}/filebeat-getting-started.html[{filebeat} getting started] to
-learn how to configure inputs.
+{filebeat-ref}/configuration-filebeat-options.html[Conifgure inputs].
 
-* *Auditbeat.* See {auditbeat-ref}/auditbeat-getting-started.html[{auditbeat} getting started].
+* *Auditbeat.* See {auditbeat-ref}/auditbeat-installation-configuration.html[{auditbeat} quick start].
 
-* *Winlogbeat.* See {winlogbeat-ref}/winlogbeat-getting-started.html[{winlogbeat} getting started].
+* *Winlogbeat.* See {winlogbeat-ref}/winlogbeat-installation-configuration.html[{winlogbeat} quick start].
 
-* *Packetbeat.* See {packetbeat-ref}/packetbeat-getting-started.html[{packetbeat} getting started].
+* *Packetbeat.* See {packetbeat-ref}/packetbeat-installation-configuration.html[{packetbeat} quick start].
 
 [float]
 === Enable modules and configuration options


### PR DESCRIPTION
Updates links to reflect changes added in elastic/beats#19302.

This change applies to 7.9 and later.