### PR TITLE
[7.x] makes admin overview a first-level section (#99)

### DIFF
--- a/docs/management/admin/admin-pg-ov.asciidoc
+++ b/docs/management/admin/admin-pg-ov.asciidoc
@@ -1,5 +1,6 @@
 [[admin-page-ov]]
-== Administration page overview
+[chapter, role="xpack"]
+= Administration page overview
 The Administration page enables admins to view and manage hosts that are running Elastic Endpoint Security.
 
 NOTE: Ingest Manager must be enabled in a Kibana Space for administrative actions to function correctly.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - makes admin overview a first-level section (#99)