### PR TITLE
[DOCS] Update nesting of event investigation

### DIFF
--- a/docs/events/index.asciidoc
+++ b/docs/events/index.asciidoc
@@ -1,5 +1,4 @@
 [[investigate-events]]
-
 = Investigate events
 
 [partintro]
@@ -7,5 +6,5 @@
 This sections describes how to use timelines and the timeline graphical interface to investigate events.
 ---
 
-include::timeline-ui-overview.asciidoc[]
-include::timeline-templates.asciidoc[]
+include::timeline-ui-overview.asciidoc[leveloffset=+1]
+include::timeline-templates.asciidoc[leveloffset=+2]

--- a/docs/events/timeline-templates.asciidoc
+++ b/docs/events/timeline-templates.asciidoc
@@ -1,5 +1,5 @@
 [[timeline-templates-ui]]
-== About Timeline templates
+= About Timeline templates
 
 You can attach Timeline templates to detection rules. When attached, the rule's
 alerts use the template when they are investigated in Timeline. This enables
@@ -37,7 +37,7 @@ a starting point for your own custom templates.
 
 [discrete]
 [[template-legend-ui]]
-=== Timeline template legend
+== Timeline template legend
 
 When you add filters to a Timelime template, the items are color coded to
 indicate which type of filter is added. Additionally, you change Timeline
@@ -65,7 +65,7 @@ filter (see <<pivot>>).
 
 
 [discrete]
-=== Create a Timeline template
+== Create a Timeline template
 
 . Go to *Security* -> *Timelines*.
 . Click the *Templates* tab, and then *Create new timeline template*.
@@ -100,7 +100,7 @@ value is retrieved from the alert's `process.name` field.
 
 [discrete]
 [[man-templates-ui]]
-=== Manage existing Timeline templates
+== Manage existing Timeline templates
 
 You can view, duplicate, delete, and create templates from existing Timelines:
 


### PR DESCRIPTION
Related to https://github.com/elastic/security-docs/pull/129

This PR fixes the following build error:

> INFO:build_docs:asciidoctor: ERROR: events/timeline-ui-overview.asciidoc: line 3: invalid part, must have at least one section (e.g., chapter, appendix, etc.)

It also resets the section levels in timeline-templates.asciidoc so that the hierarchy is managed from the index.asciidoc