### PR TITLE
[7.x] Remove standalone Endpoint installation instructions (#158)

### DIFF
--- a/docs/getting-started/install-endpoint.asciidoc
+++ b/docs/getting-started/install-endpoint.asciidoc
@@ -38,10 +38,9 @@ image::images/install-endpoint/add-elastic-endpoint-security.png[]
 [[enroll-security-agent]]
 == Configure and enroll Elastic Agent
 
-There are two methods to install the Elastic Agent with the Elastic Endpoint Security integration using Ingest Manager.
+When integrating with the Elastic Agent, Elastic Endpoint Security **requires** enrollment through Fleet to enable the integration. 
 
-[discrete]
-=== Enroll with Fleet
+IMPORTANT: Elastic Endpoint Security cannot be integrated with an Elastic Agent in Standalone mode.
 
 1. Go to Ingest Manager. Select **Overview** > **Add agent**.
 +
@@ -58,19 +57,4 @@ image::images/install-endpoint/endpoint-configuration.png[]
 
 After you have enrolled the Elastic Agent on your host, select **Continue**. The host now appears on the Hosts view page inside the Elastic Security app.
 
-[discrete]
-=== Standalone mode
-
-If you want to manage the Elastic Agent without using Fleet to manage your hosts, you can enroll the Agent on your host in {ingest-guide}/ingest-management-getting-started.html#agent-standalone-mode.
-
-1. In the Add agent pane, select the **Standalone mode** tab.
-2. Download the Elastic Agent on your host's machine and select an agent configuration.
-3. In the installed Agent's directory, create a file named `elastic-agent.yml`. Copy your configuration into the file from Step 3 of the Add agent pane. Remember to modify `ES_USERNAME` and `ES_PASSWORD` in the `outputs` section with your Elastic username and password.
-4. Save the file and start the Agent using `./elastic-agent run` for your OS.
-5. Once the Agent begins to send data, verify that the data is viewable in Kibana by going to **Ingest Manager** > **Datasets**.
-
-[role="screenshot"]
-image::images/install-endpoint/datasets.png[]
-
-
-TIP: To unenroll an agent from your host, see {ingest-guide}/unenroll-elastic-agent.html[Unenroll Elastic Agent].
+To unenroll an agent from your host, see {ingest-guide}/unenroll-elastic-agent.html[Unenroll Elastic Agent].


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Remove standalone Endpoint installation instructions (#158)