### PR TITLE
[7.9] Update es-overview.asciidoc (#166)

### DIFF
--- a/docs/es-overview.asciidoc
+++ b/docs/es-overview.asciidoc
@@ -72,19 +72,27 @@ collectors mapped to the {ecs-ref}[Elastic Common Schema (ECS)].
 === Hosts data sources
 
 * https://www.elastic.co/products/beats/auditbeat[{auditbeat}]
-** {auditbeat-ref}/auditbeat-module-system.html[System module  - Linux, macOS, Win]
+** {auditbeat-ref}/auditbeat-module-system.html[System module  - Linux, macOS, Windows]
 *** packages
 *** processes
 *** logins
 *** sockets
 *** users and groups
 ** {auditbeat-ref}/auditbeat-module-auditd.html[Auditd module (Linux Kernel Audit info)]
-** {auditbeat-ref}/auditbeat-module-file_integrity.html[File integrity module (FIM) - Linux, macOS, Win]
+** {auditbeat-ref}/auditbeat-module-file_integrity.html[File integrity module (FIM) - Linux, macOS, Windows
 * https://www.elastic.co/products/beats/filebeat[{filebeat}]
 ** system logs (auth logs) - Linux
 ** Santa - macOS
 * https://www.elastic.co/products/beats/winlogbeat[{winlogbeat}]
 ** Windows event logs - Windows
+* https://www.elastic.co/products/endpoint-security[Elastic Endpoint Security]
+** Process - Linux, macOS, Windows
+** Network - Linux, macOS, Windows
+** File - Linux, macOS, Windows
+** DNS - Windows
+** Registry - Windows
+** DLL and Driver Load - Windows
+** Security - Windows
 
 [discrete]
 [[network-data-sources]]


### PR DESCRIPTION
Backports the following commits to 7.9:
 - Update es-overview.asciidoc (#166)