### PR TITLE
[7.9] removes resolver from section URL (#183)

### DIFF
--- a/docs/detections/alerts-ui-manage.asciidoc
+++ b/docs/detections/alerts-ui-manage.asciidoc
@@ -96,7 +96,7 @@ For information about exceptions and how to use them, see
 <<detections-ui-exceptions>>.
 
 [float]
-[[alerts-to-resolver]]
+[[alerts-analyze-events]]
 === Visually analyze process relationships.
 
 For process events received from the Elastic Endpoint agent, you can open a


### PR DESCRIPTION
Backports the following commits to 7.9:
 - removes resolver from section URL (#183)