### PR TITLE
[7.9] removes unnecessary tip (#198)

### DIFF
--- a/docs/getting-started/detections-req.asciidoc
+++ b/docs/getting-started/detections-req.asciidoc
@@ -86,11 +86,6 @@ Management` features
 +
 Where `<kib-space>` is the {kib} space name.
 
-TIP: To enable autocomplete for rule queries when creating or modifying
-detection rules, add `read` privileges for all `securitySolution:defaultIndex`
-indices (*{kib}* -> *Stack Management* -> *Advanced Settings* ->
-*`securitySolution:defaultIndex`*).
-
 Here's a screenshot of a user role that can view and create detection rules in all {kib}
 spaces:
 


### PR DESCRIPTION
Backports the following commits to 7.9:
 - removes unnecessary tip (#198)