### PR TITLE
[7.9] removes full stop from title (#211)

### DIFF
--- a/docs/detections/alerts-ui-manage.asciidoc
+++ b/docs/detections/alerts-ui-manage.asciidoc
@@ -97,7 +97,7 @@ For information about exceptions and how to use them, see
 
 [float]
 [[alerts-analyze-events]]
-=== Visually analyze process relationships.
+=== Visually analyze process relationships
 
 For process events received from the Elastic Endpoint agent, you can open a
 visual mapping of the relationships and hierarchy connecting related processes.


### PR DESCRIPTION
Backports the following commits to 7.9:
 - removes full stop from title (#211)