### PR TITLE
[Docs]Adds index post upgrade requirement clarifications

### DIFF
--- a/docs/post-upgrade-req.asciidoc
+++ b/docs/post-upgrade-req.asciidoc
@@ -1,22 +1,13 @@
 [[post-upgrade-req]]
 [role="xpack"]
-= Post upgrade requirements
+= Enable process analyzer after upgrade
 
-After upgrading the {stack} to version 7.9.x from a previous minor release
-(7.8.x, 7.7.x, and so on), you need to:
+To enable <<alerts-analyze-events, graphical representations of process relationships>>
+after upgrading to {stack} version 7.9.0 or 7.9.1 from a
+previous minor release (7.8.x, 7.7.x, and so on), you need to update
+`.siem-signals*` system index mappings.
 
-* <<update-signal-index-mapping, Update `.siem-signals*` system index mappings>>.
-* <<enable-detections-ui, Enable access to the Detections page>>.
-+
-NOTE: Previously activated detection rules continue to run after upgrading, and this
-is only required to enable the UI.
-
-[discrete]
-[[update-signal-index-mapping]]
-== Update `.siem-signals*` index mapping
-
-After upgrading, you must update the `.siem-signals*` index mapping, which
-contains detection alerts. To do this:
+To update the .siem-signals*` index:
 
 . Create a new {ref}/index-templates.html[index template] for storing existing
 detections alerts (see <<create-template>>).

--- a/docs/post-upgrade-req.asciidoc
+++ b/docs/post-upgrade-req.asciidoc
@@ -7,7 +7,7 @@ after upgrading to {stack} version 7.9.0 or 7.9.1 from a
 previous minor release (7.8.x, 7.7.x, and so on), you need to update
 `.siem-signals*` system index mappings.
 
-To update the .siem-signals*` index:
+To update the `.siem-signals*` index:
 
 . Create a new {ref}/index-templates.html[index template] for storing existing
 detections alerts (see <<create-template>>).

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -18,10 +18,11 @@
 After upgrading the {stack} to version 7.9.x from a previous minor release
 (7.8.x, 7.7.x, and so on), you need to:
 
-* <<update-signal-index-mapping>>.
 * <<enable-detections-ui, Enable access to the Detections page>>. Previously
 activated detection rules continue to run after upgrading, and this is only
 required to enable the UI.
+* <<post-upgrade-req, Enable the process analyzer>>. This is only required if you want to view
+<<alerts-analyze-events, graphical representations of process relationships>>.
 
 [discrete]
 [[breaking-changes-7.9]]

--- a/docs/template-script.asciidoc
+++ b/docs/template-script.asciidoc
@@ -2,9 +2,10 @@
 = Index template script
 
 This code creates a new index template for temporarily storing existing
-detection alerts when you need to update `.siem-signals-*` index mappings. You
-need to update the index mappings after upgrading to {stack} release 7.9.x from
-a previous minor release (7.8.x, 7.7.x, and so on).
+detection alerts when you update `.siem-signals-*` index mappings. You
+need to update the index mappings to visualize process relationships after
+upgrading to {stack} release 7.9.0 or 7.9.1 from a previous minor release
+(7.8.x, 7.7.x, and so on).
 
 TIP: <<bottom, Click here>> to scroll to the bottom of the page and use the
 builtin functions to paste the code into the {kib} dev console. You can click on


### PR DESCRIPTION
Describes when remapping signals index is required.

[Reindex procedure preview](https://security-docs_223.docs-preview.app.elstc.co/guide/en/security/master/post-upgrade-req.html)
[RNs preview](https://security-docs_223.docs-preview.app.elstc.co/guide/en/security/master/release-notes.html)