### PR TITLE
[Docs]Fix signals index typo

### DIFF
--- a/docs/detections/api/rules/rules-api-overview.asciidoc
+++ b/docs/detections/api/rules/rules-api-overview.asciidoc
@@ -41,7 +41,7 @@ To create and run rules, the user role for the {kib} space must have:
 * {kib} space `All` privileges for the `Security` and `Saved Objects Management`
 features (see
 {kibana-ref}/xpack-spaces.html#spaces-control-user-access[Feature access based on user privileges]).
-* `read` and `write` privileges for the `.signals-*` index (the system index
+* `read` and `write` privileges for the `.siem-signals-*` index (the system index
 used for storing detection alerts created from rules).
 
 


### PR DESCRIPTION
Fixes a typo on the rules API overview page.