### PR TITLE
Replace On-Prem with self-managed in Detections section

### DIFF
--- a/docs/detections/detection-engine-intro.asciidoc
+++ b/docs/detections/detection-engine-intro.asciidoc
@@ -154,7 +154,7 @@ If you see this message, a user with specific privileges must visit the
 *Detections* page before you can view detection rules and alerts.
 See <<enable-detections-ui>> for a list of all the requirements.
 
-NOTE: For *on-premises* {stack} deployments only, this message may be displayed
+NOTE: For *self-managed* {stack} deployments only, this message may be displayed
 when the
 <<detections-permissions, `xpack.encryptedSavedObjects.encryptionKey`>>
 setting has not been added to the `kibana.yml` file. For more information, see <<detections-on-prem-requirements>>.
@@ -165,6 +165,6 @@ If you see this message, you do not have the
 <<detections-permissions, required privileges>> to view the *Detections* page,
 and you should contact your {kib} administrator.
 
-NOTE: For *on-premises* {stack} deployments only, this message may be
+NOTE: For *self-managed* {stack} deployments only, this message may be
 displayed when the <<detections-permissions, `xpack.security.enabled`>>
 setting is not enabled in the `elasticsearch.yml` file. For more information, see <<detections-on-prem-requirements>>.

--- a/docs/getting-started/detections-req.asciidoc
+++ b/docs/getting-started/detections-req.asciidoc
@@ -4,7 +4,7 @@
 To use the <<detection-engine-overview, Detections feature>>, you need to
 configure a few things.
 
-IMPORTANT: There are a number of step that are *only* required for *on-premises*
+IMPORTANT: There are a number of step that are *only* required for *self-managed*
 {stack} deployments. If you are using a cloud deployments, you only need to
 configure <<enable-detections-ui>> and <<access-detections-ui>>.
 
@@ -16,9 +16,9 @@ You need the https://www.elastic.co/subscriptions[appropriate license] to send
 
 [discrete]
 [[detections-on-prem-requirements]]
-== Configure on-premises {stack} deployments
+== Configure self-managed {stack} deployments
 
-These steps are only required for *on-premises* deployments:
+These steps are only required for *self-managed* deployments:
 
 * HTTPS must be configured for communication between
 {kibana-ref}/configuring-tls.html#configuring-tls-kib-es[{es} and {kib}].

--- a/docs/getting-started/detections-req.asciidoc
+++ b/docs/getting-started/detections-req.asciidoc
@@ -5,7 +5,7 @@ To use the <<detection-engine-overview, Detections feature>>, you need to
 configure a few things.
 
 IMPORTANT: There are a number of step that are *only* required for *self-managed*
-{stack} deployments. If you are using a cloud deployments, you only need to
+{stack} deployments. If you are using an Elastic Cloud deployment, you only need to
 configure <<enable-detections-ui>> and <<access-detections-ui>>.
 
 Additionally, there are some <<adv-list-settings, advanced settings>> used to
@@ -22,12 +22,12 @@ These steps are only required for *self-managed* deployments:
 
 * HTTPS must be configured for communication between
 {kibana-ref}/configuring-tls.html#configuring-tls-kib-es[{es} and {kib}].
-* In the `elasticsearch.yml` configuration file, set the 
-`xpack.security.enabled` setting to `true`. For more information, see 
+* In the `elasticsearch.yml` configuration file, set the
+`xpack.security.enabled` setting to `true`. For more information, see
 {ref}/settings.html[Configuring {es}] and
 {ref}/security-settings.html[Security settings in {es}].
-* In the `kibana.yml` {kibana-ref}/settings.html[configuration file], add the 
-`xpack.encryptedSavedObjects.encryptionKey` setting with any alphanumeric value 
+* In the `kibana.yml` {kibana-ref}/settings.html[configuration file], add the
+`xpack.encryptedSavedObjects.encryptionKey` setting with any alphanumeric value
 of at least 32 characters. For example:
 +
 `xpack.encryptedSavedObjects.encryptionKey: 'fhjskloppd678ehkdfdlliverpoolfcr'`
@@ -118,5 +118,5 @@ uploading value lists. Set to a higher value to increase throughput at the
 expense of using more Kibana memory, or a lower value to decrease throughput and
 reduce memory usage.
 
-NOTE: For information on how to configure cloud deployments, see
+NOTE: For information on how to configure Elastic Cloud deployments, see
 {cloud}/ec-manage-kibana-settings.html[Add Kibana user settings].

--- a/docs/getting-started/sec-app-requirements.asciidoc
+++ b/docs/getting-started/sec-app-requirements.asciidoc
@@ -70,5 +70,5 @@ For information on how to perform cross-cluster searches on {es-sec}
 indices, see:
 
 * {ref}/modules-cross-cluster-search.html[Search across cluster]
-(for on-premises {stack} deployments)
+(for self-managed {stack} deployments)
 * {cloud}/ec-enable-ccs.html[Enable cross-cluster search] (for hosted deployments)


### PR DESCRIPTION
- Changed all instances of "on-premises" to "self-managed".
- Replaced all instances of "Cloud deployments" with Elastic Cloud Deployments. Elastic Cloud covers a wider gamut of potential Elastic deployments beyond Elasticsearch.