### PR TITLE
[DOCS] Add machine learning jobs to Whats New

### DIFF
--- a/docs/whats-new.asciidoc
+++ b/docs/whats-new.asciidoc
@@ -8,6 +8,7 @@
 
 coming::[7.10.0]
 
+[discrete]
 [[sec-ml-7.10-changes]]
 === New prebuilt {ml} {anomaly-jobs}
 

--- a/docs/whats-new.asciidoc
+++ b/docs/whats-new.asciidoc
@@ -3,6 +3,20 @@
 = What's new
 
 [discrete]
+[[sec-7.10-release]]
+== 7.10 release
+
+coming::[7.10.0]
+
+[[sec-ml-7.10-changes]]
+=== New prebuilt {ml} {anomaly-jobs}
+
+{elastic-sec} now provides additional {anomaly-jobs} for {auditbeat} and
+{winlogbeat} data. Twelve new metadata and discovery analysis jobs have been
+added to enable threat detection on metadata services, system and discovery
+processes, and compiler events. For the full list, see <<prebuilt-ml-jobs>>.
+
+[discrete]
 [[sec-7.9-release]]
 == 7.9 release
 


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/pull/76023 and https://github.com/elastic/stack-docs/pull/1363

This PR adds a blurb about the new prebuilt machine learning jobs in the "[What's New](https://www.elastic.co/guide/en/security/master/whats-new.html)" for 7.10

### Preview

https://security-docs_319.docs-preview.app.elstc.co/guide/en/security/master/whats-new.html