### PR TITLE
[7.x] update to what's new (#361)

### DIFF
--- a/docs/whats-new.asciidoc
+++ b/docs/whats-new.asciidoc
@@ -6,8 +6,6 @@
 [[sec-7.10-release]]
 == 7.10 release
 
-coming::[7.10.0]
-
 [discrete]
 [[sec-7.10-term-changes]]
 === Terminology changes
@@ -21,8 +19,8 @@ coming::[7.10.0]
 * New support for macOS 11.0 (Big Sur).
 * Enhanced user interface for the <<admin-page-ov, Endpoint Administration>> page.
 * Add <<trusted-apps-ov, trusted applications>> to avoid performance or compatibility issues.
-* New Event Correlation rule type>> based on {ref}/eql.html[EQL (Event Query Language)].
-* New Indicator Match rule type to create alerts for index field values that match threat indices.
+* New <<create-eql-rule, Event Correlation rule type>> based on {ref}/eql.html[EQL (Event Query Language)].
+* New <<create-indicator-rule, Indicator Match rule type>> to create alerts for index field values that match threat indices.
 * Free, open detections in the https://github.com/elastic/detection-rules#detection-rules[Detection Rules repo].
 * New <<timelines-ui, timeline enhancements>> that include detection alert actions.
 * Connect and send <<cases-overview, cases>> to external systems (ServiceNow, Jira, Resilient)


### PR DESCRIPTION
Backports the following commits to 7.x:
 - update to what's new (#361)