### PR TITLE
[7.10] [7.10]: Add upgrade requirements to 7.10 release notes (#369)

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -25,6 +25,15 @@ required to enable the UI.
 == 7.10.0
 
 [discrete]
+[[upgrade-notes-7.10]]
+==== Post upgrade requirements
+
+When upgrading the {stack} to version 7.10.0 from a previous minor version (7.9.x), 
+perform the following:
+
+* Grant `view_index_metadata` https://www.elastic.co/guide/en/security/current/detections-permissions-section.html#enable-detections-ui[permissions] to any Elastic Security users. This is required to enable **event correlation** rules. Other previously activated detection rules will continue to run after upgrade.
+
+[discrete]
 [[breaking-changes-7.10.0]]
 ==== Breaking changes
 
@@ -79,6 +88,19 @@ image::images/detection-rule-failure.png[]
 [discrete]
 [[release-notes-7.9.1]]
 == 7.9.1
+
+[discrete]
+[[upgrade-notes-7.9.1]]
+==== Post upgrade requirements
+
+After upgrading the {stack} to version 7.9.0 and 7.9.1 from a previous minor
+release (7.8.x, 7.7.x, and so on), you need to:
+
+* <<enable-detections-ui, Enable access to the Detections page>>. Previously
+activated detection rules continue to run after upgrading, and this is only
+required to enable the UI.
+* <<post-upgrade-req, Enable the process analyzer>>. This is only required if you want to view
+<<alerts-analyze-events, graphical representations of process relationships>>.
 
 [discrete]
 [[bug-fixes-7.9.1]]


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [7.10]: Add upgrade requirements to 7.10 release notes (#369)