### PR TITLE
Fix Fleet links and naming

### DIFF
--- a/docs/es-overview.asciidoc
+++ b/docs/es-overview.asciidoc
@@ -88,7 +88,7 @@ and maps.
 The Elastic https://www.elastic.co/endpoint-security/[Endpoint Security agent integration]
 provides capabilities such as collecting events, detecting and preventing
 malicious activity, exceptions, and artifact delivery. The
-{ingest-guide}/ingest-management-overview.html[Ingest Manager] is used to
+{ingest-guide}/fleet-overview.html[{fleet}] is used to
 install and manage Elastic agents and integrations on your hosts.
 
 [discrete]

--- a/docs/getting-started/advanced-setting.asciidoc
+++ b/docs/getting-started/advanced-setting.asciidoc
@@ -53,7 +53,7 @@ NOTE: Index patterns use wildcards to specify a set of indices. For example, the
 available in the {es-sec-app}.
 
 All of the default index patterns match {beats-ref}/beats-reference.html[{beats}] and
-{ingest-guide}/ingest-management-overview.html[{agent}] indices. This means all
+{ingest-guide}/fleet-overview.html[{agent}] indices. This means all
 data shipped via {beats} and the {agent} is automatically added to the
 {es-sec-app}.
 

--- a/docs/getting-started/install-endpoint.asciidoc
+++ b/docs/getting-started/install-endpoint.asciidoc
@@ -5,9 +5,9 @@
 beta[]
 
 
-Like other Elastic integrations, Elastic Endpoint Security can be integrated into the Elastic Agent through {ingest-guide}/ingest-management-overview.html[Ingest Manager]. Upon configuration, the integration allows the Elastic Agent to monitor for events on your host and send data to the Elastic Security app.
+Like other Elastic integrations, Elastic Endpoint Security can be integrated into the Elastic Agent through {ingest-guide}/fleet-overview.html[{fleet}]. Upon configuration, the integration allows the Elastic Agent to monitor for events on your host and send data to the Elastic Security app.
 
-NOTE: Configuring the Endpoint Integration on the Elastic Agent requires that the user have permission to use Ingest Manager in Kibana.
+NOTE: Configuring the Endpoint Integration on the Elastic Agent requires that the user have permission to use {fleet} in Kibana.
 
 [discrete]
 [[security-before-you-begin]]
@@ -19,7 +19,7 @@ Depending on the version of macOS you're using, macOS requires that you give ful
 [[add-security-integration]]
 == Add Elastic Endpoint integration
 
-1. In Kibana, select **Security** > **Administration**. If this is not your first time using Elastic Security, select **Ingest Manager** > **Integrations** and search for "Elastic Endpoint Security".
+1. In Kibana, select **Security** > **Administration**. If this is not your first time using Elastic Security, select **{fleet}** > **Integrations** and search for "Elastic Endpoint Security".
 +
 [role="screenshot"]
 image::images/install-endpoint/security-integration.png[]

--- a/docs/management/admin/admin-pg-ov.asciidoc
+++ b/docs/management/admin/admin-pg-ov.asciidoc
@@ -93,7 +93,7 @@ image::images/config-status.png[Config status details]
 
 Expand each section and subsection to view individual responses from the agent.
 
-TIP: If you need help troubleshooting a configuration failure, see the {ingest-guide}/ingest-management-troubleshooting.html[Fleet troubleshooting topic].
+TIP: If you need help troubleshooting a configuration failure, see the {ingest-guide}/fleet-troubleshooting.html[{fleet} troubleshooting topic].
 
 *Filter endpoints*
 

--- a/docs/siem/overview.asciidoc
+++ b/docs/siem/overview.asciidoc
@@ -101,12 +101,12 @@ collectors mapped to the {ecs-ref}[Elastic Common Schema (ECS)].
 
 [discrete]
 [[endpoint-security-platform]]
-==== Elastic Endpoint and Ingest Manager
+==== Elastic Endpoint and {fleet}
 
 The Elastic Endpoint provides capabilities such as collecting events, detecting
 and preventing malicious activity, allowlisting and artifact delivery. A single
 unified agent is used to install the endpoint on hosts. Agents and integrations
-are managed by the Ingest Manager.
+are managed by {fleet}.
 
 [discrete]
 [[apm-transactions-data]]


### PR DESCRIPTION
Fixes links to the Fleet documentation, which has moved in 7.10 and later.

Also renames Ingest Manager to Fleet (changed in 7.10, too)

Related PR: https://github.com/elastic/observability-docs/pull/257