### PR TITLE
[7.x] Adding ECS note to docs. (#379)

### DIFF
--- a/docs/es-overview.asciidoc
+++ b/docs/es-overview.asciidoc
@@ -118,6 +118,7 @@ index patterns in the `securitySolution:defaultIndex` setting ({kib} -> Stack Ma
 The {ecs-ref}[Elastic Common Schema (ECS)] defines a common set of fields to be used for
 storing event data in Elasticsearch. ECS helps users normalize their event data
 to better analyze, visualize, and correlate the data represented in their
-events.
+events. {es-sec} can ingest and normalize events from any ECS-compliant data source.
 
-Elastic Security can ingest and normalize events from any ECS-compliant data source.
+IMPORTANT: {es-sec} requires {ecs-ref}[ECS-compliant data]. If you use third-party data collectors to ship data to {es}, the data must be mapped to ECS.
+<<siem-field-reference>> lists ECS fields used in {es-sec}.

--- a/docs/getting-started/sec-app-requirements.asciidoc
+++ b/docs/getting-started/sec-app-requirements.asciidoc
@@ -64,6 +64,16 @@ required subscription plans for all features.
 links.
 
 [discrete]
+== Third-party collectors mapped to ECS
+
+The {ecs-ref}[Elastic Common Schema (ECS)] defines a common set of fields to be used for storing event data in Elasticsearch. ECS helps users normalize their event data
+to better analyze, visualize, and correlate the data represented in their
+events. {es-sec} can ingest and normalize events from any ECS-compliant data source.
+
+IMPORTANT: {es-sec} requires {ecs-ref}[ECS-compliant data]. If you use third-party data collectors to ship data to {es}, the data must be mapped to ECS.
+<<siem-field-reference>> lists ECS fields used in {es-sec}.
+
+[discrete]
 == Cross-cluster searches
 
 For information on how to perform cross-cluster searches on {es-sec}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Adding ECS note to docs. (#379)