### PR TITLE
[7.x] Issue #410: Add 7.10.1 release notes (#402)

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -9,6 +9,21 @@
 
 
 [discrete]
+[[release-notes-7.10.1]]
+== 7.10.1
+
+[discrete]
+[[bug-fixes-7.10.1]]
+==== Bug fixes and enhancements
+
+* Fixes EQL previews which now accept all date formats ({pull}83939[#83939]).
+* Fixes incorrect time for DNS histograms ({pull}83781[#83781]).
+* Fixes UI strings around indicator matching and mapping definitions 
+({pull}82510[#82510]).
+* Fixes layout in "Severity override" drop-down when creating a new rule ({pull}82271[#82271]).
+
+
+[discrete]
 [[release-notes-7.10.0]]
 == 7.10.0
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Issue #410: Add 7.10.1 release notes (#402)