### PR TITLE
[7.x] Issue-395: Change Event Type for Timeline Schema (#400)

### DIFF
--- a/docs/reference/timeline-schema.asciidoc
+++ b/docs/reference/timeline-schema.asciidoc
@@ -53,9 +53,9 @@ timestamp.
 |[[timeline-object-eventtype]]`eventType` |String a|Event types displayed in
 the timeline, which can be:
 
-* `all`: all events
-* `raw`: raw events only
-* `signal`: alerts only
+* `All data sources`
+* `Events`: Event sources only
+* `Detection Alerts`: Detection alerts only
 
 |`favorite` |<<favorite-obj, favorite[]>> |Indicates when and who marked a
 timeline as a favorite.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Issue-395: Change Event Type for Timeline Schema (#400)