### PR TITLE
[7.10] Fix broken Fleet links (#420)

### DIFF
--- a/docs/es-overview.asciidoc
+++ b/docs/es-overview.asciidoc
@@ -88,7 +88,7 @@ and maps.
 The Elastic https://www.elastic.co/endpoint-security/[Endpoint Security agent integration]
 provides capabilities such as collecting events, detecting and preventing
 malicious activity, exceptions, and artifact delivery. The
-{ingest-guide}/fleet-overview.html[{fleet}] is used to
+{fleet-guide}/fleet-overview.html[{fleet}] is used to
 install and manage Elastic agents and integrations on your hosts.
 
 [discrete]

--- a/docs/getting-started/advanced-setting.asciidoc
+++ b/docs/getting-started/advanced-setting.asciidoc
@@ -53,7 +53,7 @@ NOTE: Index patterns use wildcards to specify a set of indices. For example, the
 available in the {es-sec-app}.
 
 All of the default index patterns match {beats-ref}/beats-reference.html[{beats}] and
-{ingest-guide}/fleet-overview.html[{agent}] indices. This means all
+{fleet-guide}/fleet-overview.html[{agent}] indices. This means all
 data shipped via {beats} and the {agent} is automatically added to the
 {es-sec-app}.
 

--- a/docs/getting-started/install-endpoint.asciidoc
+++ b/docs/getting-started/install-endpoint.asciidoc
@@ -5,7 +5,7 @@
 beta[]
 
 
-Like other Elastic integrations, Endpoint Security can be integrated into the Elastic Agent through {ingest-guide}/fleet-overview.html[{fleet}]. Upon configuration, the integration allows the Elastic Agent to monitor for events on your host and send data to the Elastic Security app.
+Like other Elastic integrations, Endpoint Security can be integrated into the Elastic Agent through {fleet-guide}/fleet-overview.html[{fleet}]. Upon configuration, the integration allows the Elastic Agent to monitor for events on your host and send data to the Elastic Security app.
 
 NOTE: Configuring the Endpoint Integration on the Elastic Agent requires that the user have permission to use {fleet} in Kibana.
 
@@ -25,7 +25,7 @@ Depending on the version of macOS you're using, macOS requires that you give ful
 image::images/install-endpoint/security-integration.png[]
 +
 2. On the Administration page of the {security-app} or the Endpoint Security integration page in Fleet, select **Add Endpoint Security**. The integration configuration page appears.
-3. Select a configuration for the Elastic Agent. You can use either the **Default config**, or add security integration to a custom or existing configuration. For more details on Elastic Agent configuration settings, see {ingest-guide}/elastic-agent-configuration.html[Configuration settings].
+3. Select a configuration for the Elastic Agent. You can use either the **Default config**, or add security integration to a custom or existing configuration. For more details on Elastic Agent configuration settings, see {fleet-guide}/elastic-agent-configuration.html[Configuration settings].
 4. Configure the Endpoint Security integration with a name and optional description. When configuration is complete, select **Save integration**. Kibana redirects you back to the administration section of the {security-app}.
 +
 [role="screenshot"]
@@ -57,7 +57,7 @@ image::images/install-endpoint/endpoint-configuration.png[]
 
 After you have enrolled the {agent} on your host, select **Continue**. The host now appears in the Endpoints list, located on the Administration page in the {security-app}.
 
-To unenroll an agent from your host, see {ingest-guide}/unenroll-elastic-agent.html[Unenroll Elastic Agent].
+To unenroll an agent from your host, see {fleet-guide}/unenroll-elastic-agent.html[Unenroll Elastic Agent].
 
 [discrete]
 [[enable-kernel-extension]]

--- a/docs/management/admin/admin-pg-ov.asciidoc
+++ b/docs/management/admin/admin-pg-ov.asciidoc
@@ -93,7 +93,7 @@ image::images/config-status.png[Config status details]
 
 Expand each section and subsection to view individual responses from the agent.
 
-TIP: If you need help troubleshooting a configuration failure, see the {ingest-guide}/fleet-troubleshooting.html[{fleet} troubleshooting topic].
+TIP: If you need help troubleshooting a configuration failure, see the {fleet-guide}/fleet-troubleshooting.html[{fleet} troubleshooting topic].
 
 *Filter endpoints*
 


### PR DESCRIPTION
Backports the following commits to 7.10:
 - Fix broken Fleet links (#420)