### PR TITLE
[7.10] Correct source/destination.as field listings (#447)

### DIFF
--- a/docs/reference/field-ref.asciidoc
+++ b/docs/reference/field-ref.asciidoc
@@ -88,11 +88,13 @@ These fields must be mapped to display network data in the {es-sec-app}:
 
 These fields can be mapped to display additional network data in the {es-sec-app}:
 
-* `destination.as`
+* `destination.as.number`
+* `destination.as.organization.name`
 * `destination.bytes`
 * `destination.domain`
 * `destination.geo.country_iso_code`
-* `source.as`
+* `source.as.number`
+* `source.as.organization.name`
 * `source.bytes`
 * `source.domain`
 * `source.geo.country_iso_code`


### PR DESCRIPTION
Backports the following commits to 7.10:
 - Correct source/destination.as field listings (#447)