### PR TITLE
Add 7.11 branch to backport config

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,5 +1,5 @@
 {
   "upstream": "elastic/security-docs",
-  "branches": [{ "name": "7.x", "checked": true }, "7.10", "7.9", "7.8"],
+  "branches": [{ "name": "7.x", "checked": true }, "7.11", "7.10", "7.9", "7.8"],
   "labels": ["backport"]
 }


### PR DESCRIPTION
This PR updates the config file so that the 7.11 branch is one of the options in the backport tool.