### PR TITLE
[DOCS] Adding alert array placeholder to 7.x.

### DIFF
--- a/docs/detections/api/rules/rules-api-create.asciidoc
+++ b/docs/detections/api/rules/rules-api-create.asciidoc
@@ -453,6 +453,7 @@ All text fields (such as `message` fields) can contain placeholders for rule
 and alert details:
 
 * `{{state.signals_count}}`: Number of alerts detected
+* `{{context.alerts}}`: Array of detected alerts
 * `{{{context.results_link}}}`: URL to the alerts in {kib}
 * `{{context.rule.anomaly_threshold}}`: Anomaly threshold score above which
 alerts are generated ({ml} rules only)


### PR DESCRIPTION
Adding `{{context.alerts}}`: Array of detected alerts to 7.x branch. 