### PR TITLE
[DOCS] Removes redundant intro to prebuilt ML modules

### DIFF
--- a/docs/detections/machine-learning/machine-learning.asciidoc
+++ b/docs/detections/machine-learning/machine-learning.asciidoc
@@ -70,16 +70,4 @@ NOTE: To adjust the `score` threshold that determines which
 [[prebuilt-ml-jobs]]
 == Prebuilt job reference
 
-Prebuilt jobs automatically detect file system and network anomalies on your
-hosts. To enable jobs when you are not using {beats} or the {agent}, you must
-map your data to the ECS fields listed in each job description. Some jobs use 
-fields that are not ECS-compliant. These jobs are available only when you use 
-{beats} or the {agent} to ship data.
-
-IMPORTANT: If the {agent} or Beat is version 7.10 or higher, use the
-<<security-linux-jobs>> and <<security-windows-jobs>> jobs. For earlier 
-versions, use the <<security-auditbeat-jobs>> and <<security-winlogbeat-jobs>>
-jobs. After you upgrade to 7.10 or later versions and start using the new jobs,
-disable the old jobs.
-
 include::{ml-dir}/anomaly-detection/ootb-ml-jobs-siem.asciidoc[tag=siem-jobs]

--- a/docs/detections/machine-learning/machine-learning.asciidoc
+++ b/docs/detections/machine-learning/machine-learning.asciidoc
@@ -36,19 +36,20 @@ details).
 host and network anomalies. The jobs are displayed in the `Anomaly Detection`
 interface. They are available when either:
 
-* You ship data using https://www.elastic.co/products/beats[Beats], and
-{kib} is configured with the required index patterns
-(`auditbeat-*`, `filebeat-*`, `packetbeat-*`, or `winlogbeat-*` via {kib} -> Management -> Index Patterns).
+* You ship data using https://www.elastic.co/products/beats[Beats] or the 
+<<install-endpoint,{agent}>> and {kib} is configured with the required index 
+patterns (such as `auditbeat-*`, `filebeat-*`, `packetbeat-*`, or `winlogbeat-*` 
+in {kib} -> {stack-manage-app} -> Index Patterns).
 
 Or
 
 * Your shipped data is ECS-compliant, and {kib} is configured with the shipped
 data's index patterns.
 
-<<prebuilt-ml-jobs>> describes all available {ml} jobs, and lists
-which ECS fields are required on your hosts when you are not using {beats} to
-ship your data. For information on tuning anomaly results to reduce the number
-of false positive, see <<tuning-anomaly-results>>.
+<<prebuilt-ml-jobs>> describes all available {ml} jobs, and lists which ECS 
+fields are required on your hosts when you are not using {beats} or the {agent}
+to ship your data. For information on tuning anomaly results to reduce the
+number of false positives, see <<tuning-anomaly-results>>.
 
 NOTE: Machine learning jobs look back and analyse two weeks of historical data
 prior to the time they are enabled. After jobs are enabled, they continuously
@@ -63,16 +64,16 @@ the user must have the `machine_learning_admin` or `machine_learning_user` role.
 
 NOTE: To adjust the `score` threshold that determines which
 {ml-docs}/xpack-ml.html[anomalies] are shown, you can modify {kib} ->
-Stack Management -> Advanced Settings -> `securitySolution:defaultAnomalyScore`.
+{stack-manage-app} -> Advanced Settings ->
+`securitySolution:defaultAnomalyScore`.
 
 [[prebuilt-ml-jobs]]
 == Prebuilt job reference
 
 Prebuilt jobs automatically detect file system and network anomalies on your
-hosts. To enable jobs when you are not using {beats}, you must map your data to
-the ECS fields listed in each job description.
+hosts. To enable jobs when you are not using {beats} or the {agent}, you must map your data to the ECS fields listed in each job description.
 
 NOTE: Some jobs use fields that are not ECS-compliant. These jobs are only
-available when you use {beats} to ship data.
+available when you use {beats} or the {agent} to ship data.
 
 include::{ml-dir}/anomaly-detection/ootb-ml-jobs-siem.asciidoc[tag=siem-jobs]

--- a/docs/detections/machine-learning/machine-learning.asciidoc
+++ b/docs/detections/machine-learning/machine-learning.asciidoc
@@ -71,9 +71,15 @@ NOTE: To adjust the `score` threshold that determines which
 == Prebuilt job reference
 
 Prebuilt jobs automatically detect file system and network anomalies on your
-hosts. To enable jobs when you are not using {beats} or the {agent}, you must map your data to the ECS fields listed in each job description.
+hosts. To enable jobs when you are not using {beats} or the {agent}, you must
+map your data to the ECS fields listed in each job description. Some jobs use 
+fields that are not ECS-compliant. These jobs are available only when you use 
+{beats} or the {agent} to ship data.
 
-NOTE: Some jobs use fields that are not ECS-compliant. These jobs are only
-available when you use {beats} or the {agent} to ship data.
+IMPORTANT: If the {agent} or Beat is version 7.10 or higher, use the
+<<security-linux-jobs>> and <<security-windows-jobs>> jobs. For earlier 
+versions, use the <<security-auditbeat-jobs>> and <<security-winlogbeat-jobs>>
+jobs. After you upgrade to 7.10 or later versions and start using the new jobs,
+disable the old jobs.
 
 include::{ml-dir}/anomaly-detection/ootb-ml-jobs-siem.asciidoc[tag=siem-jobs]


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/pull/85065 and https://github.com/elastic/stack-docs/pull/1504

This PR removes the redundant introduction and adds mention of the Elastic Agent in https://www.elastic.co/guide/en/security/master/machine-learning.html