### PR TITLE
[7.11] [DOCS] Detection engine/cold tier data - 7.11 (#487)

### DIFF
--- a/docs/detections/detection-engine-intro.asciidoc
+++ b/docs/detections/detection-engine-intro.asciidoc
@@ -64,6 +64,23 @@ To make sure you can access Detections and manage rules, see
 ==============
 
 [float]
+[[cold-tier-detections]]
+== Compatibility with cold tier nodes
+
+Cold tier is a {ref}/data-tiers.html[data tier] that holds time series data that is accessed only occasionally. In {stack} version >=7.11.0, {es-sec} supports cold tier data for the following {es} indices:
+
+* Index patterns specified in `securitySolution:defaultIndex`
+* Index patterns specified in the definitions of detection rules
+* Index patterns specified in the data sources selector on various {security-app} pages
+
+{es-sec} does NOT support cold tier data for the following {es} indices:
+
+* Index patterns controlled by {es-sec}, including signals and list indices
+* Index patterns specified in indicator match rules as indicator index patterns
+
+Using cold tier data for unsupported indices may result in detection rule timeouts and overall performance degradation.
+
+[float]
 [[det-engine-terminology]]
 == Terminology
 
@@ -108,7 +125,7 @@ alerts.
 External alerts::
 Alerts {es-sec} receives from external systems, such as Suricata.
 
-Threat indices::
+Indicator indices::
 Indices containing suspect field values. <<create-indicator-rule, Indicator match rules>> use these
 indices to compare their field values with source event values contained in
 <<term-sec-indices, {es-sec} indices>>.

--- a/docs/es-overview.asciidoc
+++ b/docs/es-overview.asciidoc
@@ -83,6 +83,22 @@ advanced data analysis and visualize your data in a variety of charts, tables,
 and maps.
 
 [discrete]
+=== Compatibility with cold tier nodes
+
+Cold tier is a {ref}/data-tiers.html[data tier] that holds time series data that is accessed only occasionally. In {stack} version >=7.11.0, {es-sec} supports cold tier data for the following {es} indices:
+
+* Index patterns specified in `securitySolution:defaultIndex`
+* Index patterns specified in the definitions of detection rules
+* Index patterns specified in the data sources selector on various {security-app} pages
+
+{es-sec} does NOT support cold tier data for the following {es} indices:
+
+* Index patterns controlled by {es-sec}, including signals and list indices
+* Index patterns specified in indicator match rules as indicator index patterns
+
+Using cold tier data for unsupported indices may result in detection rule timeouts and overall performance degradation.
+
+[discrete]
 === Additional Elastic Endpoint Security information
 
 The Elastic https://www.elastic.co/endpoint-security/[Endpoint Security agent integration]


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [DOCS] Detection engine/cold tier data - 7.11 (#487)