### PR TITLE
[7.x] Issue #518: Remove beta tag from detections (#521)

### DIFF
--- a/docs/detections/detection-engine-intro.asciidoc
+++ b/docs/detections/detection-engine-intro.asciidoc
@@ -5,6 +5,7 @@
 
 beta[]
 
+
 Use the Detections feature to create and manage rules, and view the alerts
 these rules create. Rules periodically search indices (such as `endgame-*` and
 `filebeat-*`) for suspicious source events, and create alerts when a rule's


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Issue #518: Remove beta tag from detections (#521)