### PR TITLE
[7.x] [DOCS] Updates Create Rule API docs for Threshold and Indicator Match Rules  (#522)

### DIFF
--- a/docs/detections/api/rules/rules-api-create.asciidoc
+++ b/docs/detections/api/rules/rules-api-create.asciidoc
@@ -160,8 +160,13 @@ whether an alert is generated.
 |threshold |Object a|Defines the field and threshold value for when alerts
 are generated, where:
 
-* `field` (string, required): The field on which the threshold is applied. If
-you specify an empty field (`""`), alerts are generated when the query returns
+* `cardinality` (Array of length 1): The field on which the cardinality is applied.
+* `cardinality.field` (string, required): The field on which to calculate and compare the
+cardinality.
+* `cardinality.value` (integer, required): The threshold value from which an alert is
+generated based on unique number of values of `cardinality.field`.
+* `field` (string or string[], required): The field on which the threshold is applied. If
+you specify an empty array (`[]`), alerts are generated when the query returns
 at least the number of results specified in the `value` field.
 * `value` (integer, required): The threshold value from which an alert is
 generated.
@@ -336,9 +341,12 @@ a detection rule exception (`detection`) or an endpoint exception (`endpoint`).
 |==============================================
 |Name |Type |Description
 
-|threat_filter |Object[]
+|threat_filters |Object[]
 |{ref}/query-filter-context.html[Query and filter context] array used to filter
 documents from the {es} index containing the threat values.
+
+|threat_indicator_path |String
+|Much like an ingest processor, users can use this field to define where their threat indicator can be found on their indicator documents. Defaults to `threatintel.indicator`.
 |==============================================
 
 [[opt-fields-query-threshold]]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Updates Create Rule API docs for Threshold and Indicator Match Rules  (#522)