### PR TITLE
[7.x] Issue #538: 7.11.2 release notes (#542)

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -8,6 +8,22 @@
 :pull: https://github.com/elastic/kibana/pull/
 
 [discrete]
+[[release-notes-7.11.2]]
+== 7.11.2
+
+[discrete]
+[[bug-fixes-7.11.2]]
+==== Bug fixes and enhancements
+
+- Updates warning message when no indices match provided index patterns ({pull}93094[#93094]).
+- Fixes rule edit bug with `max_signals` ({pull}92748[#92748]).
+- Fixes issue where the file name in a value modal list would be truncated ({pull}91952[#91952]).
+- Adds an overflow text wrap for rule descriptions ({pull}91945[#91945]).
+- Fixes issue in detection search where searching with the timestamp override field would yield a 400 error({pull}91597[#91597]).
+- Replaces `partial failure` with `warning` for rule statuses ({pull}91167[#91167]).
+
+
+[discrete]
 [[release-notes-7.11.0]]
 == 7.11.0
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Issue #538: 7.11.2 release notes (#542)