### PR TITLE
[7.x] [DOCS] 7.12.0 release notes  (#550)

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -8,6 +8,51 @@
 :pull: https://github.com/elastic/kibana/pull/
 
 [discrete]
+[[release-notes-7.12.0]]
+== 7.12.0
+
+[discrete]
+[[features-7.12.0]]
+==== Features
+* Implements a connector for ServiceNow SIR ({pull}88190[#88190]).
+*  Implements the case's fields for the ServiceNow SIR connector.({pull}88655[#88655]).
+
+[discrete]
+[[bug-fixes-7.12.0]]
+==== Bug fixes and enhancements
+* Enables the Microsoft Team's action type for the detection engine ({pull}94239[#94239]).
+* Fixes bug for pre-populated endpoint exceptions ({pull}94025[#94025]).
+* Pushes ServiceNow ITSM comments on cases and alerts as work notes and improves error messaging ({pull}93916[#93916]).
+* Alert migrations can be finalized and cleaned up in all spaces ({pull}93809[#93809]).
+* Updates error handling logic to produce a cleaner message when deeply nested fields in KQL queries are greater than the default or what is set for the config property ({pull}93536[#93536]).
+* Updates shellcode telemetry for schema adjustment ({pull}93143[#93143]).
+* Fixes bug in the allowlist layout for security telemetry  ({pull}92850[#92850]).
+* Updates exceptions modal to use existing lists plug-in ({pull}92348[#92348]).
+* Moves PE details out of Ext context ({pull}92146[#92146]).
+* Fixes loading indicators in the rules management table ({pull}91925[#91925]).
+* Adds missing fields for security telemetry ({pull}91920[#91920]).
+* Fixes issues when pushing a case, that has alerts attached, to an external service ({pull}91638[#91638]).
+* Updates error banner when refreshing the rule status ({pull}91051[#91051]).
+* Fixes bug in the exceptions builder UI that causes invalid values to overwrite other values ({pull}90634[#90634]).
+* Fixes issues with searching the Exceptions list table by name ({pull}88701[#88701]).
+* Threshold rule fixes ({pull}93553[#93553])({pull}92667[#92667]).
+* Adds sub cases to the case list and a case details page ({pull}91434[#91434]).
+* Upgrades to use the IndexPatternService to get fields ({pull}91153[#91153]).
+* Adds new fields to the allowlist for alert telemetry ({pull}90868[#90868]).
+* Adds support for multiple `terms` aggregations within a Threshold Rule, as well as an additional `cardinality` aggregation for matching a specific number of unique values across a field. ({pull}90826[#90826]).
+* Introduces the network details and host details to the side panel. ({pull}90064[#90064]).
+* Adds ransomware exceptions  ({pull}89974[#89974]).
+* Extends the daily usage collection to include perf and run information on active security ML jobs. ({pull}89705[#89705]).
+* Reduces the detection engine's reliance on `_source` ({pull}89371[#89371]).
+* Pushes a new case to the connector when created ({pull}89131[#89131]).
+* Disallows JIRA labels with spaces ({pull}90548[#90548]).
+
+[discrete]
+[[known-issues-7.12.0]]
+==== Known Issues
+* Pagination does not work in the All Cases table. To circumvent this, increase the total number of rows that are displayed per page by selecting an option from the *Rows per page* menu. Alternatively, decrease the number of rows displayed in the table by filtering the list of cases that are returned. Finally, if you know which case you want to view, enter descriptive text about it into the search bar at the top of the table. ({pull}94929[#94929]).
+
+[discrete]
 [[release-notes-7.11.2]]
 == 7.11.2
 
@@ -21,7 +66,6 @@
 - Adds an overflow text wrap for rule descriptions ({pull}91945[#91945]).
 - Fixes issue in detection search where searching with the timestamp override field would yield a 400 error({pull}91597[#91597]).
 - Replaces `partial failure` with `warning` for rule statuses ({pull}91167[#91167]).
-
 
 [discrete]
 [[release-notes-7.11.0]]
@@ -69,7 +113,7 @@ The `/api/lists` `DELETE` API has been updated to check for references before re
 
 * Fixes EQL previews which now accept all date formats ({pull}83939[#83939]).
 * Fixes incorrect time for DNS histograms ({pull}83781[#83781]).
-* Fixes UI strings around indicator matching and mapping definitions 
+* Fixes UI strings around indicator matching and mapping definitions
 ({pull}82510[#82510]).
 * Fixes layout in "Severity override" drop-down when creating a new rule ({pull}82271[#82271]).
 
@@ -82,7 +126,7 @@ The `/api/lists` `DELETE` API has been updated to check for references before re
 [[upgrade-notes-7.10]]
 ==== Post upgrade requirements
 
-When upgrading the {stack} to version 7.10.0 from a previous minor version (7.9.x), 
+When upgrading the {stack} to version 7.10.0 from a previous minor version (7.9.x),
 perform the following:
 
 * Grant `view_index_metadata` https://www.elastic.co/guide/en/security/current/detections-permissions-section.html#enable-detections-ui[permissions] to any Elastic Security users. This is required to enable **event correlation** rules. Other previously activated detection rules will continue to run after upgrade.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] 7.12.0 release notes  (#550)