### PR TITLE
[7.x] Adding #91718 to 7.12 RNs. (#584)

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -46,6 +46,7 @@
 * Reduces the detection engine's reliance on `_source` ({pull}89371[#89371]).
 * Pushes a new case to the connector when created ({pull}89131[#89131]).
 * Disallows JIRA labels with spaces ({pull}90548[#90548]).
+* Fixes "Error loading data" displaying under Analyze Event ({pull}91718[#91718]).
 
 [discrete]
 [[known-issues-7.12.0]]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Adding #91718 to 7.12 RNs. (#584)