### PR TITLE
Clarify large value list exceptions depend on rule type

### DIFF
--- a/docs/detections/detections-ui-exceptions.asciidoc
+++ b/docs/detections/detections-ui-exceptions.asciidoc
@@ -26,6 +26,9 @@ with these types:
 After creating value lists, you can use `is in list` and `is not in list`
 operators to define exceptions.
 
+IMPORTANT: Operators `is in list` and `is not in list` are not available for 
+Threshold rules and Event correlation rules.
+
 [float]
 [[manage-value-lists]]
 === Create and manage value lists


### PR DESCRIPTION
The exceptions that are `is in list`/`is not in list` do not show up for threshold and eql rules.

Please add links to Threshold rules and Event correlation rules.