### PR TITLE
[7.12] Clarify large value list exceptions depend on rule type (#627)

### DIFF
--- a/docs/detections/detections-ui-exceptions.asciidoc
+++ b/docs/detections/detections-ui-exceptions.asciidoc
@@ -26,6 +26,9 @@ with these types:
 After creating value lists, you can use `is in list` and `is not in list`
 operators to define exceptions.
 
+IMPORTANT: Operators `is in list` and `is not in list` are not available for 
+Threshold rules and Event correlation rules.
+
 [float]
 [[manage-value-lists]]
 === Create and manage value lists


### PR DESCRIPTION
Backports the following commits to 7.12:
 - Clarify large value list exceptions depend on rule type (#627)