### PR TITLE
Flag Elastic Endpoint Integration through Kibana as `WARNING beta`

### DIFF
--- a/docs/getting-started/install-endpoint.asciidoc
+++ b/docs/getting-started/install-endpoint.asciidoc
@@ -2,6 +2,8 @@
 [role="xpack"]
 = Configure and install Elastic Endpoint integration
 
+beta[]
+
 Like other Elastic integrations, Endpoint Security can be integrated into the Elastic Agent through {fleet-guide}/fleet-overview.html[{fleet}]. Upon configuration, the integration allows the Elastic Agent to monitor for events on your host and send data to the Elastic Security app.
 
 NOTE: To configure the Endpoint integration on the {agent}, you must have permission to use {fleet} in {kib}.


### PR DESCRIPTION
Since the entire fleet process is still in beta, it should be noted on the docs, that this is also a WARNING beta not GA yet situation.