### PR TITLE
[DOCS] Moving prebuilt rules update to the correct topic

### DIFF
--- a/docs/detections/alerts-ui-manage.asciidoc
+++ b/docs/detections/alerts-ui-manage.asciidoc
@@ -10,26 +10,6 @@ TIP: From Timeline, you can <<cases-ui-open, create cases>> to track issues and
 share information with colleagues.
 
 [float]
-[[download-prebuilt-rules]]
-=== Download latest prebuilt Elastic rules
-
-[beta]
-
-As of {stack} >=7.13.0., you can download the latest version of Elastic prebuilt rules outside of a regular release cycle. This feature ensures you have the latest detection capabilties before upgrading to the latest {stack}.
-
-To download the latest version of prebuilt rules:
-
-. In {kib}, go to *Fleet > Integrations*.
-. Search for "Prebuilt Security Detection Rules."
-. Select the integration, then click *Add Prebuilt Security Detection Rules*. The integration configuration page is displayed.
-. (Optional) If you have an {agent} enrolled and have created an agent policy you want to assign to this integration, select it from the drop-down.
-. Configure the integration settings by entering a name and optional description.
-. Click *Save integration* in the lower right corner.
-
-[role="screenshot"]
-image::images/prebuilt-integration.png[]
-
-[float]
 [[detection-view-and-filter-alerts]]
 === View and filter detection alerts
 The Detections page offers various ways for you to organize and triage detection alerts as you investigate suspicious events. You can:

--- a/docs/detections/rules-ui-manage.asciidoc
+++ b/docs/detections/rules-ui-manage.asciidoc
@@ -45,6 +45,26 @@ You can then modify the duplicated rules and, if required, delete the prebuilt
 ones.
 
 [float]
+[[download-prebuilt-rules]]
+=== Download latest prebuilt Elastic rules
+
+beta::[]
+
+As of {stack} >=7.13.0., you can download the latest version of Elastic prebuilt rules outside of a regular release cycle. This feature ensures you have the latest detection capabilties before upgrading to the latest {stack}.
+
+To download the latest version of prebuilt rules:
+
+. In {kib}, go to *Fleet > Integrations*.
+. Search for "Prebuilt Security Detection Rules."
+. Select the integration, then click *Add Prebuilt Security Detection Rules*. The integration configuration page is displayed.
+. (Optional) If you have an {agent} enrolled and have created an agent policy you want to assign to this integration, select it from the drop-down.
+. Configure the integration settings by entering a name and optional description.
+. Click *Save integration* in the lower right corner.
+
+[role="screenshot"]
+image::images/prebuilt-integration.png[]
+
+[float]
 [[manage-rules-ui]]
 === Modify existing rules
 


### PR DESCRIPTION
Per comment [here](https://github.com/elastic/security-team/issues/17#issuecomment-842552644): 

Moving this from [here](https://www.elastic.co/guide/en/security/master/alerts-ui-manage.html) to the correct place [here](https://www.elastic.co/guide/en/security/master/rules-ui-management.html). 

Related: #666, #650, and https://github.com/elastic/security-team/issues/17