### PR TITLE
Remove "Copy as curl" and "View in console" links from examples

### DIFF
--- a/docs/getting-started/install-endpoint.asciidoc
+++ b/docs/getting-started/install-endpoint.asciidoc
@@ -196,7 +196,7 @@ Follow these instructions to uninstall an endpoint **ONLY** if uninstalling an {
 
 Windows
 
-[source,console]
+[source,shell]
 ----------------------------------
 cd %TEMP%
 copy "c:\Program Files\Elastic\Endpoint\elastic-endpoint.exe" elastic-endpoint.exe
@@ -206,7 +206,7 @@ del .\elastic-endpoint.exe
 
 macOS
 
-[source,console]
+[source,shell]
 ----------------------------------
 cd /tmp
 cp /Library/Elastic/Endpoint/elastic-endpoint elastic-endpoint
@@ -216,7 +216,7 @@ rm elastic-endpoint
 
 Linux
 
-[source,console]
+[source,shell]
 ----------------------------------
 cd /tmp
 cp /opt/Elastic/Endpoint/elastic-endpoint elastic-endpoint


### PR DESCRIPTION
It doesn't make sense to include "Copy as curl" or "View in console" here because the commands are not cURL, and you can't run them from the Dev Tools console.