### PR TITLE
[7.13] Remove copy as curl and run in console links (#723)

### DIFF
--- a/docs/getting-started/install-endpoint.asciidoc
+++ b/docs/getting-started/install-endpoint.asciidoc
@@ -196,7 +196,7 @@ Follow these instructions to uninstall an endpoint **ONLY** if uninstalling an {
 
 Windows
 
-[source,console]
+[source,shell]
 ----------------------------------
 cd %TEMP%
 copy "c:\Program Files\Elastic\Endpoint\elastic-endpoint.exe" elastic-endpoint.exe
@@ -206,7 +206,7 @@ del .\elastic-endpoint.exe
 
 macOS
 
-[source,console]
+[source,shell]
 ----------------------------------
 cd /tmp
 cp /Library/Elastic/Endpoint/elastic-endpoint elastic-endpoint
@@ -216,7 +216,7 @@ rm elastic-endpoint
 
 Linux
 
-[source,console]
+[source,shell]
 ----------------------------------
 cd /tmp
 cp /opt/Elastic/Endpoint/elastic-endpoint elastic-endpoint


### PR DESCRIPTION
Backports the following commits to 7.13:
 - Remove copy as curl and run in console links (#723)