### PR TITLE
[DOCS] Fixes links to anomaly detection overview

### DIFF
--- a/docs/detections/machine-learning/machine-learning.asciidoc
+++ b/docs/detections/machine-learning/machine-learning.asciidoc
@@ -2,8 +2,8 @@
 [role="xpack"]
 = Anomaly Detection with Machine Learning
 
-{kibana-ref}/xpack-ml.html[{ml-cap}] functionality is available when
-you have the *https://www.elastic.co/subscriptions[appropriate license]*, are
+{ml-docs}/ml-ad-overview.html[{ml-cap}] functionality is available when
+you have the *{subscriptions}[appropriate license]*, are
 using a *{ess-trial}[cloud deployment]*, or are testing out a *Free Trial*.
 
 You can view the details of detected anomalies within the `Anomalies` table
@@ -62,10 +62,9 @@ time frame, previously analysed data is not processed again.
 To view the `Anomalies` table widget and `Max Anomaly Score By Job` details,
 the user must have the `machine_learning_admin` or `machine_learning_user` role.
 
-NOTE: To adjust the `score` threshold that determines which
-{ml-docs}/xpack-ml.html[anomalies] are shown, you can modify {kib} ->
-{stack-manage-app} -> Advanced Settings ->
-`securitySolution:defaultAnomalyScore`.
+NOTE: To adjust the `score` threshold that determines which anomalies are shown,
+you can modify
+{kib} -> {stack-manage-app} -> Advanced Settings -> `securitySolution:defaultAnomalyScore`.
 
 [[prebuilt-ml-jobs]]
 == Prebuilt job reference


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/stack-docs/pull/1731

This PR updates links from the Security documentation to the Machine Learning anomaly detection pages.