### PR TITLE
[Detection rules] Add release note to 0.13.2 summary

### DIFF
--- a/docs/detections/prebuilt-rules/downloadable-packages/0-13-2/prebuilt-rules-0-13-2-summary.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-13-2/prebuilt-rules-0-13-2-summary.asciidoc
@@ -4,6 +4,11 @@
 
 This section lists all updates associated with version 0.13.2 of the Fleet integration *Prebuilt Security Detection Rules*.
 
+Included in this release are 3 new rules for the recently observed
+https://www.elastic.co/blog/elastic-security-prevents-100-percent-of-revil-ransomware-samples[REvil]
+activity as well as 4 new rules covering the recent
+https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-34527[PrintNightmare] vulnerability.
+
 
 [width="100%",options="header"]
 |==============================================


### PR DESCRIPTION
Add release note to 0.13.2 summary (same note from the downloadable package index)

This needs to backport to 7.13