### PR TITLE
[DOCS] Fixes link to ML custom rules

### DIFF
--- a/docs/detections/machine-learning/tune-anomaly-results.asciidoc
+++ b/docs/detections/machine-learning/tune-anomaly-results.asciidoc
@@ -60,8 +60,8 @@ example).
 .. The _IS IN_ statement.
 .. The filter you created as part of the <<create-fiter-list>> procedure.
 +
-TIP: For more information about detectors, see
-{ml-docs}/ml-jobs.html[Anomaly detection jobs].
+TIP: For more information, see
+{ml-docs}/ml-configuring-detector-custom-rules.html[Customizing detectors with custom rules].
 
 . Click *Save*.
 


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/pull/1750

This PR fixes a link in the https://www.elastic.co/guide/en/security/master/tuning-anomaly-results.html page, since the target has moved in the machine learning guide.