### PR TITLE
[7.x] Correct typos in index.asciidoc (#817)

### DIFF
--- a/docs/events/index.asciidoc
+++ b/docs/events/index.asciidoc
@@ -2,7 +2,7 @@
 
 = Investigate events
 
-This sections describes how to use timelines and the timeline graphical interface to investigate events.
+These sections describe how to use Timelines and the Timeline graphical interface to investigate events.
 
 include::timeline-ui-overview.asciidoc[leveloffset=+1]
 include::timeline-templates.asciidoc[leveloffset=+1]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Correct typos in index.asciidoc (#817)