### PR TITLE
[DOCS] Update link to TLS instructions

### DIFF
--- a/docs/getting-started/detections-req.asciidoc
+++ b/docs/getting-started/detections-req.asciidoc
@@ -21,7 +21,7 @@ configure {kib} <<detections-ui-exceptions, value list>> upload limits.
 These steps are only required for *self-managed* deployments:
 
 * HTTPS must be configured for communication between
-{kibana-ref}/configuring-tls.html#configuring-tls-kib-es[{es} and {kib}].
+{ref}/security-basic-setup-https.html#encrypt-kibana-elasticsearch[{es} and {kib}].
 * In the `elasticsearch.yml` configuration file, set the
 `xpack.security.enabled` setting to `true`. For more information, see
 {ref}/settings.html[Configuring {es}] and


### PR DESCRIPTION
In [#106996](https://github.com/elastic/kibana/pull/106996), we replaced the Kibana TLS documentation with pointers to the updated TLS documentation for the Elastic Stack. That PR implemented a redirect for the link changed in this PR. The change in this PR links directly to the new page instead of requiring users to hit the redirect.

Preview link: https://security-docs_838.docs-preview.app.elstc.co/guide/en/security/7.13/detections-permissions-section.html