### PR TITLE
[7.x] [BUG] Detection Rule execution authorization model not outlined in security docs  (#889)

### DIFF
--- a/docs/detections/rules-ui-create.asciidoc
+++ b/docs/detections/rules-ui-create.asciidoc
@@ -75,7 +75,18 @@ scheduled run time.
 ==============
 
 [role="screenshot"]
-image::images/all-rules.png[]
+image::images/all-rules.png[Shows the Rules page]
+
+[float]
+[[alerting-authorization-model]]
+=== Authorization
+
+Rules, including all background detection and the actions they generate, are authorized using an {kibana-ref}/api-keys.html[API key] associated with the last user to edit the rule. Upon creating or modifying a rule, an API key is generated for that user, capturing a snapshot of their privileges. The API key is then used to run all background tasks associated with the rule including detection checks and executing actions.
+
+[IMPORTANT]
+==============================================
+If a rule requires certain privileges to run, such as index privileges, keep in mind that if a user without those privileges updates the rule, the rule will no longer function.
+==============================================
 
 [float]
 [[create-rule-ui]]

--- a/docs/getting-started/detections-req.asciidoc
+++ b/docs/getting-started/detections-req.asciidoc
@@ -83,7 +83,7 @@ a|The `manage`, `write`,`read`, and `view_index_metadata` index privileges for t
 | {kib} space `All` privileges for the `Security` feature (see
 {kibana-ref}/xpack-spaces.html#spaces-control-user-access[Feature access based on user privileges])
 
-*Note*: To manage rule connectors, your role will also need `All` privileges for the `Action and Connectors` feature (*Management* -> *Action and Connectors*). 
+*Note*: To manage rule connectors, your role will also need `All` privileges for the `Action and Connectors` feature (*Management* -> *Action and Connectors*).
 
 |Manage alerts
 
@@ -103,7 +103,18 @@ Here is an example of a user who has the Detections feature enabled in all {kib}
 spaces:
 
 [role="screenshot"]
-image::images/sec-admin-user.png[]
+image::images/sec-admin-user.png[Shows user with the Detections feature enabled in all Kibana spaces]
+
+[float]
+[[alerting-auth-model]]
+=== Authorization
+
+Rules, including all background detection and the actions they generate, are authorized using an {kibana-ref}/api-keys.html[API key] associated with the last user to edit the rule. Upon creating or modifying a rule, an API key is generated for that user, capturing a snapshot of their privileges. The API key is then used to run all background tasks associated with the rule including detection checks and executing actions.
+
+[IMPORTANT]
+==============================================
+If a rule requires certain privileges to run, such as index privileges, keep in mind that if a user without those privileges updates the rule, the rule will no longer function.
+==============================================
 
 ////
 [discrete]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [BUG] Detection Rule execution authorization model not outlined in security docs  (#889)