### PR TITLE
[BUG] Round Closing bracket missing for under Create Case Doc

### DIFF
--- a/docs/cases/api/cases-api/cases-api-create.asciidoc
+++ b/docs/cases/api/cases-api/cases-api-create.asciidoc
@@ -85,7 +85,7 @@ For {ibm-r} connectors:
 
 For {swimlane} connectors:
 
-* `caseId` (string | null): The case ID.
+* `caseId` (string \| null): The case ID.
 
 |Yes
 |==============================================


### PR DESCRIPTION
Addresses #894.

Preview [here](https://security-docs_921.docs-preview.app.elstc.co/guide/en/security/master/cases-api-create.html). 