### PR TITLE
[BUG] New Security Navigation not present under Verify Elastic Endpoint Enrollment Doc Section

### DIFF
--- a/docs/getting-started/install-endpoint.asciidoc
+++ b/docs/getting-started/install-endpoint.asciidoc
@@ -178,21 +178,11 @@ NOTE: Advanced settings are not recommended for most users.
 
 2. On the dialog that appears, click **Save and Deploy changes**. If successful, a "Success" confirmation appears in the lower right corner.
 
-
 [discrete]
-[[verify-endpoint-enrollment]]
-== Verify Elastic Endpoint enrollment
-
-After installing the {agent}, there's a lag time of several hours between when the Elastic Endpoint begins detecting and sending alerts to {kib}. To ensure that the installation of Elastic Endpoint on your host was successful,  go to **Manage** -> **Endpoints**. A message appears that says, "Endpoints are enrolling. View agents to track progress." Select **View agents** to check the status of your endpoint enrollment.
-
-[role="screenshot"]
-image::images/install-endpoint/endpoints-enrolling.png[]
-
-
 [[uninstall-endpoint]]
-*Uninstall an endpoint*
+== Uninstall an endpoint
 
-Follow these instructions to uninstall an endpoint **ONLY** if uninstalling an {agent} is unsuccessful.
+Use these commands to uninstall an endpoint **ONLY** if uninstalling an {agent} is unsuccessful.
 
 Windows
 


### PR DESCRIPTION
Addresses #900. 
Remove section and screenshot for verifying enrollment, because currently not available. See [#102334](https://github.com/elastic/kibana/issues/102334).

Preview [here](https://security-docs_922.docs-preview.app.elstc.co/guide/en/security/master/install-endpoint.html).