### PR TITLE
[7.x] Remove beta tag from install-endpoint.asciidoc (#929)

### DIFF
--- a/docs/getting-started/install-endpoint.asciidoc
+++ b/docs/getting-started/install-endpoint.asciidoc
@@ -2,8 +2,6 @@
 [role="xpack"]
 = Configure and install the Endpoint Security integration
 
-beta::[]
-
 Like other Elastic integrations, Endpoint Security can be integrated into the Elastic Agent through {fleet-guide}/fleet-overview.html[{fleet}]. Upon configuration, the integration allows the Elastic Agent to monitor for events on your host and send data to the Elastic Security app.
 
 NOTE: To configure the Endpoint integration on the {agent}, you must have permission to use {fleet} in {kib}. You must also have admin permissions in {kib} to access the **Endpoints** page in the {security-app}.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Remove beta tag from install-endpoint.asciidoc (#929)