### PR TITLE
[7.x] [BUG] Comment is mentioned to be overwritten however expected it to be append under Swimlane mapping doc (#917)

### DIFF
--- a/docs/cases/cases-ui-integrations.asciidoc
+++ b/docs/cases/cases-ui-integrations.asciidoc
@@ -103,9 +103,7 @@ overwritten.
 ** *Description*: Mapped to the {swimlane} `Description` field. When an update to a
 Security case description is sent to {swimlane}, the field that is mapped to the {swimlane} `Description`
 field is overwritten.
-** *Comments*: Mapped to the {swimlane} `Comments` field. When a comment is updated
-in a Security case, the field that is mapped to the {swimlane} `Comment` field is overwritten.
-
+** *Comments*: Mapped to the {swimlane} `Comments` field. When a new comment is added to a Security case, or an existing one is updated, the field that is mapped to the {swimlane} `Comment` field is appended. Comments are posted to the {swimlane} incident record individually.
 
 [float]
 === Close sent cases automatically


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [BUG] Comment is mentioned to be overwritten however expected it to be append under Swimlane mapping doc (#917)