### PR TITLE
[7.15] [DOCS] Add _bulk_action API route documentation (#952)

### DIFF
--- a/docs/detections/api/rules/rules-api-bulk-actions.asciidoc
+++ b/docs/detections/api/rules/rules-api-bulk-actions.asciidoc
@@ -186,3 +186,54 @@ PATCH api/detection_engine/rules/_bulk_update
 ===== Response payload
 
 A JSON array containing the updated rules.
+
+
+
+==== Bulk action
+
+Apply a bulk action to multiple rules. The bulk action is applied to all rules that match the filter.
+
+===== Request URL
+
+`POST  <kibana host>:<port>/api/detection_engine/rules/_bulk_action`
+
+===== Request body
+
+A JSON object with two required parameters:
+
+* `query` - A string containing KQL search query to match the rules.
+* `action` - A bulk action to apply. Possible values: `enable`, `disable`, `delete`, `duplicate`, and `export`
+
+====== Example request
+
+The following request will activate all detection rules that have the `test` tag.
+
+[source,console]
+--------------------------------------------------
+POST api/detection_engine/rules/_bulk_action
+{
+  "query": "alert.attributes.tags: \"test\"",
+  "action": "enable"
+}
+--------------------------------------------------
+// KIBANA
+
+===== Response code
+
+`200`::
+    Indicates a successful call.
+
+===== Response payload
+
+For `enable`, `disable`, `delete`, and `duplicate` actions, a JSON object containing the outcome of the call and the number of affected rules:
+
+[source,json]
+--------------------------------------------------
+{
+  "success": true,
+  "rules_count": 4280
+}
+--------------------------------------------------
+
+
+For an `export` action, an `.ndjson` file containing exported rules.


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [DOCS] Add _bulk_action API route documentation (#952)