### PR TITLE
[7.15] [DOCS] Release note cleanup (#974)

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -1,15 +1,21 @@
 [[release-notes]]
-[chapter]
 = Release Notes
+
+This section summarizes the changes in each release.
 
 // Use these for links to issue and pulls. Note issues and pulls redirect one to
 // each other on Github, so don't worry too much on using the right prefix.
 :issue: https://github.com/elastic/kibana/issues/
 :pull: https://github.com/elastic/kibana/pull/
 
+// add this back in once we are ready to release 7.15
+//[discrete]
+//[[release-notes-header-7.14]]
+//== 7.14
+
 [discrete]
 [[release-notes-7.14.0]]
-== 7.14.0
+=== 7.14.0
 
 [discrete]
 [[features-7.14.0]]
@@ -72,7 +78,7 @@
 ----
 PATCH <kibana host>:<port>/api/detection_engine/rules
 {
-  "id": <id-value-of-rule>",
+  "id": <id-value-of-rule>,
   "author": []
 }
 ----
@@ -86,9 +92,13 @@ PATCH <kibana host>:<port>/api/detection_engine/rules
 ==== Security update
 * Our security advisory for this release can be found https://discuss.elastic.co/t/elastic-stack-7-14-0-security-update/280344[here].
 
+
+[[release-notes-header-7.13]]
+== 7.13
+
 [discrete]
 [[release-notes-7.13.3]]
-== 7.13.3
+=== 7.13.3
 
 [discrete]
 [[bug-fixes-7.13.3]]
@@ -97,7 +107,7 @@ PATCH <kibana host>:<port>/api/detection_engine/rules
 
 [discrete]
 [[release-notes-7.13.2]]
-== 7.13.2
+=== 7.13.2
 
 [discrete]
 [[known-issue-7.13.2]]
@@ -120,7 +130,7 @@ To ensure these rules can successfully run, duplicate the rule and edit it using
 
 [discrete]
 [[release-notes-7.13.0]]
-== 7.13.0
+=== 7.13.0
 
 [discrete]
 [[features-7.13.0]]
@@ -167,9 +177,13 @@ To ensure these rules can successfully run, duplicate the rule and edit it using
 ** `dll.Ext.mapped_size`
 ** `process.thread.Ext.start_address`
 
+
+[[release-notes-7.12-header]]
+== 7.12
+
 [discrete]
 [[release-notes-7.12.1]]
-== 7.12.1
+=== 7.12.1
 
 [discrete]
 [[bug-fixes-7.12.1]]
@@ -184,7 +198,7 @@ To ensure these rules can successfully run, duplicate the rule and edit it using
 
 [discrete]
 [[release-notes-7.12.0]]
-== 7.12.0
+=== 7.12.0
 
 [discrete]
 [[features-7.12.0]]
@@ -228,9 +242,12 @@ To ensure these rules can successfully run, duplicate the rule and edit it using
 ==== Known Issues
 * Pagination does not work in the All Cases table. To circumvent this, increase the total number of rows that are displayed per page by selecting an option from the *Rows per page* menu. Alternatively, decrease the number of rows displayed in the table by filtering the list of cases that are returned. Finally, if you know which case you want to view, enter descriptive text about it into the search bar at the top of the table. ({pull}94929[#94929]).
 
+[[release-notes-7.11-header]]
+== 7.11
+
 [discrete]
 [[release-notes-7.11.2]]
-== 7.11.2
+=== 7.11.2
 
 [discrete]
 [[bug-fixes-7.11.2]]
@@ -245,7 +262,7 @@ To ensure these rules can successfully run, duplicate the rule and edit it using
 
 [discrete]
 [[release-notes-7.11.0]]
-== 7.11.0
+=== 7.11.0
 
 [discrete]
 [[breaking-changes-7.11.0]]
@@ -278,10 +295,12 @@ The `/api/lists` `DELETE` API has been updated to check for references before re
 
 * In the Alert Details Summary view, values for some fields appear truncated. You'll only be able to see the first character ({issue}90539[#90539]).
 
+[[release-notes-7.10-header]]
+== 7.10
 
 [discrete]
 [[release-notes-7.10.1]]
-== 7.10.1
+=== 7.10.1
 
 [discrete]
 [[bug-fixes-7.10.1]]
@@ -296,7 +315,7 @@ The `/api/lists` `DELETE` API has been updated to check for references before re
 
 [discrete]
 [[release-notes-7.10.0]]
-== 7.10.0
+=== 7.10.0
 
 [discrete]
 [[upgrade-notes-7.10]]
@@ -359,11 +378,12 @@ image::images/detection-rule-failure.png[]
 
 * When adding a rule exception, you cannot select value lists of type `ip_range`. Lists of type `ip_range` will not appear in the **Add Exception** dropdown as possible values after selecting the is in list operator. ({pull}79511[#79511]).
 
-
+[[release-notes-7.9-header]]
+== 7.9
 
 [discrete]
 [[release-notes-7.9.1]]
-== 7.9.1
+=== 7.9.1
 
 [discrete]
 [[upgrade-notes-7.9.1]]
@@ -395,7 +415,7 @@ required to enable the UI.
 
 [discrete]
 [[release-notes-7.9.0]]
-== 7.9.0
+=== 7.9.0
 
 [discrete]
 [[breaking-changes-7.9]]


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [DOCS] Release note cleanup (#974)