### PR TITLE
[EDIT] Add _bulk_action API route documentation

### DIFF
--- a/docs/detections/api/rules/rules-api-bulk-actions.asciidoc
+++ b/docs/detections/api/rules/rules-api-bulk-actions.asciidoc
@@ -4,7 +4,7 @@
 
 You can bulk create, update, and delete rules.
 
-NOTE: The {kib} Console supports only Elasticsearch APIs. Console doesn't allow interactions with {kib} APIs. You must use `curl` or another HTTP tool instead. For more information, refer to https://www.elastic.co/guide/en/kibana/current/console-kibana.html[Console].
+NOTE: Console supports only {es} APIs and doesn't allow interactions with {kib} APIs. You must use `curl` or another HTTP tool instead. For more information, refer to https://www.elastic.co/guide/en/kibana/current/console-kibana.html[Console].
 
 ==== Bulk create
 
@@ -191,7 +191,7 @@ A JSON array containing the updated rules.
 
 ==== Bulk action
 
-Apply a bulk action to multiple rules. The bulk action is applied to all rules that match the filter.
+Applies a bulk action to multiple rules. The bulk action is applied to all rules that match the filter.
 
 ===== Request URL
 
@@ -201,12 +201,12 @@ Apply a bulk action to multiple rules. The bulk action is applied to all rules t
 
 A JSON object with two required parameters:
 
-* `query` - A string containing KQL search query to match the rules.
+* `query` - A string containing a KQL search query to match the rules.
 * `action` - A bulk action to apply. Possible values: `enable`, `disable`, `delete`, `duplicate`, and `export`
 
 ====== Example request
 
-The following request will activate all detection rules that have the `test` tag.
+The following request will activate all rules that have the `test` tag:
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
Small addendum to #952. 

Preview [here](https://security-docs_978.docs-preview.app.elstc.co/guide/en/security/master/bulk-actions-rules-api.html). 