### PR TITLE
[7.14] [BUG] Remove mention that CSS is supported for the defaultThreatIndex setting and update note about CCS for IM rules (#1004)

### DIFF
--- a/docs/detections/detection-engine-intro.asciidoc
+++ b/docs/detections/detection-engine-intro.asciidoc
@@ -82,9 +82,9 @@ Using cold tier data for unsupported indices may result in detection rule timeou
 [[support-indicator-rules]]
 == Limited support for indicator match rules
 
-Indicator match rules provide a powerful capability to search your security data; however, their queries can consume significant deployment resources. As such, the following support restrictions are in place:
+Indicator match rules provide a powerful capability to search your security data; however, their queries can consume significant deployment resources. We recommend avoiding indicator index queries that return more indicators than necessary for the desired rule coverage. In addition, the following support restrictions are in place:
 
-* {es-sec} does not support the use of cold tier data with indicator match rules.
+* {es-sec} does not support the use of frozen tier data with indicator match rules.
 * The use of Cross Cluster Search (CCS) with indicator match rules is not supported.
 * Indicator match rules with an additional look-back time value greater than 24 hours are not supported.
 

--- a/docs/getting-started/advanced-setting.asciidoc
+++ b/docs/getting-started/advanced-setting.asciidoc
@@ -73,8 +73,6 @@ collectors to ship data to {es}, the data must be mapped to ECS.
 
 The `securitySolution:defaultThreatIndex` advanced setting defines threat intelligence indices that {elastic-sec} will use when collecting threat indicators. The setting controls features that query threat indices, such as the Threat Intelligence view on the Overview page and threat indicator match rules. One or more threat intelligence indices can be defined; the `filebeat-*` index is specified by default.
 
-TIP: You can enable cross-cluster search by adding threat indices from remote clusters.
-
 IMPORTANT: Threat intelligence indices aren't required to be ECS compatible when used in an indicator match rule. However, we recommend compatibility if you'd like for your alerts to be enriched with relevant threat indicator information. By default, indicator match rules are configured to ingest indicators from the Threat Intel {filebeat} module and to check for fields prefixed with `threatintel.indicator`. See {filebeat-ref}/filebeat-module-threatintel.html[Threat Intel module] for more information about these fields. This rule setting is stored in the *Indicator prefix override* field, under indicator match rule advanced settings. If your indicator data contains indicator fields at a different location, update this field accordingly to ensure alert enrichment can still be performed.
 
 [discrete]


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [BUG] Remove mention that CSS is supported for the defaultThreatIndex setting and update note about CCS for IM rules (#1004)