### PR TITLE
[Detection-rules] Remove extra entries in rules update table

### DIFF
--- a/docs/detections/prebuilt-rules/prebuilt-rules-downloadable-updates.asciidoc
+++ b/docs/detections/prebuilt-rules/prebuilt-rules-downloadable-updates.asciidoc
@@ -23,10 +23,6 @@ https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-34527[PrintNightm
 
 |<<prebuilt-rule-0-13-1-prebuilt-rules-0-13-1-summary, 0.13.1>> | 21 Jun 2021 | 4 | 41 |
 
-|Update version |Date | New rules | Updated rules
-
-|<<prebuilt-rule-0-13-1-prebuilt-rules-0-13-1-summary, 0.13.1>> | 21 Jun 2021 | 4 | 41
-
 |==============================================
 
 


### PR DESCRIPTION
Looks like some extra lines were accidentally left from a previous merge-conflict resolution. 7.15 and main look fine.

![image](https://user-images.githubusercontent.com/16747370/132087761-4e7cb03c-ef38-4e82-bdb7-c01541de2ba1.png)
