### PR TITLE
[7.15] Replace gsuite link with Google Workspace (#1036)

### DIFF
--- a/docs/detections/rules-ui-create.asciidoc
+++ b/docs/detections/rules-ui-create.asciidoc
@@ -358,7 +358,7 @@ caused the event directly in the Alerts table.
 TIP: These Filebeat modules have an `event.ingested` timestamp field that can
 be used instead of the default `@timestamp` field:
 {filebeat-ref}/filebeat-module-microsoft.html[Microsoft] and
-{filebeat-ref}/filebeat-module-gsuite.html[GSuite].
+{filebeat-ref}/filebeat-module-google_workspace.html[Google Workspace].
 
 . Click *Continue*. The *Schedule rule* pane is displayed.
 +


### PR DESCRIPTION
Backports the following commits to 7.15:
 - Replace gsuite link with Google Workspace (#1036)