### PR TITLE
[7.15] [DOCS] Add more context to indicator match rule restrictions (#1025)

### DIFF
--- a/docs/detections/detection-engine-intro.asciidoc
+++ b/docs/detections/detection-engine-intro.asciidoc
@@ -82,8 +82,9 @@ Using cold tier data for unsupported indices may result in detection rule timeou
 [[support-indicator-rules]]
 == Limited support for indicator match rules
 
-Indicator match rules provide a powerful capability to search your security data; however, their queries can consume significant deployment resources. We recommend avoiding indicator index queries that return more indicators than necessary for the desired rule coverage. In addition, the following support restrictions are in place:
+Indicator match rules provide a powerful capability to search your security data; however, their queries can consume significant deployment resources. When creating an <<create-indicator-rule, indicator match rule>>, we recommend limiting the time range of the indicator index query to the minimum period necessary for the desired rule coverage. For example, entering a query such as `@timestamp > "now-30d"` will return indicators ingested during the past 30 days. Without this limitation, the rule will include all of the indicators in your indicator indices, which may extend the time it takes for the indicator index query to complete.
 
+In addition, the following support restrictions are in place:
 * {es-sec} does not support the use of frozen tier data with indicator match rules.
 * The use of Cross Cluster Search (CCS) with indicator match rules is not supported.
 * Indicator match rules with an additional look-back time value greater than 24 hours are not supported.


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [DOCS] Add more context to indicator match rule restrictions (#1025)