### PR TITLE
[mergify] Use mergify to backport PRs that were tagged with v\d labels

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,56 @@
+pull_request_rules:
+  - name: ask to resolve conflict
+    conditions:
+      - conflict
+    actions:
+        comment:
+          message: |
+            This pull request is now in conflicts. Could you fix it @{{author}}? 🙏
+            To fixup this pull request, you can check out it locally. See documentation: https://help.github.com/articles/checking-out-pull-requests-locally/
+            ```
+            git fetch upstream
+            git checkout -b {{head}} upstream/{{head}}
+            git merge upstream/{{base}}
+            git push upstream {{head}}
+            ```
+  - name: backport patches to 7.x branch
+    conditions:
+      - merged
+      - base=main
+      - label=v7.x
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "7.x"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+  - name: backport patches to 7.15 branch
+    conditions:
+      - merged
+      - base=master
+      - label=v7.15
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "7.15"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+  - name: notify the backport policy
+    conditions:
+      - -label~=(^v\d|backport-skip)
+      - base=main
+    actions:
+      comment:
+        message: |
+          This pull request does not have a backport label. Could you fix it @{{author}}? 🙏
+          To fixup this pull request, you need to add the backport labels for the needed
+          branches, such as:
+          * `v7.x` is the label to automatically backport to the `7.x` branch.
+          * `v7./d` is the label to automatically backport to the `7./d` branch. `/d` is the digit
+
+          **NOTE**: `backport-skip` has been added to this pull request.
+      label:
+        add:
+          - backport-skip


### PR DESCRIPTION
### What

This is just a proposal to use `mergify` in order to:
1. create the backports automatically
2. notify when a backport has a conflict to be resolved.
3. notify in the original PR when there is no `v\d*` labels or `backport-skip` labels

### Why

This is a SaaS that works out of the box with public repositories. So it can simplify your backport.

It's stateless, so it does not track if a particular PR should have been backported, it backports any PR only if:
1) It was merged and tagged with the labels -> https://docs.mergify.io/actions/backport/ and see the `.mergify.yml` file.
2) An explicit GitHub comment was added -> https://docs.mergify.io/commands/#backport

### How does it work?

- Tag your PR with `v7.x`, o

### What's required?

0) Agree if you'd like to move forward.
1) Enable mergify (need to ask infra to enable this service)
2) Agree with the `v7.x` label since it's required to help to easily backport to the 7.x branch.
3) Agree with the `backport-skip` label since it's required to explicitly comment in the original PR when no backport tags have been added.
3) When a new release branch is created, then it's required to edit `.mergify.yml` to add the new branch backport entry and bump the branch for the `v7.x` label.

### Further details

This particular service has been enabled for different projects:
- https://github.com/elastic/apm-server
- https://github.com/elastic/beats

It does allow to auto-merge backported PRs if their GitHub checks passed and some other automations.

