### PR TITLE
[7.x] [DOCS] Migrating Enriched CTI Alerts (#1035)

### DIFF
--- a/docs/post-upgrade-req-cti-alerts
+++ b/docs/post-upgrade-req-cti-alerts
@@ -1,0 +1,33 @@
+[[post-upgrade-req-cti-alerts]]
+
+= Migrate detection alerts enriched with threat intelligence
+
+After upgrading to {stack} version 7.15.x from a release between 7.12.0 and 7.14.2, you need to migrate detection alerts enriched with threat intelligence data to ensure threat intelligence properly displays in {elastic-sec}.
+
+To migrate detection alerts:
+
+. Ensure that all <<deactivate-detect-rules, detection rules are deactivated>> prior to upgrading your {stack}.
+. Upgrade Kibana. For more information, refer to {kibana-ref}/upgrade.html[Upgrade Kibana].
+. Visit the Overview or Alerts page in {elastic-sec} to update the `.siem-signals*` index.
+. Migrate old alerts using the <<signals-migration-api, Detection Alerts Migration API >>.
+. <<reactivate-detect-rules, Reactivate all detection rules>> .
+
+[float]
+[[deactivate-detect-rules]]
+== Deactivate all detection rules
+
+To deactivate all detection rules:
+
+. Go to *Detect* -> *Rules*.
+. Click the *Select All Rules* button above the All rules table.
+. Click *Bulk actions* -> *Deactivate selected*.
+
+[float]
+[[reactivate-detect-rules]]
+== Reactivate all detection rules
+
+To reactivate all detection rules:
+
+. Go to *Detect* -> *Rules*.
+. Click the *Select All Rules* button above the All rules table.
+. Click *Bulk actions* -> *Activate selected*.

--- a/docs/post-upgrade/post-upgrade-intro.asciidoc
+++ b/docs/post-upgrade/post-upgrade-intro.asciidoc
@@ -4,5 +4,6 @@
 
 The following section describes optional procedures to complete after upgrading the {stack}.
 
-include::post-upgrade-req.asciidoc[leveloffset=+1]
-include::template-script.asciidoc[leveloffset=+1]
+include::post-upgrade-req.asciidoc[]
+include::post-upgrade-req-cti-alerts.asciidoc[]
+include::template-script.asciidoc[]

--- a/docs/post-upgrade/post-upgrade-req-cti-alerts.asciidoc
+++ b/docs/post-upgrade/post-upgrade-req-cti-alerts.asciidoc
@@ -1,0 +1,33 @@
+[[post-upgrade-req-cti-alerts]]
+
+== Migrate detection alerts enriched with threat intelligence
+
+After upgrading to {stack} version 7.15.x from a release between 7.12.0 and 7.14.2, you need to migrate detection alerts enriched with threat intelligence data to ensure threat intelligence properly displays in {elastic-sec}.
+
+To migrate detection alerts:
+
+. Ensure that all <<deactivate-detect-rules, detection rules are deactivated>> prior to upgrading your {stack}.
+. Upgrade Kibana. See {kibana-ref}/upgrade.html[Upgrade {kib}] for more information.
+. Visit the Overview or Alerts page in {elastic-sec} to update the `.siem-signals*` index.
+. Migrate old alerts using the <<signals-migration-api, Detection Alerts Migration API>>.
+. <<reactivate-detect-rules, Reactivate all detection rules>>.
+
+[float]
+[[deactivate-detect-rules]]
+=== Deactivate all detection rules
+
+To deactivate all detection rules:
+
+. Go to *Detect* -> *Rules*.
+. Click the *Select All Rules* button above the All rules table.
+. Click *Bulk actions* -> *Deactivate selected*.
+
+[float]
+[[reactivate-detect-rules]]
+=== Reactivate all detection rules
+
+To reactivate all detection rules:
+
+. Go to *Detect* -> *Rules*.
+. Click the *Select All Rules* button above the All rules table.
+. Click *Bulk actions* -> *Activate selected*.

--- a/docs/post-upgrade/post-upgrade-req.asciidoc
+++ b/docs/post-upgrade/post-upgrade-req.asciidoc
@@ -1,6 +1,6 @@
 [[post-upgrade-req]]
 [role="xpack"]
-= Enable process analyzer after an upgrade
+== Enable process analyzer after an upgrade
 
 After upgrading from {stack} version 7.9.x to >= 7.10.x from a previous minor release (e.g., 7.8.x, etc.), you need to update `.siem-signals*` system index mappings to enable <<alerts-analyze-events, graphical representations of process relationships>>.
 

--- a/docs/post-upgrade/template-script.asciidoc
+++ b/docs/post-upgrade/template-script.asciidoc
@@ -1,5 +1,5 @@
 [[signals-index-template]]
-= Index template script
+== Index template script
 
 This code creates a new index template for temporarily storing existing
 detection alerts when you update `.siem-signals-*` index mappings. You


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Migrating Enriched CTI Alerts (#1035)