### PR TITLE
[7.x] Add query for finding outdated alerts with CTI data (#1090)

### DIFF
--- a/docs/detections/api/signals-migration-api.asciidoc
+++ b/docs/detections/api/signals-migration-api.asciidoc
@@ -84,6 +84,28 @@ NOTE: Indices that do not contain detection alerts in the specified range will b
 
 With the above info, we can compile a list of indices that we wish to migrate.
 
+*Find outdated detection alerts with threat intelligence data*
+
+After upgrading to {stack} version 7.15.x from release versions 7.12.0 through 7.14.2, you need to migrate detection alerts enriched with threat intelligence data to ensure threat intelligence properly displays in {elastic-sec}. Run this query to find outdated detection alerts with threat intelligence data:
+
+[source,json]
+--------------------------------------------------
+GET .siem-signals-{KIBANA SPACE ID}/_search
+{
+  "query": {
+    "nested": {
+      "path": "threat.indicator",
+      "query": {
+        "exists": {
+          "field": "threat.indicator.matched.*"
+        }
+      }
+    }
+  }
+}
+--------------------------------------------------
+
+
 [[migration-2]]
 [float]
 === Initiate migrations


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add query for finding outdated alerts with CTI data (#1090)