### PR TITLE
[7.x] Clarify admin access to Trusted Applications page (#1062)

### DIFF
--- a/docs/management/admin/trusted-apps.asciidoc
+++ b/docs/management/admin/trusted-apps.asciidoc
@@ -2,7 +2,7 @@
 [chapter, role="xpack"]
 = Trusted applications
 
-Administrators can add Windows, macOS, and Linux applications that should be trusted. By adding these trusted applications, you can use {elastic-sec} without compatibility or performance issues with other installed applications on your system. Trusted applications are applied only to hosts running {endpoint-sec}.
+Users with `superuser` role can add Windows, macOS, and Linux applications that should be trusted. By adding these trusted applications, you can use {elastic-sec} without compatibility or performance issues with other installed applications on your system. Trusted applications are applied only to hosts running {endpoint-sec}.
 
 Trusted applications are designed to help mitigate performance issues and incompatibilities with other endpoint software. However, they create blindspots for {elastic-sec}. One avenue attackers use to exploit these blindspots is by DLL (Dynamic Link Library) side-loading, where they leverage processes signed by trusted vendors -- such as antivirus software -- to execute their malicious DLLs. Such activity appears to originate from the trusted vendor's process.
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Clarify admin access to Trusted Applications page (#1062)