### PR TITLE
[DOCS] Add 7.15 anchor for what's new to 7.x

### DIFF
--- a/docs/whats-new.asciidoc
+++ b/docs/whats-new.asciidoc
@@ -6,7 +6,7 @@ Here are the highlights of what’s new and improved in {es-sec}!
 
 For detailed information about this release, see the <<release-notes, Release notes>>.
 
-Other versions: {security-guide-all}/7.14/whats-new.html[7.14] | {security-guide-all}/7.13/whats-new.html[7.13] | {security-guide-all}/7.12/whats-new.html[7.12] | {security-guide-all}/7.11/whats-new.html[7.11] | {security-guide-all}/7.10/whats-new.html[7.10] |
+Other versions: {security-guide-all}/7.15/whats-new.html[7.15] | {security-guide-all}/7.14/whats-new.html[7.14] | {security-guide-all}/7.13/whats-new.html[7.13] | {security-guide-all}/7.12/whats-new.html[7.12] | {security-guide-all}/7.11/whats-new.html[7.11] | {security-guide-all}/7.10/whats-new.html[7.10] |
 {security-guide-all}/7.9/whats-new.html[7.9]
 ////
 


### PR DESCRIPTION
- Adds 7.15 ref link for what's new: https://www.elastic.co/guide/en/security/7.15/whats-new.html