### PR TITLE
[7.x] [BUG] Revise 7.15 release notes: host isolation Linux version support (#1116)

### DIFF
--- a/docs/release-notes/7.15.asciidoc
+++ b/docs/release-notes/7.15.asciidoc
@@ -32,7 +32,8 @@
 * Adds malicious behavior protection as an option for configuring integration policies. This option detects and stops threats by monitoring the behavior of system processes for suspicious activity. Behavioral signals are much more difficult for adversaries to evade than traditional file-based detection techniques. Users can also create exceptions for behavior protection alerts ({pull}106853[#106853], {pull}106247[#106247]).
 * For {stack} version >= 7.15.0, adds support for host isolation for endpoints in Windows, macOS, and these Linux distributions ({pull}108230[#108230]):
 
-** CentOS 7/Rehl 7
+** CentOS 8
+** RHEL 8
 ** Ubuntu 18.04
 ** Ubuntu 20.04
 ** AWS Linux 2


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [BUG] Revise 7.15 release notes: host isolation Linux version support (#1116)