### PR TITLE
[7.15] [DOCS] Clarify usage of field overrides with Threshold Rules (#1124)

### DIFF
--- a/docs/detections/rules-ui-create.asciidoc
+++ b/docs/detections/rules-ui-create.asciidoc
@@ -300,6 +300,8 @@ values:
 +
 [role="screenshot"]
 image::images/severity-mapping-ui.png[]
++
+NOTE: For threshold rules, not all source event values can be used for overrides; only the fields that were aggregated over (the `Group by` fields) will contain data.
 .. *Default risk score*: A numerical value between 0 and 100 that correlates
 with the *Severity* level. General guidelines are:
 * `0` - `21` represents low severity.
@@ -315,6 +317,7 @@ alerts:
 [role="screenshot"]
 image::images/risk-source-field-ui.png[]
 +
+NOTE: For threshold rules, not all source event values can be used for overrides; only the fields that were aggregated over (the `Group by` fields) will contain data.
 .. *Tags* (optional): Words and phrases used to categorize, filter, and search
 the rule.
 
@@ -353,6 +356,8 @@ rule name in the UI (Alerts table). This is useful for exposing, at a glance,
 more information about an alert. For example, if the rule generates alerts from
 Suricata, selecting `event.action` lets you see what action (Suricata category)
 caused the event directly in the Alerts table.
++
+NOTE: For threshold rules, not all source event values can be used for overrides; only the fields that were aggregated over (the `Group by` fields) will contain data.
 .. *Timestamp override* (optional): Select a source event timestamp field. When selected, the rule's query uses the selected field, instead of the default `@timestamp` field, to search for alerts. This can help reduce missing alerts due to network or server outages. Specifically, if your ingest pipeline adds a timestamp when events are sent to {es}, this avoids missing alerts due to ingestion delays.
 +
 TIP: These Filebeat modules have an `event.ingested` timestamp field that can


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [DOCS] Clarify usage of field overrides with Threshold Rules (#1124)