### PR TITLE
[7.x] [DOCS] Clarify alert de-duplication logic around configured 'additional look-back time' (#1125)

### DIFF
--- a/docs/detections/rules-ui-create.asciidoc
+++ b/docs/detections/rules-ui-create.asciidoc
@@ -390,8 +390,8 @@ It is recommended to set the `Additional look-back time` to at
 least 1 minute. This ensures there are no missing alerts when a rule does not
 run exactly at its scheduled time.
 
-The {es-sec-app} prevents duplication. Any duplicate alerts that are discovered during the
-`Additional look-back time` are *not* created.
+{elastic-sec} prevents duplication. Any duplicate alerts that are discovered during the
+`Additional look-back time` are _not_ created.
 ==============
 . Click *Continue*. The *Rule actions* pane is displayed.
 +

--- a/docs/detections/rules-ui-monitor.asciidoc
+++ b/docs/detections/rules-ui-monitor.asciidoc
@@ -36,6 +36,13 @@ If you see values in the Gaps column in the All rules table or on the Rule detai
 for a small number of rules, you can increase those rules'
 Additional look-back time (*Detect* -> *Rules* -> the rule's *All actions* button (*...*) -> *Edit rule settings* -> *Schedule* -> *Additional look-back time*).
 
+It's recommended to set the `Additional look-back time` to at
+least 1 minute. This ensures there are no missing alerts when a rule doesn't
+run exactly at its scheduled time.
+
+{elastic-sec} prevents duplication. Any duplicate alerts that are discovered during the
+`Additional look-back time` are _not_ created.
+
 NOTE: If the rule that experiences gaps is an indicator match rule, see <<tune-indicator-rules, how to tune indicator match rules>>. Also please note that {es-sec} provides <<support-indicator-rules, limited support for indicator match rules>>.
 
 If you see gaps for numerous rules:


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Clarify alert de-duplication logic around configured 'additional look-back time' (#1125)