### PR TITLE
Fix relative links to images

### DIFF
--- a/docs/getting-started/security-ui.asciidoc
+++ b/docs/getting-started/security-ui.asciidoc
@@ -99,7 +99,7 @@ There are a few scenarios when data won't display in the Threat Intelligence vie
 The Alerts page allows you to view and manage all alerts to monitor activity within your network. See <<detection-engine-overview, Detections and Alerts>> for more information.
 
 [role="screenshot"]
-image::../detections/images/alert-page.png[]
+image::/detections/images/alert-page.png[]
 
 [float]
 [[rules-page]]
@@ -175,7 +175,7 @@ image::images/endpoints-page.png[Shows the Endpoints page]
 The Trusted applications page allows you to add Windows, macOS, and Linux applications that should be trusted. See <<trusted-apps-ov, Trusted applications>> for more information.
 
 [role="screenshot"]
-image::../management/admin/images/trusted-apps-list.png[Shows the Trusted applications page]
+image::/management/admin/images/trusted-apps-list.png[Shows the Trusted applications page]
 
 [float]
 [[event-filters-page]]
@@ -184,7 +184,7 @@ image::../management/admin/images/trusted-apps-list.png[Shows the Trusted applic
 The Event filters page allows filter endpoint events that you do not need or want stored in Elasticsearch. See <<event-filters, Event filters>> for more information.
 
 [role="screenshot"]
-image::../management/admin/images/event-filters-list.png[Shows the Event filters page]
+image::/management/admin/images/event-filters-list.png[Shows the Event filters page]
 
 [discrete]
 [[timeline-accessibility-features]]

--- a/docs/troubleshooting/management/ts-management.asciidoc
+++ b/docs/troubleshooting/management/ts-management.asciidoc
@@ -15,7 +15,7 @@ This topic covers common troubleshooting issues when using {elastic-sec} <<sec-m
 If you encounter a `“Required transform failed”` notice on the Endpoints page, you can usually resolve the issue by restarting the transform. See {ref}/transforms.html[Transforming data] for more information about transforms.
 
 [role="screenshot"]
-image::../images/endpoints-transform-failed.png[Endpoints page with Required transform failed notice]
+image::/images/endpoints-transform-failed.png[Endpoints page with Required transform failed notice]
 
 To restart a transform that’s not running:
 
@@ -26,7 +26,7 @@ To restart a transform that’s not running:
 * `failed`: Select *Stop* to first stop the transform, and then select *Start* to restart it.
 +
 [role="screenshot"]
-image::../images/transforms-start.png[Transforms page with Start option selected]
+image::/images/transforms-start.png[Transforms page with Start option selected]
 
 . On the confirmation message that displays, click *Start* to restart the transform.
 . The transform’s status changes to `started`. Refresh the page if you don't see the change.


### PR DESCRIPTION
This PR fixes two docs pages that have broken image references due to relative links/paths to the image files.

* [Elastic Security UI](https://www.elastic.co/guide/en/security/current/es-ui-overview.html)

  - Alerts page: `../detections/images/alert-page.png`
  - Trusted applications page: `../management/admin/images/trusted-apps-list.png`
  - Event filters page: `../management/admin/images/event-filters-list.png`

* [Troubleshooting - Management tools](https://www.elastic.co/guide/en/security/current/ts-management.html)
  - Endpoints page: `../images/endpoints-transform-failed.png`
  - Transforms page: `../images/transforms-start.png`
