### PR TITLE
[mergify] support labels with 3 digits and v7.14.0

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -31,7 +31,7 @@ pull_request_rules:
     conditions:
       - merged
       - base=main
-      - label=v7.15.0
+      - label=v7.16.0
     actions:
       backport:
         assignees:


### PR DESCRIPTION
### What

- Automated backports to be tagged with the `backport` label
- Match labels with the patch version, therefore `v7.Y.0` rather than `v7.Y` (where `Y` represents a number, for instance: `v7.15.0`.
- Add 7.14 branch support for the automated backport.