### PR TITLE
[BUG] Formatting errors in the "Limited support for indicator match rules" section

### DIFF
--- a/docs/detections/detection-engine-intro.asciidoc
+++ b/docs/detections/detection-engine-intro.asciidoc
@@ -87,7 +87,7 @@ Indicator match rules provide a powerful capability to search your security data
 In addition, the following support restrictions are in place:
 
 * {es-sec} does not support the use of frozen tier data with indicator match rules.
-* The use of Cross Cluster Search (CCS) with indicator match rules is not supported.
+* The use of cross-cluster search with indicator match rules is not supported.
 * Indicator match rules with an additional look-back time value greater than 24 hours are not supported.
 
 [float]


### PR DESCRIPTION
Addresses #1152.

Preview [here](https://security-docs_1153.docs-preview.app.elstc.co/guide/en/security/master/detection-engine-overview.html#support-indicator-rules).