### PR TITLE
[Docs] [Security Platform] adds warning for basic auth only

### DIFF
--- a/docs/detections/api/rules/rules-api-bulk-actions.asciidoc
+++ b/docs/detections/api/rules/rules-api-bulk-actions.asciidoc
@@ -8,6 +8,8 @@ NOTE: Console supports only {es} APIs and doesn't allow interactions with {kib} 
 
 ==== Bulk create
 
+WARNING: This API supports <<token-api-authentication>> only.
+
 Creates new rules.
 
 ===== Request URL
@@ -116,6 +118,8 @@ DELETE api/detection_engine/rules/_bulk_delete
 A JSON array containing the deleted rules.
 
 ==== Bulk update
+
+WARNING: This API supports <<token-api-authentication>> only.
 
 Updates multiple rules.
 

--- a/docs/detections/api/rules/rules-api-create.asciidoc
+++ b/docs/detections/api/rules/rules-api-create.asciidoc
@@ -1,6 +1,8 @@
 [[rules-api-create]]
 === Create rule
 
+WARNING: This API supports <<token-api-authentication>> only.
+
 Creates a new detection rule.
 
 NOTE: The {kib} Console supports only Elasticsearch APIs. Console doesn't allow interactions with {kib} APIs. You must use `curl` or another HTTP tool instead. For more information, refer to https://www.elastic.co/guide/en/kibana/current/console-kibana.html[Console].

--- a/docs/detections/api/rules/rules-api-import.asciidoc
+++ b/docs/detections/api/rules/rules-api-import.asciidoc
@@ -1,6 +1,8 @@
 [[rules-api-import]]
 === Import rules
 
+WARNING: This API supports <<token-api-authentication>> only.
+
 Imports rules from an ndjson file.
 
 NOTE: The {kib} Console supports only Elasticsearch APIs. Console doesn't allow interactions with {kib} APIs. You must use `curl` or another HTTP tool instead. For more information, refer to https://www.elastic.co/guide/en/kibana/current/console-kibana.html[Console].

--- a/docs/detections/api/rules/rules-api-update.asciidoc
+++ b/docs/detections/api/rules/rules-api-update.asciidoc
@@ -1,6 +1,8 @@
 [[rules-api-update]]
 === Update rule
 
+WARNING: This API supports <<token-api-authentication>> only.
+
 Updates an existing detection rule.
 
 NOTE: The {kib} Console supports only Elasticsearch APIs. Console doesn't allow interactions with {kib} APIs. You must use `curl` or another HTTP tool instead. For more information, refer to https://www.elastic.co/guide/en/kibana/current/console-kibana.html[Console].


### PR DESCRIPTION
Alerting docs added a warning to their docs to inform users that the create / update / enable api's only allow basic auth. Because we rely on the alerting api's we need to bubble up this same warning in our docs too.