### PR TITLE
[DOCS] Github style markdown causes issues during upgrade

### DIFF
--- a/docs/release-notes/7.15.asciidoc
+++ b/docs/release-notes/7.15.asciidoc
@@ -97,4 +97,4 @@
 [discrete]
 [[known-issue-7.15.0]]
 ==== Known issues
-* Case comments containing GitHub Formatted Markdown (GFM) will cause migrations to fail when upgrading to 7.150 or later. To prevent this, remove GFM from the case comment before upgrading ({pull}1195093[#119509]).
+* Case comments containing https://github.github.com/gfm/#what-is-github-flavored-markdown[GitHub Flavored Markdown (GFM)] will cause migrations to fail when upgrading to 7.150 or later. To prevent this, remove GFM from the case comment before upgrading ({pull}1195093[#119509]).

--- a/docs/release-notes/7.15.asciidoc
+++ b/docs/release-notes/7.15.asciidoc
@@ -15,7 +15,6 @@
 * Fixes a rule execution bug that intermittently caused large status documents to be generated and indexed, which contributed to Kibana upgrades failing ({pull}112257[#112257]).
 * Updates status queries to use the new `kibana.alert.workflow_status` field, and removes `replaceAll` references that caused older browser versions to crash if they didn’t support it ({pull}114481[#114481]).
 
-
 [discrete]
 [[release-notes-7.15.1]]
 === 7.15.1
@@ -94,3 +93,8 @@
 * Adds the `Responses` field to telemetry ({pull}111892[#111892]).
 * Fixes issues with the pagination on the Exceptions table ({pull}111000[#111000]).
 * Fixes a bug that caused empty comments to display in an endpoint's activity log ({pull}111163[#111163]).
+
+[discrete]
+[[known-issue-7.15.0]]
+==== Known issues
+* Case comments containing GitHub Formatted Markdown (GFM) will cause migrations to fail when upgrading to 7.150 or later. To prevent this, remove GFM from the case comment before upgrading ({pull}1195093[#119509]).

--- a/docs/release-notes/7.15.asciidoc
+++ b/docs/release-notes/7.15.asciidoc
@@ -97,4 +97,4 @@
 [discrete]
 [[known-issue-7.15.0]]
 ==== Known issues
-* Case comments containing https://github.github.com/gfm/#what-is-github-flavored-markdown-[GitHub Flavored Markdown (GFM)] will cause migrations to fail when upgrading to {stack} version 7.15.0 or later. To prevent this, remove GFM from the case comment before upgrading ({pull}1195093[#119509]).
+* Case comments containing https://github.github.com/gfm/#what-is-github-flavored-markdown-[GitHub Flavored Markdown (GFM)] will cause migrations to fail when upgrading to {stack} version 7.15.0 or later. To prevent this, remove GFM from the case comment before upgrading ({pull}119509[#119509]).

--- a/docs/release-notes/7.15.asciidoc
+++ b/docs/release-notes/7.15.asciidoc
@@ -97,4 +97,4 @@
 [discrete]
 [[known-issue-7.15.0]]
 ==== Known issues
-* Case comments containing https://github.github.com/gfm/#what-is-github-flavored-markdown[GitHub Flavored Markdown (GFM)] will cause migrations to fail when upgrading to 7.150 or later. To prevent this, remove GFM from the case comment before upgrading ({pull}1195093[#119509]).
+* Case comments containing https://github.github.com/gfm/#what-is-github-flavored-markdown-[GitHub Flavored Markdown (GFM)] will cause migrations to fail when upgrading to {stack} version 7.15.0 or later. To prevent this, remove GFM from the case comment before upgrading ({pull}1195093[#119509]).


### PR DESCRIPTION
Addresses #1267.

Preview here:
- [Release Notes](https://security-docs_1268.docs-preview.app.elstc.co/guide/en/security/7.15/release-notes.html#known-issue-7.15.0) 