### PR TITLE
[DOCS] Move Known issues section to top of page

### DIFF
--- a/docs/release-notes/7.15.asciidoc
+++ b/docs/release-notes/7.15.asciidoc
@@ -10,7 +10,7 @@
 [discrete]
 [[bug-fixes-7.15.2]]
 ==== Bug fixes and enhancements
-* The Analyze event option has been moved from the overflow menu to the Actions column. It now only displays events that can be opened in the visual event analyzer ({pull}115478[#115478]).
+* Moves the *Analyze event* option from the overflow menu to the *Actions* column within the Alerts and Events tables. It now only displays events that can be opened in the visual event analyzer ({pull}115478[#115478]).
 * Fixes a table height issue that occurs when the Alerts table only has a few alerts ({pull}114718[#114718]).
 * Fixes a rule execution bug that intermittently caused large status documents to be generated and indexed, which contributed to Kibana upgrades failing ({pull}112257[#112257]).
 * Updates status queries to use the new `kibana.alert.workflow_status` field, and removes `replaceAll` references that caused older browser versions to crash if they didn’t support it ({pull}114481[#114481]).
@@ -22,7 +22,7 @@
 [discrete]
 [[bug-fixes-7.15.1]]
 ==== Bug fixes and enhancements
-* Supports newlines in the JIRA summary field. Newlines are replaced with commas ({pull}113571[#113571]).
+* Supports newlines in the {jira} summary field. Newlines are replaced with commas ({pull}113571[#113571]).
 * Fixes a bug that prevented the Endpoints table from resetting after the KQL query was removed ({pull}112595[#112595]).
 * Fixes a bug that caused threshold and indicator match rules to ignore custom rule filters if a saved query was used in the rule definition ({pull}109253[#109253]).
 * Fixes a bug on the Alerts page that prevented the Trend histogram and Count table from being updated after an alert’s status was changed. With this fix, refreshing the Alerts page is no longer necessary to view the updates ({pull}111042[#111042]).
@@ -30,6 +30,11 @@
 [discrete]
 [[release-notes-7.15.0]]
 === 7.15.0
+
+[discrete]
+[[known-issue-7.15.0]]
+==== Known issues
+* Case comments containing https://github.github.com/gfm/#what-is-github-flavored-markdown-[GitHub Flavored Markdown (GFM)] will cause migrations to fail when upgrading to {stack} version 7.15.0 or later. To prevent this, remove GFM from the case comment before upgrading ({pull}119509[#119509]).
 
 [discrete]
 [[breaking-changes-7.15.0]]
@@ -93,8 +98,3 @@
 * Adds the `Responses` field to telemetry ({pull}111892[#111892]).
 * Fixes issues with the pagination on the Exceptions table ({pull}111000[#111000]).
 * Fixes a bug that caused empty comments to display in an endpoint's activity log ({pull}111163[#111163]).
-
-[discrete]
-[[known-issue-7.15.0]]
-==== Known issues
-* Case comments containing https://github.github.com/gfm/#what-is-github-flavored-markdown-[GitHub Flavored Markdown (GFM)] will cause migrations to fail when upgrading to {stack} version 7.15.0 or later. To prevent this, remove GFM from the case comment before upgrading ({pull}119509[#119509]).


### PR DESCRIPTION
Addresses https://github.com/elastic/security-docs/issues/1285.

Preview:
- [Release notes](https://security-docs_1295.docs-preview.app.elstc.co/guide/en/security/7.15/release-notes.html)