### PR TITLE
[BUG] Remove discrete tags at the top of the 7.15 RN page

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -5,7 +5,7 @@ This section summarizes the changes in each release.
 
 * <<release-notes-7.15.2, {elastic-sec} version 7.15.2>>
 * <<release-notes-7.15.1, {elastic-sec} version 7.15.1>>
-* <<release-notes-header-7.15.0, {elastic-sec} version 7.15.0>>
+* <<release-notes-7.15.0, {elastic-sec} version 7.15.0>>
 * <<release-notes-7.14.2, {elastic-sec} version 7.14.2>>
 * <<release-notes-7.14.1, {elastic-sec} version 7.14.1>>
 * <<release-notes-7.14.0, {elastic-sec} version 7.14.0>>
@@ -13,7 +13,7 @@ This section summarizes the changes in each release.
 * <<release-notes-7.13.2, {elastic-sec} version 7.13.2>>
 * <<release-notes-7.13.0, {elastic-sec} version 7.13.0>>
 * <<release-notes-7.12.1, {elastic-sec} version 7.12.1>>
-* <<release-notes-7.12-header, {elastic-sec} version 7.12.0>>
+* <<release-notes-7.12.0, {elastic-sec} version 7.12.0>>
 * <<release-notes-7.11.2, {elastic-sec} version 7.11.2>>
 * <<release-notes-7.11.0, {elastic-sec} version 7.11.0>>
 * <<release-notes-7.10.1, {elastic-sec} version 7.10.1>>

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -1,7 +1,25 @@
 [[release-notes]]
-= Release Notes
+= Release notes
 
 This section summarizes the changes in each release.
+
+* <<release-notes-7.15.2, {elastic-sec} version 7.15.2>>
+* <<release-notes-7.15.1, {elastic-sec} version 7.15.1>>
+* <<release-notes-header-7.15.0, {elastic-sec} version 7.15.0>>
+* <<release-notes-7.14.2, {elastic-sec} version 7.14.2>>
+* <<release-notes-7.14.1, {elastic-sec} version 7.14.1>>
+* <<release-notes-7.14.0, {elastic-sec} version 7.14.0>>
+* <<release-notes-7.13.3, {elastic-sec} version 7.13.3>>
+* <<release-notes-7.13.2, {elastic-sec} version 7.13.2>>
+* <<release-notes-7.13.0, {elastic-sec} version 7.13.0>>
+* <<release-notes-7.12.1, {elastic-sec} version 7.12.1>>
+* <<release-notes-7.12-header, {elastic-sec} version 7.12.0>>
+* <<release-notes-7.11.2, {elastic-sec} version 7.11.2>>
+* <<release-notes-7.11.0, {elastic-sec} version 7.11.0>>
+* <<release-notes-7.10.1, {elastic-sec} version 7.10.1>>
+* <<release-notes-7.10.0, {elastic-sec} version 7.10.0>>
+* <<release-notes-7.9.1, {elastic-sec} version 7.9.1>>
+* <<release-notes-7.9.0, {elastic-sec} version 7.9.0>>
 
 // Use these for links to issue and pulls. Note issues and pulls redirect one to
 // each other on Github, so don't worry too much on using the right prefix.

--- a/docs/release-notes/7.15.asciidoc
+++ b/docs/release-notes/7.15.asciidoc
@@ -1,5 +1,3 @@
-
-[discrete]
 [[release-notes-header-7.15.0]]
 == 7.15
 


### PR DESCRIPTION
Addresses https://github.com/elastic/security-docs/issues/1299.

- Release notes page preview [here](https://security-docs_1300.docs-preview.app.elstc.co/guide/en/security/7.15/release-notes-header-7.15.0.html). 
- TOC preview [here](https://security-docs_1300.docs-preview.app.elstc.co/guide/en/security/7.15/index.html).
- 7.15 RN landing page [here](https://security-docs_1300.docs-preview.app.elstc.co/guide/en/security/7.15/release-notes.html). 