### PR TITLE
[7.9] [DOCS] Update security doc ML requirements (#1281)

### DIFF
--- a/docs/getting-started/ml-req.asciidoc
+++ b/docs/getting-started/ml-req.asciidoc
@@ -4,7 +4,6 @@
 To run and create {ml} jobs and rules, you need all of these:
 
 * The *https://www.elastic.co/subscriptions[appropriate license]*
-* {ml-cap} enabled on all master-eligible and coordinating {es} nodes (see
-{ref}/modules-node.html#ml-node[{ml-cap} node])
+* There must be at least one {ml} node in your cluster (see {ml-docs}/setup.html[Set up {ml} features])
 * The `machine_learning_admin` user role (see
 {ref}/built-in-roles.html[Built-in roles])


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [DOCS] Update security doc ML requirements (#1281)