### PR TITLE
[DOCS] 7.16.1 Release Notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in each release.
 
+** <<release-notes-7.16.1, {elastic-sec} version 7.16.0>>
 * <<release-notes-7.16.0, {elastic-sec} version 7.16.0>>
 * <<release-notes-7.15.2, {elastic-sec} version 7.15.2>>
 * <<release-notes-7.15.1, {elastic-sec} version 7.15.1>>

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,7 +3,7 @@
 
 This section summarizes the changes in each release.
 
-** <<release-notes-7.16.1, {elastic-sec} version 7.16.0>>
+* <<release-notes-7.16.1, {elastic-sec} version 7.16.1>>
 * <<release-notes-7.16.0, {elastic-sec} version 7.16.0>>
 * <<release-notes-7.15.2, {elastic-sec} version 7.15.2>>
 * <<release-notes-7.15.1, {elastic-sec} version 7.15.1>>

--- a/docs/release-notes/7.16.asciidoc
+++ b/docs/release-notes/7.16.asciidoc
@@ -2,6 +2,17 @@
 == 7.16
 
 [discrete]
+[[release-notes-7.16.1]]
+=== 7.16.1
+
+[discrete]
+[[bug-fixes-7.16.1]]
+==== Bug fixes and enhancements
+* Fixes a 409 conflict error that occurred when users enabled a rule ({pull}120088[#120088]).
+* Fixes a bug in the cases upgrade migration that was preventing upgrades from completing. This was due to Github Flavored Markdown (GFM) not being supported in case comments ({pull}119995[#119995]).
+* Adds host isolation exceptions summary in the {fleet} integration advance tab ({pull}119029[#119029]).
+
+[discrete]
 [[features-7.16.0]]
 ==== Features
 * Adds the ability to configure trusted applications on a per-policy basis, allowing security administrators to target a set of hosts with specific configurations and settings. For example, trusted applications can be tailored to certain functions within an organization or for testing and troubleshooting purposes ({pull}112182[#112182], {pull}111051[#111051], {pull}110966[#110966]).

--- a/docs/release-notes/7.16.asciidoc
+++ b/docs/release-notes/7.16.asciidoc
@@ -9,8 +9,8 @@
 [[bug-fixes-7.16.1]]
 ==== Bug fixes and enhancements
 * Fixes a 409 conflict error that occurred when users enabled a rule ({pull}120088[#120088]).
-* Fixes a bug in the cases upgrade migration that was preventing upgrades from completing. This was due to Github Flavored Markdown (GFM) not being supported in case comments ({pull}119995[#119995]).
-* Adds host isolation exceptions summary in the {fleet} integration advance tab ({pull}119029[#119029]).
+* Fixes a bug where case comments containing https://github.github.com/gfm/#what-is-github-flavored-markdown-[GitHub Flavored Markdown (GFM)] caused migrations to fail when upgrading to {stack} version 7.15.0 or later ({pull}119509[#119509]).
+* Adds the {fleet} host isolation exceptions summary card in the {fleet} integration *Advance* tab ({pull}119029[#119029]).
 
 [discrete]
 [[features-7.16.0]]

--- a/docs/release-notes/7.16.asciidoc
+++ b/docs/release-notes/7.16.asciidoc
@@ -9,7 +9,7 @@
 [[bug-fixes-7.16.1]]
 ==== Bug fixes and enhancements
 * Fixes a 409 conflict error that occurred when users enabled a rule ({pull}120088[#120088]).
-* Fixes a bug where case comments containing https://github.github.com/gfm/#what-is-github-flavored-markdown-[GitHub Flavored Markdown (GFM)] caused migrations to fail when upgrading to {stack} version 7.15.0 or later ({pull}119509[#119509]).
+* Fixes a bug where case comments containing https://github.github.com/gfm/#what-is-github-flavored-markdown-[GitHub Flavored Markdown (GFM)] caused migrations to fail when upgrading to {stack} version 7.15.0 or later ({pull}119995[#119995]).
 * Adds the {fleet} host isolation exceptions summary card in the {fleet} integration *Advance* tab ({pull}119029[#119029]).
 
 [discrete]


### PR DESCRIPTION
Addresses https://github.com/elastic/security-docs/issues/1332.

Preview [here](https://security-docs_1333.docs-preview.app.elstc.co/guide/en/security/current/release-notes-7.16.0.html). 