### PR TITLE
[7.16] [DOCS] Move Known issues section to top of page (#1295)

### DIFF
--- a/docs/release-notes/7.15.asciidoc
+++ b/docs/release-notes/7.15.asciidoc
@@ -35,11 +35,15 @@
 * Case comments containing https://github.github.com/gfm/#what-is-github-flavored-markdown-[GitHub Flavored Markdown (GFM)] will cause migrations to fail when upgrading to {stack} version 7.15.0 or later. To prevent this, remove GFM from the case comment before upgrading ({pull}119509[#119509]).
 
 [discrete]
+[[known-issue-7.15.0]]
+==== Known issues
+* Case comments containing https://github.github.com/gfm/#what-is-github-flavored-markdown-[GitHub Flavored Markdown (GFM)] will cause migrations to fail when upgrading to {stack} version 7.15.0 or later. To prevent this, remove GFM from the case comment before upgrading ({pull}119509[#119509]).
+
+[discrete]
 [[breaking-changes-7.15.0]]
 ==== Breaking changes
 * After upgrading to {stack} version 7.15.x from release versions 7.12.0 through 7.14.2, you need to migrate detection alerts enriched with threat intelligence data to ensure threat intelligence properly displays in {elastic-sec}. For more information, refer to instructions for <<post-upgrade-req-cti-alerts, migrating detection alerts enriched with threat intelligence data>> ({pull}1102[#1102]).
 * Removes the metadata query strategy v1 ({pull}104196[#104196]).
-
 
 [discrete]
 [[features-7.15.0]]
@@ -96,8 +100,3 @@
 * Adds the `Responses` field to telemetry ({pull}111892[#111892]).
 * Fixes issues with the pagination on the Exceptions table ({pull}111000[#111000]).
 * Fixes a bug that caused empty comments to display in an endpoint's activity log ({pull}111163[#111163]).
-
-[discrete]
-[[known-issue-7.15.0]]
-==== Known issues
-* Case comments containing https://github.github.com/gfm/#what-is-github-flavored-markdown-[GitHub Flavored Markdown (GFM)] will cause migrations to fail when upgrading to {stack} version 7.15.0 or later. To prevent this, remove GFM from the case comment before upgrading ({pull}119509[#119509]).

--- a/docs/release-notes/7.15.asciidoc
+++ b/docs/release-notes/7.15.asciidoc
@@ -35,11 +35,6 @@
 * Case comments containing https://github.github.com/gfm/#what-is-github-flavored-markdown-[GitHub Flavored Markdown (GFM)] will cause migrations to fail when upgrading to {stack} version 7.15.0 or later. To prevent this, remove GFM from the case comment before upgrading ({pull}119509[#119509]).
 
 [discrete]
-[[known-issue-7.15.0]]
-==== Known issues
-* Case comments containing https://github.github.com/gfm/#what-is-github-flavored-markdown-[GitHub Flavored Markdown (GFM)] will cause migrations to fail when upgrading to {stack} version 7.15.0 or later. To prevent this, remove GFM from the case comment before upgrading ({pull}119509[#119509]).
-
-[discrete]
 [[breaking-changes-7.15.0]]
 ==== Breaking changes
 * After upgrading to {stack} version 7.15.x from release versions 7.12.0 through 7.14.2, you need to migrate detection alerts enriched with threat intelligence data to ensure threat intelligence properly displays in {elastic-sec}. For more information, refer to instructions for <<post-upgrade-req-cti-alerts, migrating detection alerts enriched with threat intelligence data>> ({pull}1102[#1102]).

--- a/docs/release-notes/7.15.asciidoc
+++ b/docs/release-notes/7.15.asciidoc
@@ -8,7 +8,7 @@
 [discrete]
 [[bug-fixes-7.15.2]]
 ==== Bug fixes and enhancements
-* The Analyze event option has been moved from the overflow menu to the Actions column. It now only displays events that can be opened in the visual event analyzer ({pull}115478[#115478]).
+* Moves the *Analyze event* option from the overflow menu to the *Actions* column within the Alerts and Events tables. It now only displays events that can be opened in the visual event analyzer ({pull}115478[#115478]).
 * Fixes a table height issue that occurs when the Alerts table only has a few alerts ({pull}114718[#114718]).
 * Fixes a rule execution bug that intermittently caused large status documents to be generated and indexed, which contributed to Kibana upgrades failing ({pull}112257[#112257]).
 * Updates status queries to use the new `kibana.alert.workflow_status` field, and removes `replaceAll` references that caused older browser versions to crash if they didn’t support it ({pull}114481[#114481]).
@@ -21,7 +21,7 @@
 [discrete]
 [[bug-fixes-7.15.1]]
 ==== Bug fixes and enhancements
-* Supports newlines in the JIRA summary field. Newlines are replaced with commas ({pull}113571[#113571]).
+* Supports newlines in the {jira} summary field. Newlines are replaced with commas ({pull}113571[#113571]).
 * Fixes a bug that prevented the Endpoints table from resetting after the KQL query was removed ({pull}112595[#112595]).
 * Fixes a bug that caused threshold and indicator match rules to ignore custom rule filters if a saved query was used in the rule definition ({pull}109253[#109253]).
 * Fixes a bug on the Alerts page that prevented the Trend histogram and Count table from being updated after an alert’s status was changed. With this fix, refreshing the Alerts page is no longer necessary to view the updates ({pull}111042[#111042]).
@@ -29,6 +29,11 @@
 [discrete]
 [[release-notes-7.15.0]]
 === 7.15.0
+
+[discrete]
+[[known-issue-7.15.0]]
+==== Known issues
+* Case comments containing https://github.github.com/gfm/#what-is-github-flavored-markdown-[GitHub Flavored Markdown (GFM)] will cause migrations to fail when upgrading to {stack} version 7.15.0 or later. To prevent this, remove GFM from the case comment before upgrading ({pull}119509[#119509]).
 
 [discrete]
 [[breaking-changes-7.15.0]]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,10 @@
+{
+  "name": "security-docs",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "security-docs"
+    }
+  }
+}


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [DOCS] Move Known issues section to top of page (#1295)