### PR TITLE
[7.17] [DOCS] 7.16.3 Release Notes (#1381)

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.16.3, {elastic-sec} version 7.16.3>>
 * <<release-notes-7.16.2, {elastic-sec} version 7.16.2>>
 * <<release-notes-7.16.1, {elastic-sec} version 7.16.1>>
 * <<release-notes-7.16.0, {elastic-sec} version 7.16.0>>

--- a/docs/release-notes/7.16.asciidoc
+++ b/docs/release-notes/7.16.asciidoc
@@ -1,5 +1,15 @@
-[[release-notes-7.16.0]]
+[[release-notes-header-7.16.0]]
 == 7.16
+
+[discrete]
+[[release-notes-7.16.3]]
+=== 7.16.3
+
+[discrete]
+[[bug-fixes-7.16.3]]
+==== Bug fixes and enhancements
+
+There are no user-facing changes in the 7.16.3 release.
 
 [discrete]
 [[release-notes-7.16.2]]
@@ -21,6 +31,10 @@ There are no user-facing changes in the 7.16.2 release.
 * Fixes a 409 conflict error that occurred when users enabled a rule ({pull}120088[#120088]).
 * Fixes a bug where case comments containing https://github.github.com/gfm/#what-is-github-flavored-markdown-[GitHub Flavored Markdown (GFM)] caused migrations to fail when upgrading to {stack} version 7.15.0 or later ({pull}119995[#119995]).
 * Adds the {fleet} host isolation exceptions summary card in the {fleet} integration *Advance* tab ({pull}119029[#119029]).
+
+[discrete]
+[[release-notes-7.16.0]]
+=== 7.16.0
 
 [discrete]
 [[features-7.16.0]]


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [DOCS] 7.16.3 Release Notes (#1381)