### PR TITLE
[DOCS] Fix links to the Filebeat Google Workspace module

### DIFF
--- a/docs/detections/prebuilt-rules/downloadable-packages/0-13-3/prebuilt-rule-0-13-3-google-workspace-mfa-enforcement-disabled.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-13-3/prebuilt-rule-0-13-3-google-workspace-mfa-enforcement-disabled.asciidoc
@@ -45,7 +45,7 @@ Detects when multi-factor authentication (MFA) enforcement is disabled for Googl
 ==== Investigation guide
 
 
-[source, markdown]
+[source, markdown, subs="attributes"]
 ----------------------------------
 ## Config
 
@@ -58,7 +58,7 @@ The Google Workspace Fleet integration, Filebeat module, or similarly structured
 - By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 - See the following references for further information.
   - https://support.google.com/a/answer/7061566
-  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-gsuite.html
+  - https://www.elastic.co/guide/en/beats/filebeat/{branch}/filebeat-module-google_workspace.html
 ----------------------------------
 
 ==== Rule query

--- a/docs/detections/prebuilt-rules/downloadable-packages/0-13-3/prebuilt-rule-0-13-3-google-workspace-password-policy-modified.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-13-3/prebuilt-rule-0-13-3-google-workspace-password-policy-modified.asciidoc
@@ -43,7 +43,7 @@ Detects when a Google Workspace password policy is modified. An adversary may at
 ==== Investigation guide
 
 
-[source, markdown]
+[source, markdown, subs="attributes"]
 ----------------------------------
 ## Config
 
@@ -56,7 +56,7 @@ The Google Workspace Fleet integration, Filebeat module, or similarly structured
 - By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 - See the following references for further information.
   - https://support.google.com/a/answer/7061566
-  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-gsuite.html
+  - https://www.elastic.co/guide/en/beats/filebeat/{branch}/filebeat-module-google_workspace.html
 ----------------------------------
 
 ==== Rule query

--- a/docs/detections/prebuilt-rules/downloadable-packages/0-13-3/prebuilt-rule-0-13-3-mfa-disabled-for-google-workspace-organization.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-13-3/prebuilt-rule-0-13-3-mfa-disabled-for-google-workspace-organization.asciidoc
@@ -43,7 +43,7 @@ Detects when multi-factor authentication (MFA) is disabled for a Google Workspac
 ==== Investigation guide
 
 
-[source, markdown]
+[source, markdown, subs="attributes"]
 ----------------------------------
 ## Config
 
@@ -56,7 +56,7 @@ The Google Workspace Fleet integration, Filebeat module, or similarly structured
 - By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 - See the following references for further information.
   - https://support.google.com/a/answer/7061566
-  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-gsuite.html
+  - https://www.elastic.co/guide/en/beats/filebeat/{branch}/filebeat-module-google_workspace.html
 ----------------------------------
 
 ==== Rule query

--- a/docs/detections/prebuilt-rules/downloadable-packages/0-14-1/prebuilt-rule-0-14-1-application-added-to-google-workspace-domain.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-14-1/prebuilt-rule-0-14-1-application-added-to-google-workspace-domain.asciidoc
@@ -45,7 +45,7 @@ Detects when a Google marketplace application is added to the Google Workspace d
 ==== Investigation guide
 
 
-[source, markdown]
+[source, markdown, subs="attributes"]
 ----------------------------------
 ## Config
 
@@ -58,7 +58,7 @@ The Google Workspace Fleet integration, Filebeat module, or similarly structured
 - By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 - See the following references for further information:
   - https://support.google.com/a/answer/7061566
-  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-gsuite.html
+  - https://www.elastic.co/guide/en/beats/filebeat/{branch}/filebeat-module-google_workspace.html
 ----------------------------------
 
 ==== Rule query

--- a/docs/detections/prebuilt-rules/downloadable-packages/0-14-1/prebuilt-rule-0-14-1-domain-added-to-google-workspace-trusted-domains.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-14-1/prebuilt-rule-0-14-1-domain-added-to-google-workspace-trusted-domains.asciidoc
@@ -45,7 +45,7 @@ Detects when a domain is added to the list of trusted Google Workspace domains. 
 ==== Investigation guide
 
 
-[source, markdown]
+[source, markdown, subs="attributes"]
 ----------------------------------
 ## Config
 
@@ -58,7 +58,7 @@ The Google Workspace Fleet integration, Filebeat module, or similarly structured
 - By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 - See the following references for further information:
   - https://support.google.com/a/answer/7061566
-  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-gsuite.html
+  - https://www.elastic.co/guide/en/beats/filebeat/{branch}/filebeat-module-google_workspace.html
 ----------------------------------
 
 ==== Rule query

--- a/docs/detections/prebuilt-rules/downloadable-packages/0-14-1/prebuilt-rule-0-14-1-google-workspace-admin-role-assigned-to-a-user.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-14-1/prebuilt-rule-0-14-1-google-workspace-admin-role-assigned-to-a-user.asciidoc
@@ -45,7 +45,7 @@ Detects when an admin role is assigned to a Google Workspace user. An adversary 
 ==== Investigation guide
 
 
-[source, markdown]
+[source, markdown, subs="attributes"]
 ----------------------------------
 ## Config
 
@@ -58,7 +58,7 @@ The Google Workspace Fleet integration, Filebeat module, or similarly structured
 - By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 - See the following references for further information:
   - https://support.google.com/a/answer/7061566
-  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-gsuite.html
+  - https://www.elastic.co/guide/en/beats/filebeat/{branch}/filebeat-module-google_workspace.html
 ----------------------------------
 
 ==== Rule query

--- a/docs/detections/prebuilt-rules/downloadable-packages/0-14-1/prebuilt-rule-0-14-1-google-workspace-admin-role-deletion.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-14-1/prebuilt-rule-0-14-1-google-workspace-admin-role-deletion.asciidoc
@@ -45,7 +45,7 @@ Detects when a custom admin role is deleted. An adversary may delete a custom ad
 ==== Investigation guide
 
 
-[source, markdown]
+[source, markdown, subs="attributes"]
 ----------------------------------
 ## Config
 
@@ -58,7 +58,7 @@ The Google Workspace Fleet integration, Filebeat module, or similarly structured
 - By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 - See the following references for further information:
   - https://support.google.com/a/answer/7061566
-  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-gsuite.html
+  - https://www.elastic.co/guide/en/beats/filebeat/{branch}/filebeat-module-google_workspace.html
 ----------------------------------
 
 ==== Rule query

--- a/docs/detections/prebuilt-rules/downloadable-packages/0-14-1/prebuilt-rule-0-14-1-google-workspace-api-access-granted-via-domain-wide-delegation-of-authority.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-14-1/prebuilt-rule-0-14-1-google-workspace-api-access-granted-via-domain-wide-delegation-of-authority.asciidoc
@@ -45,7 +45,7 @@ Detects when a domain-wide delegation of authority is granted to a service accou
 ==== Investigation guide
 
 
-[source, markdown]
+[source, markdown, subs="attributes"]
 ----------------------------------
 ## Config
 
@@ -58,7 +58,7 @@ The Google Workspace Fleet integration, Filebeat module, or similarly structured
 - By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 - See the following references for further information:
   - https://support.google.com/a/answer/7061566
-  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-gsuite.html
+  - https://www.elastic.co/guide/en/beats/filebeat/{branch}/filebeat-module-google_workspace.html
 ----------------------------------
 
 ==== Rule query

--- a/docs/detections/prebuilt-rules/downloadable-packages/0-14-1/prebuilt-rule-0-14-1-google-workspace-custom-admin-role-created.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-14-1/prebuilt-rule-0-14-1-google-workspace-custom-admin-role-created.asciidoc
@@ -45,7 +45,7 @@ Detects when a custom admin role is created in Google Workspace. An adversary ma
 ==== Investigation guide
 
 
-[source, markdown]
+[source, markdown, subs="attributes"]
 ----------------------------------
 ## Config
 
@@ -58,7 +58,7 @@ The Google Workspace Fleet integration, Filebeat module, or similarly structured
 - By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 - See the following references for further information:
   - https://support.google.com/a/answer/7061566
-  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-gsuite.html
+  - https://www.elastic.co/guide/en/beats/filebeat/{branch}/filebeat-module-google_workspace.html
 ----------------------------------
 
 ==== Rule query

--- a/docs/detections/prebuilt-rules/downloadable-packages/0-14-1/prebuilt-rule-0-14-1-google-workspace-mfa-enforcement-disabled.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-14-1/prebuilt-rule-0-14-1-google-workspace-mfa-enforcement-disabled.asciidoc
@@ -45,7 +45,7 @@ Detects when multi-factor authentication (MFA) enforcement is disabled for Googl
 ==== Investigation guide
 
 
-[source, markdown]
+[source, markdown, subs="attributes"]
 ----------------------------------
 ## Config
 
@@ -58,7 +58,7 @@ The Google Workspace Fleet integration, Filebeat module, or similarly structured
 - By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 - See the following references for further information:
   - https://support.google.com/a/answer/7061566
-  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-gsuite.html
+  - https://www.elastic.co/guide/en/beats/filebeat/{branch}/filebeat-module-google_workspace.html
 ----------------------------------
 
 ==== Rule query

--- a/docs/detections/prebuilt-rules/downloadable-packages/0-14-1/prebuilt-rule-0-14-1-google-workspace-password-policy-modified.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-14-1/prebuilt-rule-0-14-1-google-workspace-password-policy-modified.asciidoc
@@ -43,7 +43,7 @@ Detects when a Google Workspace password policy is modified. An adversary may at
 ==== Investigation guide
 
 
-[source, markdown]
+[source, markdown, subs="attributes"]
 ----------------------------------
 ## Config
 
@@ -56,7 +56,7 @@ The Google Workspace Fleet integration, Filebeat module, or similarly structured
 - By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 - See the following references for further information:
   - https://support.google.com/a/answer/7061566
-  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-gsuite.html
+  - https://www.elastic.co/guide/en/beats/filebeat/{branch}/filebeat-module-google_workspace.html
 ----------------------------------
 
 ==== Rule query

--- a/docs/detections/prebuilt-rules/downloadable-packages/0-14-1/prebuilt-rule-0-14-1-google-workspace-role-modified.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-14-1/prebuilt-rule-0-14-1-google-workspace-role-modified.asciidoc
@@ -45,7 +45,7 @@ Detects when a custom admin role or its permissions are modified. An adversary m
 ==== Investigation guide
 
 
-[source, markdown]
+[source, markdown, subs="attributes"]
 ----------------------------------
 ## Config
 
@@ -58,7 +58,7 @@ The Google Workspace Fleet integration, Filebeat module, or similarly structured
 - By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 - See the following references for further information:
   - https://support.google.com/a/answer/7061566
-  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-gsuite.html
+  - https://www.elastic.co/guide/en/beats/filebeat/{branch}/filebeat-module-google_workspace.html
 ----------------------------------
 
 ==== Rule query

--- a/docs/detections/prebuilt-rules/downloadable-packages/0-14-1/prebuilt-rule-0-14-1-mfa-disabled-for-google-workspace-organization.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-14-1/prebuilt-rule-0-14-1-mfa-disabled-for-google-workspace-organization.asciidoc
@@ -43,7 +43,7 @@ Detects when multi-factor authentication (MFA) is disabled for a Google Workspac
 ==== Investigation guide
 
 
-[source, markdown]
+[source, markdown, subs="attributes"]
 ----------------------------------
 ## Config
 
@@ -56,7 +56,7 @@ The Google Workspace Fleet integration, Filebeat module, or similarly structured
 - By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 - See the following references for further information:
   - https://support.google.com/a/answer/7061566
-  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-gsuite.html
+  - https://www.elastic.co/guide/en/beats/filebeat/{branch}/filebeat-module-google_workspace.html
 ----------------------------------
 
 ==== Rule query

--- a/docs/detections/prebuilt-rules/rule-details/application-added-to-google-workspace-domain.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/application-added-to-google-workspace-domain.asciidoc
@@ -50,7 +50,7 @@ Applications can be added to a Google Workspace domain by system administrators.
 ==== Investigation guide
 
 
-[source,markdown]
+[source, markdown, subs="attributes"]
 ----------------------------------
 ## Config
 
@@ -63,7 +63,7 @@ The Google Workspace Fleet integration, Filebeat module, or similarly structured
 - By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 - See the following references for further information:
   - https://support.google.com/a/answer/7061566
-  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-gsuite.html
+  - https://www.elastic.co/guide/en/beats/filebeat/{branch}/filebeat-module-google_workspace.html
 ----------------------------------
 
 

--- a/docs/detections/prebuilt-rules/rule-details/domain-added-to-google-workspace-trusted-domains.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/domain-added-to-google-workspace-trusted-domains.asciidoc
@@ -50,7 +50,7 @@ Trusted domains may be added by system administrators. Verify that the configura
 ==== Investigation guide
 
 
-[source,markdown]
+[source, markdown, subs="attributes"]
 ----------------------------------
 ## Config
 
@@ -63,7 +63,7 @@ The Google Workspace Fleet integration, Filebeat module, or similarly structured
 - By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 - See the following references for further information:
   - https://support.google.com/a/answer/7061566
-  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-gsuite.html
+  - https://www.elastic.co/guide/en/beats/filebeat/{branch}/filebeat-module-google_workspace.html
 ----------------------------------
 
 

--- a/docs/detections/prebuilt-rules/rule-details/google-workspace-admin-role-assigned-to-a-user.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/google-workspace-admin-role-assigned-to-a-user.asciidoc
@@ -50,7 +50,7 @@ Google Workspace admin role assignments may be modified by system administrators
 ==== Investigation guide
 
 
-[source,markdown]
+[source, markdown, subs="attributes"]
 ----------------------------------
 ## Config
 
@@ -63,7 +63,7 @@ The Google Workspace Fleet integration, Filebeat module, or similarly structured
 - By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 - See the following references for further information:
   - https://support.google.com/a/answer/7061566
-  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-gsuite.html
+  - https://www.elastic.co/guide/en/beats/filebeat/{branch}/filebeat-module-google_workspace.html
 ----------------------------------
 
 

--- a/docs/detections/prebuilt-rules/rule-details/google-workspace-admin-role-deletion.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/google-workspace-admin-role-deletion.asciidoc
@@ -50,7 +50,7 @@ Google Workspace admin roles may be deleted by system administrators. Verify tha
 ==== Investigation guide
 
 
-[source,markdown]
+[source, markdown, subs="attributes"]
 ----------------------------------
 ## Config
 
@@ -63,7 +63,7 @@ The Google Workspace Fleet integration, Filebeat module, or similarly structured
 - By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 - See the following references for further information:
   - https://support.google.com/a/answer/7061566
-  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-gsuite.html
+  - https://www.elastic.co/guide/en/beats/filebeat/{branch}/filebeat-module-google_workspace.html
 ----------------------------------
 
 

--- a/docs/detections/prebuilt-rules/rule-details/google-workspace-api-access-granted-via-domain-wide-delegation-of-authority.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/google-workspace-api-access-granted-via-domain-wide-delegation-of-authority.asciidoc
@@ -50,7 +50,7 @@ Domain-wide delegation of authority may be granted to service accounts by system
 ==== Investigation guide
 
 
-[source,markdown]
+[source, markdown, subs="attributes"]
 ----------------------------------
 ## Config
 
@@ -63,7 +63,7 @@ The Google Workspace Fleet integration, Filebeat module, or similarly structured
 - By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 - See the following references for further information:
   - https://support.google.com/a/answer/7061566
-  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-gsuite.html
+  - https://www.elastic.co/guide/en/beats/filebeat/{branch}/filebeat-module-google_workspace.html
 ----------------------------------
 
 

--- a/docs/detections/prebuilt-rules/rule-details/google-workspace-custom-admin-role-created.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/google-workspace-custom-admin-role-created.asciidoc
@@ -50,7 +50,7 @@ Custom Google Workspace admin roles may be created by system administrators. Ver
 ==== Investigation guide
 
 
-[source,markdown]
+[source, markdown, subs="attributes"]
 ----------------------------------
 ## Config
 
@@ -63,7 +63,7 @@ The Google Workspace Fleet integration, Filebeat module, or similarly structured
 - By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 - See the following references for further information:
   - https://support.google.com/a/answer/7061566
-  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-gsuite.html
+  - https://www.elastic.co/guide/en/beats/filebeat/{branch}/filebeat-module-google_workspace.html
 ----------------------------------
 
 

--- a/docs/detections/prebuilt-rules/rule-details/google-workspace-mfa-enforcement-disabled.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/google-workspace-mfa-enforcement-disabled.asciidoc
@@ -50,7 +50,7 @@ MFA policies may be modified by system administrators. Verify that the configura
 ==== Investigation guide
 
 
-[source,markdown]
+[source, markdown, subs="attributes"]
 ----------------------------------
 ## Config
 
@@ -63,7 +63,7 @@ The Google Workspace Fleet integration, Filebeat module, or similarly structured
 - By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 - See the following references for further information:
   - https://support.google.com/a/answer/7061566
-  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-gsuite.html
+  - https://www.elastic.co/guide/en/beats/filebeat/{branch}/filebeat-module-google_workspace.html
 ----------------------------------
 
 

--- a/docs/detections/prebuilt-rules/rule-details/google-workspace-password-policy-modified.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/google-workspace-password-policy-modified.asciidoc
@@ -46,7 +46,7 @@ Password policies may be modified by system administrators. Verify that the conf
 ==== Investigation guide
 
 
-[source,markdown]
+[source, markdown, subs="attributes"]
 ----------------------------------
 ## Config
 
@@ -59,7 +59,7 @@ The Google Workspace Fleet integration, Filebeat module, or similarly structured
 - By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 - See the following references for further information:
   - https://support.google.com/a/answer/7061566
-  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-gsuite.html
+  - https://www.elastic.co/guide/en/beats/filebeat/{branch}/filebeat-module-google_workspace.html
 ----------------------------------
 
 

--- a/docs/detections/prebuilt-rules/rule-details/google-workspace-role-modified.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/google-workspace-role-modified.asciidoc
@@ -50,7 +50,7 @@ Google Workspace admin roles may be modified by system administrators. Verify th
 ==== Investigation guide
 
 
-[source,markdown]
+[source, markdown, subs="attributes"]
 ----------------------------------
 ## Config
 
@@ -63,7 +63,7 @@ The Google Workspace Fleet integration, Filebeat module, or similarly structured
 - By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 - See the following references for further information:
   - https://support.google.com/a/answer/7061566
-  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-gsuite.html
+  - https://www.elastic.co/guide/en/beats/filebeat/{branch}/filebeat-module-google_workspace.html
 ----------------------------------
 
 

--- a/docs/detections/prebuilt-rules/rule-details/mfa-disabled-for-google-workspace-organization.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/mfa-disabled-for-google-workspace-organization.asciidoc
@@ -46,7 +46,7 @@ MFA settings may be modified by system administrators. Verify that the configura
 ==== Investigation guide
 
 
-[source,markdown]
+[source, markdown, subs="attributes"]
 ----------------------------------
 ## Config
 
@@ -59,7 +59,7 @@ The Google Workspace Fleet integration, Filebeat module, or similarly structured
 - By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 - See the following references for further information:
   - https://support.google.com/a/answer/7061566
-  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-gsuite.html
+  - https://www.elastic.co/guide/en/beats/filebeat/{branch}/filebeat-module-google_workspace.html
 ----------------------------------
 
 


### PR DESCRIPTION
Updates links to the [Filebeat Google Workspace module](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-gsuite.html) so they don't break when we change the current Stack version to 8.0.

Relates to https://github.com/elastic/docs/pull/2312

### Previews
https://security-docs_1441.docs-preview.app.elstc.co/diff