### PR TITLE
[DOCS] Update alert index references across repository

### DIFF
--- a/docs/detections/building-block-rule.asciidoc
+++ b/docs/detections/building-block-rule.asciidoc
@@ -6,7 +6,7 @@ Create building block rules when you do not want to see their generated alerts
 in the UI. This is useful when you want:
 
 * A record of low-risk alerts without producing noise in the Alerts table.
-* Rules that execute on the alert indices (`.siem-signals-<kibana space>-*`).
+* Rules that execute on the alert indices (`.alerts-security.alerts-<kibana space>-*`).
 You can then use building block rules to create hidden alerts that act as a
 basis for an 'ordinary' rule to generate visible alerts.
 

--- a/docs/getting-started/security-spaces.asciidoc
+++ b/docs/getting-started/security-spaces.asciidoc
@@ -22,10 +22,10 @@ the `SOC_dev` space, and they will run independently of those in the
 [NOTE]
 ===== 
 By default, alerts created by detection rules are stored in {es} indices
-under the `.siem-signals-<Kibana-space>-*` index pattern, and they may be
+under the `.alerts-security.alerts-<Kibana-space>-*` index pattern, and they may be
 accessed by any user with role privileges to access those
 {es} indices. In our example above, any user with {es} privileges to access
-`.siem-signals-SOC_prod-*` will be able to view `SOC_prod` alerts from
+`.alerts-security.alerts-SOC_prod-*` will be able to view `SOC_prod` alerts from
 within {es} and other {kib} apps such as Discover and Lens. 
 
 To ensure that detection alert data remains private to the space in which

--- a/docs/post-upgrade/post-upgrade-req-cti-alerts.asciidoc
+++ b/docs/post-upgrade/post-upgrade-req-cti-alerts.asciidoc
@@ -8,7 +8,7 @@ To migrate detection alerts:
 
 . Ensure that all <<deactivate-detect-rules, detection rules are deactivated>> prior to upgrading your {stack}.
 . Upgrade Kibana. See {kibana-ref}/upgrade.html[Upgrade {kib}] for more information.
-. Visit the Overview or Alerts page in {elastic-sec} to update the `.siem-signals*` index.
+. Visit the Overview or Alerts page in {elastic-sec} to update the detection alert indices.
 . Migrate old alerts using the <<signals-migration-api, Detection Alerts Migration API>>.
 . <<reactivate-detect-rules, Reactivate all detection rules>>.
 

--- a/docs/post-upgrade/template-script.asciidoc
+++ b/docs/post-upgrade/template-script.asciidoc
@@ -2,10 +2,12 @@
 == Index template script
 
 This code creates a new index template for temporarily storing existing
-detection alerts when you update `.siem-signals-*` index mappings. You
+detection alerts when you update system index mappings for detection alert indices. You
 need to update the index mappings to visualize process relationships after
 upgrading to {stack} release 7.9.0 or 7.9.1 from a previous minor release
 (7.8.x, 7.7.x, and so on).
+
+NOTE: As of {stack} version 8.0.0 and newer, the system index for detection alerts has been renamed from `.siem-signals-*` to `.alerts-security.alerts-*`. 
 
 TIP: <<bottom, Click here>> to scroll to the bottom of the page and use the
 builtin functions to paste the code into the {kib} dev console. You can click on

--- a/docs/post-upgrade/template-script.asciidoc
+++ b/docs/post-upgrade/template-script.asciidoc
@@ -2,15 +2,15 @@
 == Index template script
 
 This code creates a new index template for temporarily storing existing
-detection alerts when you update system index mappings for detection alert indices. You
+detection alerts when you update the index mappings for detection alert indices. You
 need to update the index mappings to visualize process relationships after
 upgrading to {stack} release 7.9.0 or 7.9.1 from a previous minor release
 (7.8.x, 7.7.x, and so on).
 
-NOTE: As of {stack} version 8.0.0 and newer, the system index for detection alerts has been renamed from `.siem-signals-*` to `.alerts-security.alerts-*`. 
+IMPORTANT: As of {stack} version 8.0.0 and newer, the system index for detection alerts has been renamed from `.siem-signals-*` to `.alerts-security.alerts-*`. 
 
 TIP: <<bottom, Click here>> to scroll to the bottom of the page and use the
-builtin functions to paste the code into the {kib} dev console. You can click on
+built-in functions to paste the code into the {kib} dev console. You can click on
 the settings icon to update {kib}'s URL.
 
 


### PR DESCRIPTION
The indices and aliases used for detection alerts has changed in 8.0, from `.siem-signals-<space id>` to `.alerts-security.alerts-<space id>`. We need to update any references to the old index patterns in the 8.0 docs.

* Resolves #1498.
