### PR TITLE
[DOCS] Add snippet tags to 8.0 release notes file

### DIFF
--- a/docs/release-notes/8.0.asciidoc
+++ b/docs/release-notes/8.0.asciidoc
@@ -67,6 +67,7 @@ NOTE: If new alerts are generated in an upgraded environment without legacy aler
 [discrete]
 [[breaking-changes-8.0.0]]
 ==== Breaking Changes
+// tag::breaking-changes[]
 * Removes the trusted application API. The trusted application interface retains current functionality, but now uses the exception list API ({pull}120134[#120134]).
 * Removes the list endpoint metadata API ({pull}119401[#119401]).
 * Lets you grant privileges for cases separately from {elastic-sec} privileges ({pull}113573[#113573], {pull}112980[#112980]). As a result of this change, you must update case privileges for existing roles _before_ upgrading to {stack} 8.0.0. Follow these steps:
@@ -74,6 +75,7 @@ NOTE: If new alerts are generated in an upgraded environment without legacy aler
 . From the Upgrade Assistant page, review the Kibana deprecation warnings. A message prompts you to update role privileges because of changes to the {elastic-sec} Cases feature.
 . Click the message to open it, then click *Quick resolve*.
 . Refresh the page to verify the deprecation was resolved, then return to the guided steps on the Upgrade Assistant page.
+// end::breaking-changes[]
 
 [discrete]
 [[new-features-8.0.0]]


### PR DESCRIPTION
Adds tags to demarcate the breaking changes snippet that we want to include in the Elastic Installation and Upgrade Guide, as part of https://github.com/elastic/stack-docs/pull/2039. 

Until this PR is merged, https://github.com/elastic/stack-docs/pull/2039 will have a broken reference to the content in `security-docs`.
