### PR TITLE
[DOCS] Add pull attribute definition to breaking changes snippet

### DIFF
--- a/docs/release-notes/8.0.asciidoc
+++ b/docs/release-notes/8.0.asciidoc
@@ -68,6 +68,7 @@ NOTE: If new alerts are generated in an upgraded environment without legacy aler
 [[breaking-changes-8.0.0]]
 ==== Breaking Changes
 // tag::breaking-changes[]
+:pull: https://github.com/elastic/kibana/pull/
 * Removes the trusted application API. The trusted application interface retains current functionality, but now uses the exception list API ({pull}120134[#120134]).
 * Removes the list endpoint metadata API ({pull}119401[#119401]).
 * Lets you grant privileges for cases separately from {elastic-sec} privileges ({pull}113573[#113573], {pull}112980[#112980]). As a result of this change, you must update case privileges for existing roles _before_ upgrading to {stack} 8.0.0. Follow these steps:


### PR DESCRIPTION
Adds definition of the `pull` attribute to the breaking changes snippet that is included in the Elastic Installation and Upgrade Guide, as part of https://github.com/elastic/stack-docs/pull/2039.

Until this PR is merged, the attribute won't resolve within the stack-docs page.