### PR TITLE
[DOCS] Add snippet tags to What's New topic

### DIFF
--- a/docs/whats-new.asciidoc
+++ b/docs/whats-new.asciidoc
@@ -9,6 +9,8 @@ For detailed information about this release, check out the <<release-notes, Rele
 Other versions: {security-guide-all}/7.17/whats-new.html[7.17] | {security-guide-all}/7.16/whats-new.html[7.16] | {security-guide-all}/7.15/whats-new.html[7.15] | {security-guide-all}/7.14/whats-new.html[7.14] | {security-guide-all}/7.13/whats-new.html[7.13] | {security-guide-all}/7.12/whats-new.html[7.12] | {security-guide-all}/7.11/whats-new.html[7.11] | {security-guide-all}/7.10/whats-new.html[7.10] |
 {security-guide-all}/7.9/whats-new.html[7.9]
 
+// tag::notable-highlights[]
+
 [discrete]
 [[name-changes-8.0]]
 == Terminology changes
@@ -67,3 +69,5 @@ The rule <<import-export-rules-ui, export and import tool>> now includes any exc
 --
 image::whats-new/images/8.0/threat-intel.png[]
 --
+
+// end::notable-highlights[]


### PR DESCRIPTION
Adds tags to demarcate the highlights snippet that we want to include in the Elastic Installation and Upgrade Guide, as part of https://github.com/elastic/security-docs/issues/1571.