### PR TITLE
[8.0] Add snippet tags to What's New topic (#1575)

### DIFF
--- a/docs/whats-new.asciidoc
+++ b/docs/whats-new.asciidoc
@@ -9,6 +9,7 @@ For detailed information about this release, check out the <<release-notes, Rele
 Other versions: {security-guide-all}/7.17/whats-new.html[7.17] | {security-guide-all}/7.16/whats-new.html[7.16] | {security-guide-all}/7.15/whats-new.html[7.15] | {security-guide-all}/7.14/whats-new.html[7.14] | {security-guide-all}/7.13/whats-new.html[7.13] | {security-guide-all}/7.12/whats-new.html[7.12] | {security-guide-all}/7.11/whats-new.html[7.11] | {security-guide-all}/7.10/whats-new.html[7.10] |
 {security-guide-all}/7.9/whats-new.html[7.9]
 
+// NOTE: The notable-highlights tagged regions are re-used in the Installation and Upgrade Guide. Full URL links are required in tagged regions.
 // tag::notable-highlights[]
 
 [discrete]

--- a/docs/whats-new.asciidoc
+++ b/docs/whats-new.asciidoc
@@ -9,6 +9,8 @@ For detailed information about this release, check out the <<release-notes, Rele
 Other versions: {security-guide-all}/7.17/whats-new.html[7.17] | {security-guide-all}/7.16/whats-new.html[7.16] | {security-guide-all}/7.15/whats-new.html[7.15] | {security-guide-all}/7.14/whats-new.html[7.14] | {security-guide-all}/7.13/whats-new.html[7.13] | {security-guide-all}/7.12/whats-new.html[7.12] | {security-guide-all}/7.11/whats-new.html[7.11] | {security-guide-all}/7.10/whats-new.html[7.10] |
 {security-guide-all}/7.9/whats-new.html[7.9]
 
+// tag::notable-highlights[]
+
 [discrete]
 [[name-changes-8.0]]
 == Terminology changes
@@ -67,3 +69,5 @@ The rule <<import-export-rules-ui, export and import tool>> now includes any exc
 --
 image::whats-new/images/8.0/threat-intel.png[]
 --
+
+// end::notable-highlights[]


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Add snippet tags to What's New topic (#1575)