### PR TITLE
[8.1] Add snippet tags to What's New topic (#1575)

### DIFF
--- a/docs/whats-new.asciidoc
+++ b/docs/whats-new.asciidoc
@@ -10,6 +10,9 @@ For detailed information about this release, see the <<release-notes, Release no
 [[sec-7.14-release]]
 == 7.14 release
 
+// NOTE: The notable-highlights tagged regions are re-used in the Installation and Upgrade Guide. Full URL links are required in tagged regions.
+// tag::notable-highlights[]
+
 [discrete]
 [[sec-nav-changes-7.14]]
 === Navigation changes
@@ -48,6 +51,8 @@ IMPORTANT: The following features are experimental and may be changed or removed
 * Host Risk Score: A framework to figure out the most suspicious hosts in your environment, based on their alert activity.
 For more information, click https://github.com/elastic/detection-rules/blob/main/docs/experimental-machine-learning/host-risk-score.md[here].
 * A new experimental https://github.com/elastic/detection-rules/tree/main/docs/experimental-machine-learning[URL Spoofing] model framework allows you to proactively detect and monitor spoofing activity by raising an alert whenever you interact with a predicted malicious URL in your environment. Requires Platinum or higher https://www.elastic.co/subscriptions[subscription].
+
+// end::notable-highlights[]
 
 [discrete]
 [[sec-7.13-release]]


### PR DESCRIPTION
Backports the following commits to 8.1:
 - Add snippet tags to What's New topic (#1575)