### PR TITLE
[8.0] [DOCS] Change links to full URLs on What's New page (#1578)

### DIFF
--- a/docs/whats-new.asciidoc
+++ b/docs/whats-new.asciidoc
@@ -34,7 +34,7 @@ To update these defaults, go to *Stack Management > Advanced Settings > Security
 image::whats-new/images/8.0/data-view.png[]
 --
 
-NOTE: To make the *Data view* option appear in an environment with legacy alerts, a user with elevated role privileges must visit the {es-sec-app}, open a page that displays alert data (such as the Overview page), then refresh the page. The user's role privileges must allow them to enable the detections feature in a {kib} space. Refer to <<enable-detections-ui, Enable and access detections>> for more information.
+NOTE: To make the *Data view* option appear in an environment with legacy alerts, a user with elevated role privileges must visit the {es-sec-app}, open a page that displays alert data (such as the Overview page), then refresh the page. The user's role privileges must allow them to enable the detections feature in a {kib} space. Refer to {security-guide}/detections-permissions-section.html#enable-detections-ui[Enable and access detections] for more information.
 
 [discrete]
 [[index-updates-8.0]]
@@ -42,10 +42,10 @@ NOTE: To make the *Data view* option appear in an environment with legacy alerts
 
 *Index changes*
 
-* The system index for detection alerts has been renamed from `.siem-signals-<space-id>` to `.alerts-security.alerts-<space-id>`. Users who use the detections feature require new privileges for these indices. Users also need new privileges to <<alerts-ui-manage, view alerts>> and <<preview-rules, preview rules>> . Refer to <<detections-permissions-section>> for a breakdown of what privileges are required to access specific detection features.
-* The schema used for alert documents in {elastic-sec} has changed. Users that access documents in the `.siem-signals-<space-id>` indices, such as customer dashboards, will need to update their API queries and scripts to operate correctly on the new 8.x alert documents. Refer to the new <<alert-schema, alert schema>> to view legacy 7.x field names and the updated field names for 8.x, and review  <<query-alert-indices, best practices on how to query alert indices>>.
-* You can now grant feature privileges for Cases separately from privileges for {elastic-sec}. Refer to <<case-permissions>> for more information.
-* New Full Disk Access approval is needed when deploying {elastic-endpoint} on macOS. Refer to <<deploy-elastic-endpoint>> to view installation requirements.
+* The system index for detection alerts has been renamed from `.siem-signals-<space-id>` to `.alerts-security.alerts-<space-id>`. Users who use the detections feature require new privileges for these indices. Users also need new privileges to {security-guide}/alerts-ui-manage.html[view alerts] and {security-guide}/rules-ui-create.html#preview-rules[preview rules]. Refer to {security-guide}/detections-permissions-section.html[Detections prerequisites and requirements] for a breakdown of what privileges are required to access specific detection features.
+* The schema used for alert documents in {elastic-sec} has changed. Users that access documents in the `.siem-signals-<space-id>` indices, such as customer dashboards, will need to update their API queries and scripts to operate correctly on the new 8.x alert documents. Refer to the new {security-guide}/alert-schema.html[alert schema] to view legacy 7.x field names and the updated field names for 8.x, and review {security-guide}/query-alert-indices.html[best practices on how to query alert indices].
+* You can now grant feature privileges for Cases separately from privileges for {elastic-sec}. Refer to {security-guide}/case-permissions.html[Cases prerequisites] for more information.
+* New Full Disk Access approval is needed when deploying {elastic-endpoint} on macOS. Refer to {security-guide}/deploy-elastic-endpoint.html[Install Elastic Endpoint manually] to view installation requirements.
 
 
 
@@ -55,17 +55,17 @@ NOTE: To make the *Data view* option appear in an environment with legacy alerts
 
 *Rules page includes enhanced tools and a simplified UI*
 
-The Rules page has been enhanced to be more compact and user-friendly so you can analyze information quickly. In addition, on the <<alerts-ui-monitor, *Rule Monitoring*>> tab, you can now perform the same actions that are available on the main *Rules* tab, such as modifying or deleting rules, activating or deactivating rules, exporting or importing rules, and duplicating prebuilt rules.
+The Rules page has been enhanced to be more compact and user-friendly so you can analyze information quickly. In addition, on the {security-guide}/alerts-ui-monitor.html[*Rule Monitoring*] tab, you can now perform the same actions that are available on the main *Rules* tab, such as modifying or deleting rules, activating or deactivating rules, exporting or importing rules, and duplicating prebuilt rules.
 --
 image::whats-new/images/8.0/rule-monitor-table.png[]
 --
-The rule <<import-export-rules-ui, export and import tool>> now includes any exception lists associated with the rules being exported or imported.
+The rule {security-guide}/rules-ui-management.html#import-export-rules-ui[export and import tool] now includes any exception lists associated with the rules being exported or imported.
 
 *Threat intelligence enhancements*
 
 * An explicit default value (`threat.indicator`) has been added to the threat indicator path setting that indicator match rules use when searching indicator indices for threat intelligence data. If a value for the indicator path setting has not been defined before upgrading to 8.0, migrated indicator match rules are given a default value of `threatintel.indicator`. This allows migrated rules to continue using indicator data from {filebeat} 7.x indices.
-* Support for the `threat.feed.name` field has been added in the <<view-alert-details, Alert details>> flyout and Timeline view.
-* You can now use {agent} integrations with the Threat Intelligence view to ingest threat intelligence data into your environment. The Threat Intelligence view also supports {filebeat} Threat intel module integrations and custom integrations. Refer to <<es-threat-intel-integrations>> for setup instructions.
+* Support for the `threat.feed.name` field has been added in the {security-guide}/alerts-ui-manage.html#view-alert-details[Alert details] flyout and Timeline view.
+* You can now use {agent} integrations with the Threat Intelligence view to ingest threat intelligence data into your environment. The Threat Intelligence view also supports {filebeat} Threat intel module integrations and custom integrations. Refer to {security-guide}/es-threat-intel-integrations.html[Enable threat intelligence integrations] for setup instructions.
 +
 --
 image::whats-new/images/8.0/threat-intel.png[]


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Change links to full URLs on What's New page (#1578)