### PR TITLE
[DOCS] 7.17.1 Release Notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.17.1, {elastic-sec} version 7.17.1>>
 * <<release-notes-7.17.0, {elastic-sec} version 7.17.0>>
 * <<release-notes-7.16.3, {elastic-sec} version 7.16.3>>
 * <<release-notes-7.16.2, {elastic-sec} version 7.16.2>>

--- a/docs/release-notes/7.17.asciidoc
+++ b/docs/release-notes/7.17.asciidoc
@@ -2,6 +2,16 @@
 == 7.17
 
 [discrete]
+[[release-notes-7.17.1]]
+=== 7.17.1
+
+[discrete]
+[[bug-fixes-7.17.1]]
+==== Bug fixes and enhancements
+
+There are no user-facing changes in the 7.17.1 release.
+
+[discrete]
 [[release-notes-7.17.0]]
 === 7.17.0
 


### PR DESCRIPTION
Addresses https://github.com/elastic/security-docs/issues/1611.

Previews:

- [Updated index page](https://security-docs_1612.docs-preview.app.elstc.co/guide/en/security/7.17/release-notes.html)
- [Release notes](https://security-docs_1612.docs-preview.app.elstc.co/guide/en/security/7.17/release-notes-header-7.17.0.html)