### PR TITLE
Correct minor typo in advanced-setting.asciidoc (#1735)

### DIFF
--- a/docs/getting-started/advanced-setting.asciidoc
+++ b/docs/getting-started/advanced-setting.asciidoc
@@ -37,7 +37,7 @@ image::images/advanced-settings.png[]
 == Update default Elastic Security indices
 
 The `securitySolution:defaultIndex` field defines which {es} indices the
-{es-sec-app} uses to collects data. By default, these index patterns are used to
+{es-sec-app} uses to collect data. By default, these index patterns are used to
 match {es} indices:
 
 * `apm-*-transaction*`


### PR DESCRIPTION
Backports #1735 to `8.0`. 