### PR TITLE
[DOCS] Retroactive Endpoint 8.1.1 release notes

### DIFF
--- a/docs/release-notes/8.1.asciidoc
+++ b/docs/release-notes/8.1.asciidoc
@@ -8,6 +8,7 @@
 [discrete]
 [[bug-fixes-8.1.1]]
 ==== Bug fixes and enhancements
+* Fixes an Endpoint Security integration bug that, in some circumstances, would prevent benign files from being deleted on Windows.
 * Adds a notification to the **Exception lists** page that informs users if they are lacking certain role privileges ({pull}126874[#126874]).
 * Turns off the **Upload value lists** option on the **Rules** page if users have `Read` Security privileges only ({pull}126829[#126829]).
 * Removes the option to select rules in the All Rules table if users have `Read` Security privileges only ({pull}126827[#126827]).

--- a/docs/release-notes/8.1.asciidoc
+++ b/docs/release-notes/8.1.asciidoc
@@ -8,7 +8,7 @@
 [discrete]
 [[bug-fixes-8.1.1]]
 ==== Bug fixes and enhancements
-* Fixes an Endpoint Security integration bug that prevented benign Windows files from being deleted during certain circumstances.
+* Fixes an {endpoint-sec} integration bug that prevented benign Windows files from being deleted during certain circumstances.
 * Adds a notification to the **Exception lists** page that informs users if they are lacking certain role privileges ({pull}126874[#126874]).
 * Turns off the **Upload value lists** option on the **Rules** page if users have `Read` Security privileges only ({pull}126829[#126829]).
 * Removes the option to select rules in the All Rules table if users have `Read` Security privileges only ({pull}126827[#126827]).

--- a/docs/release-notes/8.1.asciidoc
+++ b/docs/release-notes/8.1.asciidoc
@@ -8,7 +8,7 @@
 [discrete]
 [[bug-fixes-8.1.1]]
 ==== Bug fixes and enhancements
-* Fixes an Endpoint Security integration bug that, in some circumstances, would prevent benign files from being deleted on Windows.
+* Fixes an Endpoint Security integration bug that prevented benign Windows files from being deleted during certain circumstances.
 * Adds a notification to the **Exception lists** page that informs users if they are lacking certain role privileges ({pull}126874[#126874]).
 * Turns off the **Upload value lists** option on the **Rules** page if users have `Read` Security privileges only ({pull}126829[#126829]).
 * Removes the option to select rules in the All Rules table if users have `Read` Security privileges only ({pull}126827[#126827]).

--- a/docs/release-notes/8.1.asciidoc
+++ b/docs/release-notes/8.1.asciidoc
@@ -8,7 +8,7 @@
 [discrete]
 [[bug-fixes-8.1.1]]
 ==== Bug fixes and enhancements
-* Fixes an {endpoint-sec} integration bug that prevented benign Windows files from being deleted during certain circumstances.
+* Fixes an {endpoint-sec} integration bug that prevented benign Windows files from being deleted under certain circumstances.
 * Adds a notification to the **Exception lists** page that informs users if they are lacking certain role privileges ({pull}126874[#126874]).
 * Turns off the **Upload value lists** option on the **Rules** page if users have `Read` Security privileges only ({pull}126829[#126829]).
 * Removes the option to select rules in the All Rules table if users have `Read` Security privileges only ({pull}126827[#126827]).


### PR DESCRIPTION
Fixes https://github.com/elastic/security-docs/issues/1760.

Preview [here](https://security-docs_1763.docs-preview.app.elstc.co/guide/en/security/master/release-notes-header-8.1.0.html#release-notes-8.1.1). 