### PR TITLE
[BUG] Missing breaking change notice for preconfigured connectors in cases

### DIFF
--- a/docs/release-notes/7.17.asciidoc
+++ b/docs/release-notes/7.17.asciidoc
@@ -28,7 +28,7 @@
 [discrete]
 [[breaking-changes-7.17.0]]
 ==== Breaking changes
-* {kibana-ref}/pre-configured-connectors.html[Preconfigured connectors] cannot be used with cases.
+* {kibana-ref}/pre-configured-connectors.html[Preconfigured connectors] cannot be used with cases ({pull}120686[#120686]).
 
 [discrete]
 [[bug-fixes-7.17.0]]

--- a/docs/release-notes/7.17.asciidoc
+++ b/docs/release-notes/7.17.asciidoc
@@ -26,6 +26,11 @@
 === 7.17.0
 
 [discrete]
+[[breaking-changes-7.17.0]]
+==== Breaking changes
+* {kibana-ref}/pre-configured-connectors.html[Preconfigured connectors] cannot be used with cases.
+
+[discrete]
 [[bug-fixes-7.17.0]]
 ==== Bug fixes and enhancements
 * Adds detailed telemetry statistics for legacy and regular notifications ({pull}123332[#123332], {pull}122472[#122472]).


### PR DESCRIPTION
Fixes https://github.com/elastic/security-docs/issues/1801.

Preview [here](https://security-docs_1810.docs-preview.app.elstc.co/guide/en/security/7.17/release-notes-header-7.17.0.html#breaking-changes-7.17.0). (Documented PR #120686 as a breaking change in 7.17.0)