### PR TITLE
[8.2][DOCS] Add warning messages to deprecated APIs

### DIFF
--- a/docs/detections/api/rules/rules-api-bulk-actions.asciidoc
+++ b/docs/detections/api/rules/rules-api-bulk-actions.asciidoc
@@ -12,6 +12,8 @@ NOTE: Console supports only {es} APIs and doesn't allow interactions with {kib} 
 [[bulk-actions-rules-api-create]]
 ==== Bulk create
 
+IMPORTANT: This API has been deprecated since version 8.2, and is scheduled for end of life in Q4 2023. Please use the <<bulk-actions-rules-api-action, bulk action API>> instead.
+
 WARNING: This API supports {kibana-ref}/api.html#token-api-authentication[Token-based authentication] only.
 
 Creates new rules.
@@ -95,6 +97,8 @@ generated for all rules that did not include a `rule_id` field.
 [[bulk-actions-rules-api-delete]]
 ==== Bulk delete
 
+IMPORTANT: This API has been deprecated since version 8.2, and is scheduled for end of life in Q4 2023. Please use the <<bulk-actions-rules-api-action, bulk action API>> instead.
+
 Deletes multiple rules.
 
 [discrete]
@@ -140,6 +144,8 @@ A JSON array containing the deleted rules.
 [discrete]
 [[bulk-actions-rules-api-update]]
 ==== Bulk update
+
+IMPORTANT: This API has been deprecated since version 8.2, and is scheduled for end of life in Q4 2023. Please use the <<bulk-actions-rules-api-action, bulk action API>> instead.
 
 WARNING: This API supports {kibana-ref}/api.html#token-api-authentication[Token-based authentication] only.
 


### PR DESCRIPTION
**Resolves https://github.com/elastic/security-docs/issues/1729**

Added warning messages to deprecated Detection APIs