### PR TITLE
[BUG] Fix broken link

### DIFF
--- a/docs/detections/alerts-run-osquery.asciidoc
+++ b/docs/detections/alerts-run-osquery.asciidoc
@@ -28,7 +28,7 @@ NOTE: The host associated with the alert is automatically selected. You can spec
 [role="screenshot"]
 image::images/setup-query.png[width=80%][height=80%][Shows how to set up the query]
 
-. (Optional) Expand the **Advanced** section to view or set {kibana-ref}/osquery.html[mapped ECS fields] included in the results from the live query.
+. (Optional) Expand the **Advanced** section to view or set {kibana-ref}/osquery.html#osquery-map-fields[mapped ECS fields] included in the results from the live query.
 . Click **Submit**.
 
 +

--- a/docs/detections/alerts-run-osquery.asciidoc
+++ b/docs/detections/alerts-run-osquery.asciidoc
@@ -28,7 +28,7 @@ NOTE: The host associated with the alert is automatically selected. You can spec
 [role="screenshot"]
 image::images/setup-query.png[width=80%][height=80%][Shows how to set up the query]
 
-. (Optional) Expand the **Advanced** section to view or set {kibana-ref}/advanced-osquery.html[mapped ECS fields] included in the results from the live query.
+. (Optional) Expand the **Advanced** section to view or set {kibana-ref}/osquery.html[mapped ECS fields] included in the results from the live query.
 . Click **Submit**.
 
 +


### PR DESCRIPTION
The structure of the Osquery section in the Kibana docs has changed with this PR: https://github.com/elastic/kibana/pull/130195. This update fixes the resulting broken link on the new alerts-run-osquery.asciidoc page.