### PR TITLE
[DOCS] Remove procedure for manually enabling event analyzer

### DIFF
--- a/docs/post-upgrade/post-upgrade-intro.asciidoc
+++ b/docs/post-upgrade/post-upgrade-intro.asciidoc
@@ -4,7 +4,6 @@
 
 The following section describes optional procedures to complete after upgrading the {stack}.
 
-include::post-upgrade-req.asciidoc[]
 include::post-upgrade-req-cti-alerts.asciidoc[]
 include::template-script.asciidoc[]
 include::post-upgrade-deprecated-sn-connector.asciidoc[]


### PR DESCRIPTION
Resolves #1512.

Removes outdated topic from the docs. As previously discussed, manually enabling data for the visual event analyzer was a task related to a specific upgrade scenario (from `7.9.x` to <`7.11`), and versions since then have not required a manual procedure. This topic is likely to be confusing to a customer upgrading to more recent version who wouldn't actually need to do anything extra to get event analyzer working.

Preview: [Updated landing page for Post-Upgrade section](https://security-docs_1938.docs-preview.app.elstc.co/guide/en/security/master/post-upgrade-intro.html) (confirm topic removed from navigation TOC on right side)
