### PR TITLE
Add note on detection rule alert telemetry privacy

### DIFF
--- a/docs/getting-started/advanced-setting.asciidoc
+++ b/docs/getting-started/advanced-setting.asciidoc
@@ -76,7 +76,7 @@ IMPORTANT: Threat intelligence indices aren't required to be ECS-compatible for 
 
 Kibana transmits certain information about Elastic Security when users interact with the {security-app}, detailed below. {kib} redacts or obfuscates personal data (IP addresses, host names, usernames, etc.) before transmitting messages to Elastic. Security-specific telemetry events include:
 
-* *{detection-rule} Security alerts:* Information about Elastic authored detection rules using the detection engine. Examples of alert data include Machine Learning job influencers, process names, and cloud audit events.
+* *Detection rule security alerts:* Information about Elastic-authored prebuilt detection rules using the detection engine. Examples of alert data include machine learning job influencers, process names, and cloud audit events.
 * *{elastic-endpoint} Security alerts:* Information about malicious activity detected using {elastic-endpoint} detection engines. Examples of alert data include malicious process names, digital signatures, and file names written by the malicious software. Examples of alert metadata include the time of the alert, the {elastic-endpoint} version and related detection engine versions.
 * *Configuration data for {elastic-endpoint}:* Information about the configuration of {elastic-endpoint} deployments. Examples of configuration data include the Endpoint versions, operating system versions, and performance counters for Endpoint.
 * *Exception list entries for Elastic rules:* Information about exceptions added for Elastic rules. Examples include trusted applications, detection exceptions, and rule exceptions.

--- a/docs/getting-started/advanced-setting.asciidoc
+++ b/docs/getting-started/advanced-setting.asciidoc
@@ -76,6 +76,7 @@ IMPORTANT: Threat intelligence indices aren't required to be ECS-compatible for 
 
 Kibana transmits certain information about Elastic Security when users interact with the {security-app}, detailed below. {kib} redacts or obfuscates personal data (IP addresses, host names, usernames, etc.) before transmitting messages to Elastic. Security-specific telemetry events include:
 
+* *{detection-rule} Security alerts:* Information about Elastic authored detection rules using the detection engine. Examples of alert data include Machine Learning job influencers, process names, and cloud audit events.
 * *{elastic-endpoint} Security alerts:* Information about malicious activity detected using {elastic-endpoint} detection engines. Examples of alert data include malicious process names, digital signatures, and file names written by the malicious software. Examples of alert metadata include the time of the alert, the {elastic-endpoint} version and related detection engine versions.
 * *Configuration data for {elastic-endpoint}:* Information about the configuration of {elastic-endpoint} deployments. Examples of configuration data include the Endpoint versions, operating system versions, and performance counters for Endpoint.
 * *Exception list entries for Elastic rules:* Information about exceptions added for Elastic rules. Examples include trusted applications, detection exceptions, and rule exceptions.


### PR DESCRIPTION
We have started collecting alert telemetry on prebuilt detection rules.

Preview: [Configure advanced settings | Telemetry settings](https://security-docs_1990.docs-preview.app.elstc.co/guide/en/security/master/advanced-settings.html#telemetry-settings)