### PR TITLE
[DOCS] [7.17] Add release note for networking on macOS with Endpoint enabled

### DIFF
--- a/docs/release-notes/7.17.asciidoc
+++ b/docs/release-notes/7.17.asciidoc
@@ -8,7 +8,7 @@
 [discrete]
 [[bug-fixes-7.17.3]]
 ==== Bug fixes and enhancements
-* Fixes a bug that prevented more than 20 pinned events from displaying when opening an existing Timeline ({pull}128852[#128852]).  
+* Fixes a bug that prevented more than 20 pinned events from displaying when opening an existing Timeline ({pull}128852[#128852]).
 * Allows alerts without a populated `meta` field to be investigated in a Timeline ({pull}129427[#129427]).
 
 [discrete]
@@ -34,6 +34,11 @@
 [discrete]
 [[release-notes-7.17.0]]
 === 7.17.0
+
+[discrete]
+[[known-issue-7.17.0]]
+==== Known issues
+* If {elastic-endpoint} is used with other products that monitor or manage network traffic (such as antivirus programs, firewalls, or VPNs) users might experience network connection issues. This issue is only present on macOS. To resolve it, upgrade to macOS 12.4.
 
 [discrete]
 [[breaking-changes-7.17.0]]

--- a/docs/release-notes/7.17.asciidoc
+++ b/docs/release-notes/7.17.asciidoc
@@ -38,7 +38,7 @@
 [discrete]
 [[known-issue-7.17.0]]
 ==== Known issues
-* If {elastic-endpoint} is used with other products that monitor or manage network traffic (such as antivirus programs, firewalls, or VPNs) users might experience network connection issues. This issue is only present on macOS. To resolve it, upgrade to macOS 12.4.
+* On macOS versions before 12.4, if {elastic-endpoint} is used with other products that monitor or manage network traffic (such as antivirus programs, firewalls, or VPNs), users might experience network connection issues. To resolve this issue, upgrade to macOS 12.4 or later.
 
 [discrete]
 [[breaking-changes-7.17.0]]


### PR DESCRIPTION
Fixes https://github.com/elastic/security-docs/issues/1992.

Preview [here](https://security-docs_1997.docs-preview.app.elstc.co/guide/en/security/7.17/release-notes-header-7.17.0.html#known-issue-7.17.0). 