### PR TITLE
[DOCS] Remove broken links to discontinued anomaly detection jobs

### DIFF
--- a/docs/detections/rules-ui-monitor.asciidoc
+++ b/docs/detections/rules-ui-monitor.asciidoc
@@ -113,9 +113,9 @@ image::images/timestamp-override.png[]
 The <<prebuilt-ml-jobs,prebuilt {ml} jobs>> have dependencies on data fields
 that are populated by {beats} and {agent} integrations. In version 7.11, new
 {ml} jobs (<<security-linux-jobs>> and <<security-windows-jobs>>) were provided,
-which operate on newer ECS fields than the previous
-<<security-winlogbeat-jobs>> and <<security-auditbeat-jobs>> jobs. However, the
-<<prebuilt-rules,prebuilt rules>> were not updated to use the new {ml} jobs.
+which operate on newer ECS fields than the previous Security: {winlogbeat} and
+Security: {auditbeat} jobs. However, the <<prebuilt-rules,prebuilt rules>> were
+not updated to use the new {ml} jobs.
 
 Therefore:
 


### PR DESCRIPTION
Relates to https://github.com/elastic/stack-docs/pull/2140, https://github.com/elastic/kibana/pull/131166

The "Security:Auditbeat", "Security:Auditbeat authentication", "Security:Winlogbeat", and "Security:Winlogbeat authentication" anomaly detection jobs have been removed, so links to that content must be cleaned up.