### PR TITLE
[DOCS] 8.2.2 Release Notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.2.2, {elastic-sec} version 8.2.2>>
 * <<release-notes-8.2.1, {elastic-sec} version 8.2.1>>
 * <<release-notes-8.2.0, {elastic-sec} version 8.2.0>>
 * <<release-notes-8.1.3, {elastic-sec} version 8.1.3>>

--- a/docs/release-notes/8.2.asciidoc
+++ b/docs/release-notes/8.2.asciidoc
@@ -3,7 +3,7 @@
 
 [discrete]
 [[release-notes-8.2.2]]
-=== 8.2.1
+=== 8.2.2
 
 [discrete]
 [[bug-fixes-8.2.2]]

--- a/docs/release-notes/8.2.asciidoc
+++ b/docs/release-notes/8.2.asciidoc
@@ -2,6 +2,15 @@
 == 8.2
 
 [discrete]
+[[release-notes-8.2.2]]
+=== 8.2.1
+
+[discrete]
+[[bug-fixes-8.2.2]]
+==== Bug fixes and enhancements
+There are no user-facing changes in the 8.2.2 release.
+
+[discrete]
 [[release-notes-8.2.1]]
 === 8.2.1
 
@@ -12,7 +21,7 @@
 * Adds pagination to the *Table* tab on the Alert details flyout to fix a performance issue on the Timelines page ({pull}131358[#131358]).
 * Fixes sorting issues that were related to unmapped fields ({pull}132190[#132190]).
 * Fixes a bug in the *Filter In*, *Filter Out*, and *Add to timeline investigation* inline actions that caused incorrect results to be retrieved ({pull}132251[#132251]).
-* Enhances performance by improving calculations for the top count function and hover action in data tables ({pull}131363[#131363]). 
+* Enhances performance by improving calculations for the top count function and hover action in data tables ({pull}131363[#131363]).
 
 [discrete]
 [[release-notes-8.2.0]]

--- a/docs/release-notes/8.2.asciidoc
+++ b/docs/release-notes/8.2.asciidoc
@@ -8,7 +8,7 @@
 [discrete]
 [[bug-fixes-8.2.2]]
 ==== Bug fixes and enhancements
-There are no user-facing changes in the 8.2.2 release.
+* Fixes a sorting and tooltip issue in Timeline for non-ECS fields that don’t have nested values ({pull}132570[#132570]).
 
 [discrete]
 [[release-notes-8.2.1]]


### PR DESCRIPTION
Fixes https://github.com/elastic/security-docs/issues/1963.

Previews:
- [Index page](https://security-docs_2019.docs-preview.app.elstc.co/guide/en/security/master/release-notes.html)
- [Release notes](https://security-docs_2019.docs-preview.app.elstc.co/guide/en/security/master/release-notes-header-8.2.0.html#release-notes-8.2.2) 