### PR TITLE
[BUG] Fixes typo in 8.2 What's New page

### DIFF
--- a/docs/whats-new.asciidoc
+++ b/docs/whats-new.asciidoc
@@ -61,7 +61,7 @@ image::whats-new/images/8.2/dga.png[]
 
 
 [discrete]
-== Wilcard support for event filters
+== Wildcard support for event filters
 
 {security-guide}/event-filters.html[Event filters] now support using wildcard entries for the `file.path.text` field using the `matches` operator.
 


### PR DESCRIPTION
Fixes typo in heading: https://www.elastic.co/guide/en/security/current/whats-new.html#_wilcard_support_for_event_filters

<img width="773" alt="image" src="https://user-images.githubusercontent.com/87339667/172709943-7d6babef-6379-4974-aedb-8c7be709d45a.png">
