### PR TITLE
[DOCS] Removed ref to Stack GS

### DIFF
--- a/docs/getting-started/sec-app-requirements.asciidoc
+++ b/docs/getting-started/sec-app-requirements.asciidoc
@@ -2,20 +2,18 @@
 = Elastic Security system requirements
 
 {elastic-sec} is an inbuilt part of {kib}. To use {elastic-sec}, you only need an {stack}
-deployment (an {es} cluster and {kib}). For information on installing the
-{stack}, see
-{stack-gs}/get-started-elastic-stack.html[Getting started with the {stack}].
+deployment (an {es} cluster and {kib}). 
+
+{ecloud} offers all of the features of {es}, {kib}, and {elastic-sec} as a hosted service 
+available on AWS, GCP, and Azure. 
+To get started, sign up for a {ess-trial}[free {ecloud} trial].
+
+For information about installing and managing the {stack} yourself, 
+see {stack-ref}/installing-elastic-stack.html[Installing the {stack}].
 
 The https://www.elastic.co/support/matrix[Support Matrix] page lists officially
 supported operating systems, platforms, and browsers on which {es}, {kib}, {beats}, and
 Elastic Endpoint have been tested.
-
-[TIP]
-==============
-Skip installing {es} and {kib} locally and try a
-https://www.elastic.co/cloud/elasticsearch-service[cloud deployment],
-available on Azure, AWS, and GCP. You can {ess-trial}[try it out for free].
-==============
 
 [discrete]
 [[node-role-requirements]]


### PR DESCRIPTION
We're retiring the Stack GS in favor of the new onboarding content introduced in 8.2.