### PR TITLE
[DOCS] Fix the docs for `/api/detection_engine/rules/_bulk_action` endpoint

### DIFF
--- a/docs/detections/api/rules/rules-api-bulk-actions.asciidoc
+++ b/docs/detections/api/rules/rules-api-bulk-actions.asciidoc
@@ -280,12 +280,12 @@ Yes, if action is `edit`.
 |==============================================
 | `type` field | `value` field | Description
 | `add_tags` | String[] | Add tags to rules
-| `delete_tags` | String[] | Delete tags from rules
-| `set_tags` | String[] | Overwrite tags with value(s) in rules
+| `delete_tags` | String[] | Delete rules' tags
+| `set_tags` | String[] | Overwrite rules' tags
 | `add_index_patterns` | String[] | Add index patterns to rules
-| `delete_index_patterns` | String[] | Delete index patterns from rules
-| `set_index_patterns` | String[] | Overwrite index patterns with value in rules
-| `set_timeline` | { timeline_id: String; timeline_title: String } | Overwrite timeline template in rules
+| `delete_index_patterns` | String[] | Delete rules' index patterns
+| `set_index_patterns` | String[] | Overwrite rules' index patterns
+| `set_timeline` | { `timeline_id`: String; `timeline_title`: String } | Overwrite rules' Timeline template
 |==============================================
 
 <<bulk-edit-object-schema, Actions>> are shown in order of oldest to newest in the `edit` array payload's property.

--- a/docs/detections/api/rules/rules-api-bulk-actions.asciidoc
+++ b/docs/detections/api/rules/rules-api-bulk-actions.asciidoc
@@ -278,13 +278,14 @@ Yes, if action is `edit`.
 
 [width="100%",options="header"]
 |==============================================
-|`type` field |`value` field |Description
-| `add_tags` | String[] |  Add tags to rules
-| `delete_tags` | String[] |  Delete tags from rules
-| `set_tags` | String[] |  Overwrite tags with value(s) in rules
-| `add_index` | String[] |  Add index patterns to rules
-| `delete_index` | String[] |  Delete index patterns from rules
-| `set_index` | String[] |  Overwrite index patterns with value in rules
+| `type` field | `value` field | Description
+| `add_tags` | String[] | Add tags to rules
+| `delete_tags` | String[] | Delete tags from rules
+| `set_tags` | String[] | Overwrite tags with value(s) in rules
+| `add_index_patterns` | String[] | Add index patterns to rules
+| `delete_index_patterns` | String[] | Delete index patterns from rules
+| `set_index_patterns` | String[] | Overwrite index patterns with value in rules
+| `set_timeline` | { timeline_id: String; timeline_title: String } | Overwrite timeline template in rules
 |==============================================
 
 <<bulk-edit-object-schema, Actions>> are shown in order of oldest to newest in the `edit` array payload's property.


### PR DESCRIPTION
## Summary

Fixes the spec for the `BulkEditAction` parameters.

Background:

- https://github.com/elastic/security-docs/pull/2030#discussion_r903918687
- https://github.com/elastic/security-docs/pull/2030#discussion_r904795123