### PR TITLE
[BUG] Fixes typo in the "Add an alert to a new case" docs

### DIFF
--- a/docs/detections/alerts-ui-manage.asciidoc
+++ b/docs/detections/alerts-ui-manage.asciidoc
@@ -62,7 +62,7 @@ image::images/additional-filters.png[Shows multiple ways to filter information]
 === Customize the Alerts table
 Use the toolbar buttons in the upper-left of the Alerts table to customize the columns you want displayed:
 
-* **Columns**: Reorder the columns. 
+* **Columns**: Reorder the columns.
 * **_x_ fields sorted**: Sort the table by one or more columns.
 * **Fields**: Select the fields to display in the table. You can also add <<alerts-runtime-fields, runtime fields>> to detection alerts and display them in the Alerts table.
 
@@ -214,7 +214,7 @@ image::images/add-alert-to-case.gif[width=50%][height=50%][Shows how to add an a
 To add an alert to a new case:
 
 . Select the *More actions* menu (*...*) in the Alerts table, or **Take action** in the Alert details flyout, then select
-*Add exception*.
+*Add to new case*.
 . In the **Create new case** flyout, give your case a name, add relevant tags (optional), and include a case description.
 . Specify whether you want to sync the status of associated alerts. It is enabled by default; however, you can toggle this setting on or off at any time. If it remains enabled, the alert's status updates whenever the case's status is modified.
 . Select a connector. If you've previously added one, that connector displays as the default selection. Otherwise, the default setting is `No connector selected`.


### PR DESCRIPTION
Noticed a minor typo in step 1 of [Add an alert to a new case](https://www.elastic.co/guide/en/security/8.2/alerts-ui-manage.html#signals-to-new-cases). This typo is only present in the 8.2 docs, so I branched from 8.2 and will merge into 8.2 only. 

Preview [here](https://security-docs_2174.docs-preview.app.elstc.co/guide/en/security/8.2/alerts-ui-manage.html#signals-to-new-cases). 