### PR TITLE
Update configure-integration-policy.asciidoc

### DIFF
--- a/docs/getting-started/configure-integration-policy.asciidoc
+++ b/docs/getting-started/configure-integration-policy.asciidoc
@@ -157,6 +157,8 @@ image::images/install-endpoint/event-collection.png[Detail of event collection s
 If you download the {agent} version 7.10 or later on Windows 7 or above, you can
 configure {elastic-sec} as your antivirus software by switching the **Register as antivirus** toggle on.
 
+NOTE: Not supported by Windows Server versions
+
 [role="screenshot"]
 image::images/register-as-antivirus.png[Detail of Register as antivirus option.]
 

--- a/docs/getting-started/configure-integration-policy.asciidoc
+++ b/docs/getting-started/configure-integration-policy.asciidoc
@@ -157,7 +157,7 @@ image::images/install-endpoint/event-collection.png[Detail of event collection s
 If you download the {agent} version 7.10 or later on Windows 7 or above, you can
 configure {elastic-sec} as your antivirus software by switching the **Register as antivirus** toggle on.
 
-NOTE: Not supported by Windows Server versions
+NOTE: Windows Server versions are not supported.
 
 [role="screenshot"]
 image::images/register-as-antivirus.png[Detail of Register as antivirus option.]


### PR DESCRIPTION
added the restrictions hover-over tooltip to a note under "Register Elastic Security as antivirus (optional)"