### PR TITLE
[DOCS] 8.3.2 Release notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.3.2, {elastic-sec} version 8.3.2>>
 * <<release-notes-8.3.1, {elastic-sec} version 8.3.1>>
 * <<release-notes-8.3.0, {elastic-sec} version 8.3.0>>
 * <<release-notes-8.2.3, {elastic-sec} version 8.2.3>>

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -2,7 +2,7 @@
 == 8.3
 
 [discrete]
-[[release-notes-8.3.1]]
+[[release-notes-8.3.2]]
 === 8.3.2
 
 [discrete]

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -65,7 +65,7 @@ On the next scheduled rule execution, the *Last Response* value for the rule wil
 
 [discrete]
 [[release-notes-8.3.0]]
-== 8.3.0
+=== 8.3.0
 
 [discrete]
 [[known-issue-8.3.0]]

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -9,7 +9,7 @@
 [[bug-fixes-8.3.2]]
 ==== Bug fixes and enhancements
 * Allows indices created from value lists to be used with indicator match rules ({pull}135128[#135128]).
-
+* Fixes a bug that prevented the "Create field" button from appearing in the Fields menu when you accessed it from a Timeline created using the Alerts page's "Open in timeline" button. ({pull}135842[#135842])
 [discrete]
 [[release-notes-8.3.1]]
 === 8.3.1

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -10,9 +10,9 @@
 ==== Bug fixes and enhancements
 * Allows indices created from value lists to be used with indicator match rules ({pull}135128[#135128]).
 * Fixes a bug that prevented the "Create field" button from appearing in the Fields menu when you accessed it from a Timeline created using the Alerts page's "Open in timeline" button. ({pull}135842[#135842])
+
 [discrete]
 [[release-notes-8.3.1]]
-
 === 8.3.1
 
 [discrete]

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -3,6 +3,15 @@
 
 [discrete]
 [[release-notes-8.3.1]]
+=== 8.3.2
+
+[discrete]
+[[bug-fixes-8.3.2]]
+==== Bug fixes and enhancements
+* Allows indices created from value lists to be used with indicator match rules ({pull}135128[#135128]).
+
+[discrete]
+[[release-notes-8.3.1]]
 === 8.3.1
 
 [discrete]


### PR DESCRIPTION
Addresses https://github.com/elastic/security-docs/issues/2173.

Previews:
- [Index page](https://security-docs_2179.docs-preview.app.elstc.co/guide/en/security/master/release-notes.html)
- [Release notes](https://security-docs_2179.docs-preview.app.elstc.co/guide/en/security/master/release-notes-header-8.3.0.html#release-notes-8.3.2)