### PR TITLE
[DOCS] Document bug where alerting rules created/edited in 8.2 will stop running on upgrade 

### DIFF
--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -108,13 +108,50 @@ If you already upgraded from 8.2 to 8.3.0, detection rules affected by the bug w
 
 You will need to disable, then re-enable affected rules to restore them to a functional state. These actions generate a new API key using the credentials of the user performing these actions. The rules' states are also reset.
 
-NOTE: To complete the following steps, you need privileges to  <<enable-detections-ui, manage rules>>.
+NOTE: To restore failed custom and prebuilt rules, you need privileges to <<enable-detections-ui, manage rules>>.
 
-. Go to the *Rules* page (*Detect -> Rules*).
+*Restore custom rules*
+
+Follow these steps:
+
+. Go to the *Rules* page (*Detect -> Rules*) and click *Custom rules*.
+. Sort the rules table by the *Enabled* column to show enabled rules.
 . Select the affected rules, then click *Bulk actions -> Disable*.
-. Re-select the same rules, then click *Bulk actions -> Enable*.
++
+NOTE: Affected rules will have a `Failed` execution status and the aforementioned error message in the rule's details.
 
-After you've re-enabled the rules, the *Last Response* value for the rule will change to `Pending`, and then to `Active` or `OK`.
+. Select the affected rules, then click *Bulk actions -> Tags -> Add Tags*. Add a descriptive tag, for example `rules_to_fix`.
+. Re-select the same rules, then click *Bulk actions -> Enable*.
+. Add a descriptive tag, for example `rules_to_fix`.
++
+NOTE: Adding a tag will generate new API keys and solve the issue.
+
+. (Optional) Follow these steps if you don't want to wait until the next scheduled rule execution:
+.. From the rules table, filter for the tag you just applied to your custom rules.
+.. Click *Select all x rules* above the rules table.
+.. Click *Bulk actions -> Disable*.
+.. Filter the rules table for the same tag, re-select the same rules, and then click *Bulk actions -> Enable*.
+
+Once the rule runs, the *Last Response* value for the rule will change to `Pending`, and then to `Active` or `OK`.
+
+*Restore prebuilt rules*
+
+Follow these steps:
+
+. Go to the *Rules* page (*Detect -> Rules*) and click *Elastic rules*.
+. Sort the rules table by the *Enabled* column to show enabled rules.
+. TBD
+. Select the affected rules, then click *Bulk actions -> Disable*.
++
+NOTE: Affected rules will have a `Failed` execution status and the aforementioned error message in the rule's details.
+
+. Re-select the same rules.
++
+TIP: Click the Rule table column header to sort by rule name and then compare the table results to the results of the API call you previously ran.
+
+.  Click *Bulk actions -> Enable*.
+
+Once the rule runs, the *Last Response* value for the rule will change to `Pending`, and then to `Active` or `OK`.
 
 [discrete]
 [[breaking-changes-8.3.0]]

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -57,11 +57,11 @@ Once the rule runs, the *Last Response* value for the rule will change to `Pendi
 
 Follow these steps:
 
-. Use the <<rules-api-find, Find rules API>> to capture a list of enabled rules before you upgrade. Here is a curl command that you can run to find enabled rules:
+. Use the <<rules-api-find, Find rules API>> to capture a list of enabled rules before you upgrade. Here is a curl command that you can run to find enabled prebuilt rules:
 +
 [source,console]
 --------------------------------------------------
-GET /api/detection_engine/rules/_find?per_page=10000&filter=alert.attributes.enabled:true
+GET api/detection_engine/rules/_find?page=1&per_page=1000&sort_field=name&sort_order=asc&filter=alert.attributes.enabled:true and alert.attributes.params.immutable: true
 --------------------------------------------------
 
 . Go to the *Rules* page (*Detect -> Rules*) and click *Elastic rules*.

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -138,7 +138,7 @@ Once the rule runs, the *Last Response* value for the rule will change to `Pendi
 
 Follow these steps:
 
-. Use the <<rules-api-find, Find rules API>> to capture a list of enabled rules before you upgrade. Here is a curl command that you can run to find enabled rules:
+. Use the <<rules-api-find, Find rules API>> to capture a list of enabled rules before you upgrade. Here is a curl command that you can run to find enabled prebuilt rules:
 +
 [source,console]
 --------------------------------------------------

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -10,27 +10,35 @@
 [[known-issue-8.3.1]]
 ==== Known issue
 
-Detection rule users who are running 8.2 should not upgrade to either 8.3.0 or 8.3.1. Both 8.3.0 and 8.3.1 have a bug where detection rules that were created or edited in 8.2 will stop running on upgrade.
+8.3.1 has a bug where detection rules that were created or edited in 8.2 will stop running after you upgrade. Because of this, we advise against upgrading from 8.2 to 8.3.1.
 
-If you have upgraded to 8.3.0 or 8.3.1 and your detection rules have stopped running with an error similar to the following example, you will need to deactivate affected rules and then reactivate them on to restore them to a functional state.
+If you want to upgrade, _we highly recommend that you track your active rules beforehand so you can easily find and re-enable them after you upgrade_. Use the <<rules-api-find, Find rules API>> to capture a list of enabled rules before you upgrade.
 
-Example error message::
+NOTE: Use curl or another HTTP tool to run {elastic-sec} API commands.
+
+Here is a curl command that you can run to find enabled rules:
+
+[source,console]
+--------------------------------------------------
+GET /api/detection_engine/rules/_find?per_page=10000&filter=alert.attributes.enabled:true
+--------------------------------------------------
+
+After upgrading, detection rules affected by the bug will have stopped running with an error that is similar to the following example:
 
 [source,text]
 ----
 <rule-type>:<UUID>: execution failed - security_exception: [security_exception] Reason: missing authentication credentials for REST request [/_security/user/_has_privileges], caused by: ""
 ----
 
-IMPORTANT: Note that the *Update API key* option forces the detection rule to run with the privileges of the user selecting the option. As such, the user should have the equivalent Kibana roles and privileges that the most recent rule editors had.
+You will need to disable, then re-enable affected rules to restore them to a functional state. Doing so will generate a new API key using the credentials of the user performing these actions and reset the rule state.
 
-You can disable and then enable your rules from the Rules page:
+NOTE: To complete these steps, you need privileges to <<manage rules, enable-detections-ui>>
 
 . Go to the *Rules* page (*Detect -> Rules*).
 . Select the affected rules, then click *Bulk actions -> Disable*.
-+
-TIP: Keep track of the rules you disabled. You will need to refer to the list in the next step.
+. Refer to the list of enabled rules you gathered earlier, re-select them, then click *Bulk actions -> Enable*.
 
-. Re-select the same rules, then click *Bulk actions -> Enable*.
+After you've re-enabled the rules, the *Last Response* value for the rule will change to `Pending`, and then to `Active` or `OK`.
 
 [discrete]
 [[bug-fixes-8.3.1]]
@@ -45,27 +53,35 @@ TIP: Keep track of the rules you disabled. You will need to refer to the list in
 [[known-issue-8.3.0]]
 ==== Known issue
 
-Detection rule users who are running 8.2 should not upgrade to either 8.3.0 or 8.3.1. Both 8.3.0 and 8.3.1 have a bug where detection rules that were created or edited in 8.2 will stop running on upgrade.
+8.3.0 has a bug where detection rules that were created or edited in 8.2 will stop running after you upgrade. Because of this, we advise against upgrading from 8.2 to 8.3.0.
 
-If you have upgraded to 8.3.0 or 8.3.1 and your detection rules have stopped running with an error similar to the following example, you will need to deactivate affected rules and then reactivate them on to restore them to a functional state.
+If you want to upgrade, _we highly recommend that you track your active rules beforehand so you can easily find and re-enable them after you upgrade_. Use the <<rules-api-find, Find rules API>> to capture a list of enabled rules before you upgrade.
 
-Example error message::
+NOTE: Use curl or another HTTP tool to run {elastic-sec} API commands.
+
+Here is a curl command that you can run to find enabled rules:
+
+[source,console]
+--------------------------------------------------
+GET /api/detection_engine/rules/_find?per_page=10000&filter=alert.attributes.enabled:true
+--------------------------------------------------
+
+After upgrading, detection rules affected by the bug will have stopped running with an error that is similar to the following example:
 
 [source,text]
 ----
 <rule-type>:<UUID>: execution failed - security_exception: [security_exception] Reason: missing authentication credentials for REST request [/_security/user/_has_privileges], caused by: ""
 ----
 
-IMPORTANT: Note that the *Update API key* option forces the detection rule to run with the privileges of the user selecting the option. As such, the user should have the equivalent Kibana roles and privileges that the most recent rule editors had.
+You will need to disable, then re-enable affected rules to restore them to a functional state. Doing so will generate a new API key using the credentials of the user performing these actions and reset the rule state. 
 
-You can disable and then enable your rules from the Rules page:
+NOTE: To complete the following steps, you need privileges to <<manage rules, enable-detections-ui>>
 
 . Go to the *Rules* page (*Detect -> Rules*).
 . Select the affected rules, then click *Bulk actions -> Disable*.
-+
-TIP: Keep track of the rules you disabled. You will need to refer to the list in the next step.
+. Refer to the list of enabled rules you gathered earlier, re-select them, then click *Bulk actions -> Enable*.
 
-. Re-select the same rules, then click *Bulk actions -> Enable*.
+After you've re-enabled the rules, the *Last Response* value for the rule will change to `Pending`, and then to `Active` or `OK`.
 
 [discrete]
 [[breaking-changes-8.3.0]]

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -30,13 +30,50 @@ If you already upgraded from 8.2 to 8.3.1, detection rules affected by the bug w
 
 You will need to disable, then re-enable affected rules to restore them to a functional state. These actions generate new API keys using the credentials of the user performing these actions. The rules' states are also reset.
 
-NOTE: To complete these steps, you need privileges to <<enable-detections-ui, manage rules>>.
+NOTE: To restore failed custom and prebuilt rules, you need privileges to <<enable-detections-ui, manage rules>>.
 
-. Go to the *Rules* page (*Detect -> Rules*).
+*Restore custom rules*
+
+Follow these steps:
+
+. Go to the *Rules* page (*Detect -> Rules*) and click *Custom rules*.
+. Sort the rules table by the *Enabled* column to show enabled rules.
 . Select the affected rules, then click *Bulk actions -> Disable*.
-. Re-select the same rules, then click *Bulk actions -> Enable*.
++
+NOTE: Affected rules will have a `Failed` execution status and the aforementioned error message in the rule's details.
 
-After you've re-enabled the rules, the *Last Response* value for the rule will change to `Pending`, and then to `Active` or `OK`.
+. Select the affected rules, then click *Bulk actions -> Tags -> Add Tags*. Add a descriptive tag, for example `rules_to_fix`.
+. Re-select the same rules, then click *Bulk actions -> Enable*.
+. Add a descriptive tag, for example `rules_to_fix`.
++
+NOTE: Adding a tag will generate new API keys and solve the issue.
+
+. (Optional) Follow these steps if you don't want to wait until the next scheduled rule execution:
+.. From the rules table, filter for the tag you just applied to your custom rules.
+.. Click *Select all x rules* above the rules table.
+.. Click *Bulk actions -> Disable*.
+.. Filter the rules table for the same tag, re-select the same rules, and then click *Bulk actions -> Enable*.
+
+Once the rule runs, the *Last Response* value for the rule will change to `Pending`, and then to `Active` or `OK`.
+
+*Restore prebuilt rules*
+
+Follow these steps:
+
+. Go to the *Rules* page (*Detect -> Rules*) and click *Elastic rules*.
+. Sort the rules table by the *Enabled* column to show enabled rules.
+. TBD
+. Select the affected rules, then click *Bulk actions -> Disable*.
++
+NOTE: Affected rules will have a `Failed` execution status and the aforementioned error message in the rule's details.
+
+. Re-select the same rules.
++
+TIP: Click the Rule table column header to sort by rule name and then compare the table results to the results of the API call you previously ran.
+
+.  Click *Bulk actions -> Enable*.
+
+Once the rule runs, the *Last Response* value for the rule will change to `Pending`, and then to `Active` or `OK`.
 
 [discrete]
 [[bug-fixes-8.3.1]]

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -57,16 +57,22 @@ Once the rule runs, the *Last Response* value for the rule will change to `Pendi
 
 Follow these steps:
 
+. Use the <<rules-api-find, Find rules API>> to capture a list of enabled rules before you upgrade. Here is a curl command that you can run to find enabled rules:
++
+[source,console]
+--------------------------------------------------
+GET /api/detection_engine/rules/_find?per_page=10000&filter=alert.attributes.enabled:true
+--------------------------------------------------
+
 . Go to the *Rules* page (*Detect -> Rules*) and click *Elastic rules*.
 . Sort the rules table by the *Enabled* column to show enabled rules.
-. TBD
 . Select the affected rules, then click *Bulk actions -> Disable*.
 +
 NOTE: Affected rules will have a `Failed` execution status and the aforementioned error message in the rule's details.
 
 . Re-select the same rules.
 +
-TIP: Click the *Rule* column to sort by rule name and then compare the table results to the results of the API call you previously ran.
+TIP: Click the *Rule* column to sort by rule name and then compare the table results to the results of the API call you ran in step 1.
 
 .  Click *Bulk actions -> Enable*.
 
@@ -132,16 +138,22 @@ Once the rule runs, the *Last Response* value for the rule will change to `Pendi
 
 Follow these steps:
 
+. Use the <<rules-api-find, Find rules API>> to capture a list of enabled rules before you upgrade. Here is a curl command that you can run to find enabled rules:
++
+[source,console]
+--------------------------------------------------
+GET /api/detection_engine/rules/_find?per_page=10000&filter=alert.attributes.enabled:true
+--------------------------------------------------
+
 . Go to the *Rules* page (*Detect -> Rules*) and click *Elastic rules*.
 . Sort the rules table by the *Enabled* column to show enabled rules.
-. TBD
 . Select the affected rules, then click *Bulk actions -> Disable*.
 +
 NOTE: Affected rules will have a `Failed` execution status and the aforementioned error message in the rule's details.
 
 . Re-select the same rules.
 +
-TIP: Click the *Rule* column to sort by rule name and then compare the table results to the results of the API call you previously ran.
+TIP: Click the *Rule* column to sort by rule name and then compare the table results to the results of the API call you ran in step 1.
 
 .  Click *Bulk actions -> Enable*.
 

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -44,7 +44,7 @@ Alernatively, you can use the <<bulk-actions-rules-api-action, Bulk rule actions
 
 Detection rule users who are running 8.2 should not upgrade to either 8.3.0 or 8.3.1. Both 8.3.0 and 8.3.1 have a bug where detection rules that were created or edited in 8.2 will stop running on upgrade.
 
-If you have upgraded to 8.3.0 or 8.3.1 and your detection rules have stopped running with an error similar to the following example, you will need to deactivate your rules and then reactivate them on to restore them to a functional state.
+If you have upgraded to 8.3.0 or 8.3.1 and your detection rules have stopped running with an error similar to the following example, you will need to deactivate your rules and then reactivate them to restore them to a functional state.
 
 Example error message::
 

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -28,7 +28,7 @@ If you already upgraded from 8.2 to 8.3.1, detection rules affected by the bug w
 <rule-type>:<UUID>: execution failed - security_exception: [security_exception] Reason: missing authentication credentials for REST request [/_security/user/_has_privileges], caused by: ""
 ----
 
-You will need to disable, then re-enable affected rules to restore them to a functional state. These actions generate new API keys using the credentials of the user performing these actions. The rules' states are also reset.
+You will need to disable, then re-enable affected rules to restore them to a functional state. These actions generate new API keys using the credentials of the user performing these actions. The rules' statuses are also reset.
 
 NOTE: To restore failed custom and prebuilt rules, you need privileges to <<enable-detections-ui, manage rules>>.
 

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -44,11 +44,8 @@ NOTE: Affected rules will have a `Failed` execution status and the aforementione
 
 . Select the affected rules, then click *Bulk actions -> Tags -> Add Tags*. Add a descriptive tag, for example `rules_to_fix`.
 . Re-select the same rules, then click *Bulk actions -> Enable*.
-. Add a descriptive tag, for example `rules_to_fix`.
-+
-NOTE: Adding a tag will generate new API keys and solve the issue.
-
-. (Optional) Follow these steps if you don't want to wait until the next scheduled rule execution:
+. Add a descriptive tag, for example `rules_to_fix`. Adding a tag will generate new API keys and solve the issue.
+. Follow these steps if you don't want to wait until the next scheduled rule execution (optional):
 .. From the rules table, filter for the tag you just applied to your custom rules.
 .. Click *Select all x rules* above the rules table.
 .. Click *Bulk actions -> Disable*.
@@ -69,7 +66,7 @@ NOTE: Affected rules will have a `Failed` execution status and the aforementione
 
 . Re-select the same rules.
 +
-TIP: Click the Rule table column header to sort by rule name and then compare the table results to the results of the API call you previously ran.
+TIP: Click the *Rule* column to sort by rule name and then compare the table results to the results of the API call you previously ran.
 
 .  Click *Bulk actions -> Enable*.
 
@@ -122,11 +119,8 @@ NOTE: Affected rules will have a `Failed` execution status and the aforementione
 
 . Select the affected rules, then click *Bulk actions -> Tags -> Add Tags*. Add a descriptive tag, for example `rules_to_fix`.
 . Re-select the same rules, then click *Bulk actions -> Enable*.
-. Add a descriptive tag, for example `rules_to_fix`.
-+
-NOTE: Adding a tag will generate new API keys and solve the issue.
-
-. (Optional) Follow these steps if you don't want to wait until the next scheduled rule execution:
+. Add a descriptive tag, for example `rules_to_fix`. Adding a tag will generate new API keys and solve the issue.
+. Follow these steps if you don't want to wait until the next scheduled rule execution (optional):
 .. From the rules table, filter for the tag you just applied to your custom rules.
 .. Click *Select all x rules* above the rules table.
 .. Click *Bulk actions -> Disable*.
@@ -147,7 +141,7 @@ NOTE: Affected rules will have a `Failed` execution status and the aforementione
 
 . Re-select the same rules.
 +
-TIP: Click the Rule table column header to sort by rule name and then compare the table results to the results of the API call you previously ran.
+TIP: Click the *Rule* column to sort by rule name and then compare the table results to the results of the API call you previously ran.
 
 .  Click *Bulk actions -> Enable*.
 

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -38,7 +38,6 @@ NOTE: After you've re-enabled the affected rules, the rules' *Last Response* val
 
 *Restore affected custom rules only*
 
-IMPORTANT: To restore custom rules, you need privileges to <<enable-detections-ui, manage rules>>.
 
 . Go to the *Rules* page (*Detect -> Rules*) and click *Elastic rules*.
 . Switch on the *Technical preview* toggle above the table.

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -12,7 +12,7 @@
 
 Detection rule users who are running 8.2 should not upgrade to either 8.3.0 or 8.3.1. Both 8.3.0 and 8.3.1 have a bug where detection rules that were created or edited in 8.2 will stop running on upgrade.
 
-If you have upgraded to 8.3.0 or 8.3.1 and your detection rules have stopped running with an error similar to the following example, you will need to deactivate your rules and then reactivate them on to restore them to a functional state.
+If you have upgraded to 8.3.0 or 8.3.1 and your detection rules have stopped running with an error similar to the following example, you will need to deactivate your rules and then reactivate them to restore them to a functional state.
 
 Example error message::
 

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -12,7 +12,7 @@
 
 Detection rule users who are running 8.2 should not upgrade to either 8.3.0 or 8.3.1. Both 8.3.0 and 8.3.1 have a bug where detection rules that were created or edited in 8.2 will stop running on upgrade.
 
-If you have upgraded to 8.3.0 or 8.3.1 and your detection rules have stopped running with an error similar to the following example, you will need to deactivate your rules and then reactivate them to restore them to a functional state.
+If you have upgraded to 8.3.0 or 8.3.1 and your detection rules have stopped running with an error similar to the following example, use the *Update API key* option in the Rules and Connectors table (*Stack Management -> Alerts and Insights > Rules and Connectors*) to restore the detection rule to a functional state.
 
 Example error message::
 
@@ -21,13 +21,45 @@ Example error message::
 <rule-type>:<UUID>: execution failed - security_exception: [security_exception] Reason: missing authentication credentials for REST request [/_security/user/_has_privileges], caused by: ""
 ----
 
-You can disable and then enable your rules from the Rules page:
+IMPORTANT: Note that the *Update API key* option forces the detection rule to run with the privileges of the user selecting the option. As such, the user should have the equivalent Kibana roles and privileges that the most recent rule editors had.
 
-. Go to the *Rules* page (*Detect -> Rules*).
-. Select the rules that you want to disable, then click *Bulk actions -> Disable*.
+If you're unable to access the Rules and Connectors table, and multiple custom and prebuilt rules were affected, you can resolve the error and then restart your rules from the Rules page. Follow these steps:
+
+. Identify affected rules. You can do this manually from the Rules page (*Detect -> Rules*) or by running the following query from Console:
++
+
+```
+GET .kibana-event-log*/_search
+{
+  "size": 0,
+  "aggs": {
+    "failing_rule_ids": {
+      "terms": {
+        "field": "rule.id",
+        "size": 10000
+      }
+    }
+  },
+  "query": {
+    "query_string": {
+      "query": "Reason: missing authentication credentials for REST request, caused by \"\"",
+      "fields": [
+        "error.message"
+      ]
+    }
+  }
+}
+
+```
+. From the Rules page, select the rules that you want to disable, then click *Bulk actions -> Disable*.
 . Re-select the same rules, then click *Bulk actions -> Enable*.
 
-Alernatively, you can use the <<bulk-actions-rules-api-action, Bulk rule actions>> API to disable and re-enable rules.
+If _only_ custom rules were affected, follow these steps from the Rules page:
+
+. Select the affected rule, then edit the rule's settings to apply a tag to it. Use a clearly identifiable tag, for example `BEING FIXED`.
+. From the Rules table, filter for the tag you just applied to affected rules.
+. Select all of the filter's results, then click *Bulk actions -> Disable*.
+. Filter for the same tag, select the filter's results and then click *Bulk actions -> Enable*.
 
 [discrete]
 [[bug-fixes-8.3.1]]
@@ -44,7 +76,7 @@ Alernatively, you can use the <<bulk-actions-rules-api-action, Bulk rule actions
 
 Detection rule users who are running 8.2 should not upgrade to either 8.3.0 or 8.3.1. Both 8.3.0 and 8.3.1 have a bug where detection rules that were created or edited in 8.2 will stop running on upgrade.
 
-If you have upgraded to 8.3.0 or 8.3.1 and your detection rules have stopped running with an error similar to the following example, you will need to deactivate your rules and then reactivate them to restore them to a functional state.
+If you have upgraded to 8.3.0 or 8.3.1 and your detection rules have stopped running with an error similar to the following example, use the *Update API key* option in the Rules and Connectors table (*Stack Management -> Alerts and Insights > Rules and Connectors*) to restore the detection rule to a functional state.
 
 Example error message::
 
@@ -53,13 +85,45 @@ Example error message::
 <rule-type>:<UUID>: execution failed - security_exception: [security_exception] Reason: missing authentication credentials for REST request [/_security/user/_has_privileges], caused by: ""
 ----
 
-You can disable and then enable your rules from the Rules page:
+IMPORTANT: Note that the *Update API key* option forces the detection rule to run with the privileges of the user selecting the option. As such, the user should have the equivalent Kibana roles and privileges that the most recent rule editors had.
 
-. Go to the *Rules* page (*Detect -> Rules*).
-. Select the rules that you want to disable, then click *Bulk actions -> Disable*.
+If you're unable to access the Rules and Connectors table, and multiple custom and prebuilt rules were affected, you can resolve the error and then restart your rules from the Rules page. Follow these steps:
+
+. Identify affected rules. You can do this manually from the Rules page (*Detect -> Rules*) or by running the following query from Console:
++
+
+```
+GET .kibana-event-log*/_search
+{
+  "size": 0,
+  "aggs": {
+    "failing_rule_ids": {
+      "terms": {
+        "field": "rule.id",
+        "size": 10000
+      }
+    }
+  },
+  "query": {
+    "query_string": {
+      "query": "Reason: missing authentication credentials for REST request, caused by \"\"",
+      "fields": [
+        "error.message"
+      ]
+    }
+  }
+}
+
+```
+. From the Rules page, select the rules that you want to disable, then click *Bulk actions -> Disable*.
 . Re-select the same rules, then click *Bulk actions -> Enable*.
 
-Alernatively, you can use the <<bulk-actions-rules-api-action, Bulk rule actions>> API to disable and re-enable rules.
+If _only_ custom rules were affected, follow these steps from the Rules page:
+
+. Select the affected rule, then edit the rule's settings to apply a tag to it. Use a clearly identifiable tag, for example `BEING FIXED`.
+. From the Rules table, filter for the tag you just applied to affected rules.
+. Select all of the filter's results, then click *Bulk actions -> Disable*.
+. Filter for the same tag, select the filter's results and then click *Bulk actions -> Enable*.
 
 [discrete]
 [[breaking-changes-8.3.0]]

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -3,7 +3,35 @@
 
 [discrete]
 [[release-notes-8.3.1]]
+
 === 8.3.1
+
+[discrete]
+[[known-issue-8.3.1]]
+==== Known issues
+
+Detection rule users who are running 8.2 should not upgrade to either 8.3.0 or 8.3.1.
+Both 8.3.0 and 8.3.1 have a bug where detection rules that were created or edited
+in 8.2 will stop running on upgrade.
+
+If you have upgraded to 8.3.0 or 8.3.1 and
+your detection rules have stopped running with an error similar to the following
+example, you will need to deactivate your rules and then reactivate them on to restore them to a functional state.
+
+Example error message::
+
+[source,text]
+----
+<rule-type>:<UUID>: execution failed - security_exception: [security_exception] Reason: missing authentication credentials for REST request [/_security/user/_has_privileges], caused by: ""
+----
+
+You can disable and then enable your rules from the Rules page:
+
+. Go to the *Rules* page (*Detect -> Rules*).
+. Select the rules that you want to disable, then click *Bulk actions -> Disable*.
+. Re-select the same rules, then click *Bulk actions -> Enable*.
+
+Alernatively, you can use the <<bulk-actions-rules-api-action, Bulk rule actions>> API to disable and re-enable rules.
 
 [discrete]
 [[bug-fixes-8.3.1]]
@@ -13,6 +41,33 @@
 [discrete]
 [[release-notes-8.3.0]]
 == 8.3.0
+
+[discrete]
+[[known-issue-8.3.0]]
+==== Known issues
+
+Detection rule users who are running 8.2 should not upgrade to either 8.3.0 or 8.3.1.
+Both 8.3.0 and 8.3.1 have a bug where detection rules that were created or edited
+in 8.2 will stop running on upgrade.
+
+If you have upgraded to 8.3.0 or 8.3.1 and
+your detection rules have stopped running with an error similar to the following
+example, you will need to deactivate your rules and then reactivate them on to restore them to a functional state.
+
+Example error message::
+
+[source,text]
+----
+<rule-type>:<UUID>: execution failed - security_exception: [security_exception] Reason: missing authentication credentials for REST request [/_security/user/_has_privileges], caused by: ""
+----
+
+You can disable and then enable your rules from the Rules page:
+
+. Go to the *Rules* page (*Detect -> Rules*).
+. Select the rules that you want to disable, then click *Bulk actions -> Disable*.
+. Re-select the same rules, then click *Bulk actions -> Enable*.
+
+Alernatively, you can use the <<bulk-actions-rules-api-action, Bulk rule actions>> API to disable and re-enable rules.
 
 [discrete]
 [[breaking-changes-8.3.0]]

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -24,7 +24,6 @@ IMPORTANT: You will need <<enable-detections-ui, manage rules>> privileges.
 
 *Restore affected custom and prebuilt rules*
 
-IMPORTANT: To restore custom and prebuilt rules, you need privileges to <<enable-detections-ui, manage rules>>.
 
 . Go to the Rules page (*Detect -> Rules*).
 . Click the *Rows per page* menu under the rules table and select *100 rows*.

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -142,7 +142,7 @@ Follow these steps:
 +
 [source,console]
 --------------------------------------------------
-GET /api/detection_engine/rules/_find?per_page=10000&filter=alert.attributes.enabled:true
+GET api/detection_engine/rules/_find?page=1&per_page=1000&sort_field=name&sort_order=asc&filter=alert.attributes.enabled:true and alert.attributes.params.immutable: true
 --------------------------------------------------
 
 . Go to the *Rules* page (*Detect -> Rules*) and click *Elastic rules*.

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -20,10 +20,10 @@ If you already upgraded from 8.2 to 8.3.1, detection rules affected by the bug w
 ----
 
 To restore the affected rules and reset their statuses, complete the following.
-IMPORTANT: You will need <<enable-detections-ui, manage rules>> privileges.
+
+IMPORTANT: To restore custom and prebuilt rules, you need privileges to <<enable-detections-ui, manage rules>>.
 
 *Restore affected custom and prebuilt rules*
-
 
 . Go to the Rules page (*Detect -> Rules*).
 . Click the *Rows per page* menu under the rules table and select *100 rows*.
@@ -36,8 +36,9 @@ NOTE: After you've re-enabled the affected rules, the rules' *Last Response* val
 
 . Go to the next page of results for the rules table and repeat steps 1 through 6.
 
-*Restore affected custom rules only*
+*Restore affected custom rules only (optional)*
 
+NOTE: This is an alternative option for users who have only enabled custom rules and or duplicated and enabled pre-built rules.
 
 . Go to the *Rules* page (*Detect -> Rules*) and click *Elastic rules*.
 . Switch on the *Technical preview* toggle above the table.
@@ -72,9 +73,9 @@ If you already upgraded from 8.2 to 8.3.0, detection rules affected by the bug w
 
 To restore the affected rules and reset their statuses, complete the following.
 
-*Restore affected custom and prebuilt rules*
-
 IMPORTANT: To restore custom and prebuilt rules, you need privileges to <<enable-detections-ui, manage rules>>.
+
+*Restore affected custom and prebuilt rules*
 
 . Go to the Rules page (*Detect -> Rules*).
 . Click the *Rows per page* menu under the rules table and select *100 rows*.
@@ -87,9 +88,9 @@ NOTE: After you've re-enabled the affected rules, the rules' *Last Response* val
 
 . Go to the next page of results for the rules table and repeat steps 1 through 6.
 
-*Restore affected custom rules only*
+*Restore affected custom rules only (optional)*
 
-IMPORTANT: To restore custom rules, you need privileges to <<enable-detections-ui, manage rules>>.
+NOTE: This is an alternative option for users who have only enabled custom rules and or duplicated and enabled pre-built rules.
 
 . Go to the *Rules* page (*Detect -> Rules*) and click *Elastic rules*.
 . Switch on the *Technical preview* toggle above the table.

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -12,7 +12,7 @@
 
 Detection rule users who are running 8.2 should not upgrade to either 8.3.0 or 8.3.1. Both 8.3.0 and 8.3.1 have a bug where detection rules that were created or edited in 8.2 will stop running on upgrade.
 
-If you have upgraded to 8.3.0 or 8.3.1 and your detection rules have stopped running with an error similar to the following example, use the *Update API key* option in the Rules and Connectors table (*Stack Management -> Alerts and Insights > Rules and Connectors*) to restore the detection rule to a functional state.
+If you have upgraded to 8.3.0 or 8.3.1 and your detection rules have stopped running with an error similar to the following example, you will need to deactivate affected rules and then reactivate them on to restore them to a functional state.
 
 Example error message::
 
@@ -23,45 +23,12 @@ Example error message::
 
 IMPORTANT: Note that the *Update API key* option forces the detection rule to run with the privileges of the user selecting the option. As such, the user should have the equivalent Kibana roles and privileges that the most recent rule editors had.
 
-*Resolving the error using the {security-app} UI*
-
-If you're unable to access the Rules and Connectors table, and multiple custom and prebuilt rules were affected, you can resolve the error and then restart your rules from the Rules page. Follow these steps:
-
-. Identify affected rules. You can do this manually from the Rules page (*Detect -> Rules*) or by running the following query from Console:
+You can disable and then enable your rules from the Rules page:
+. Go to the *Rules* page (*Detect -> Rules*).
+. Select the affected rules, then click *Bulk actions -> Disable*.
 +
-
-```
-GET .kibana-event-log*/_search
-{
-  "size": 0,
-  "aggs": {
-    "failing_rule_ids": {
-      "terms": {
-        "field": "rule.id",
-        "size": 10000
-      }
-    }
-  },
-  "query": {
-    "query_string": {
-      "query": "Reason: missing authentication credentials for REST request, caused by \"\"",
-      "fields": [
-        "error.message"
-      ]
-    }
-  }
-}
-
-```
-. From the Rules page, select the rules that you want to disable, then click *Bulk actions -> Disable*.
+TIP: Keep track of the rules you disabled. You will need to refer to the list in the next step.
 . Re-select the same rules, then click *Bulk actions -> Enable*.
-
-If _only_ custom rules were affected, follow these steps from the Rules page:
-
-. Select the affected rule, then edit the rule's settings to apply a tag to it. Use a clearly identifiable tag, for example `BEING FIXED`.
-. From the Rules table, filter for the tag you just applied to affected rules.
-. Select all of the filter's results, then click *Bulk actions -> Disable*.
-. Filter for the same tag, select the filter's results and then click *Bulk actions -> Enable*.
 
 [discrete]
 [[bug-fixes-8.3.1]]
@@ -78,7 +45,7 @@ If _only_ custom rules were affected, follow these steps from the Rules page:
 
 Detection rule users who are running 8.2 should not upgrade to either 8.3.0 or 8.3.1. Both 8.3.0 and 8.3.1 have a bug where detection rules that were created or edited in 8.2 will stop running on upgrade.
 
-If you have upgraded to 8.3.0 or 8.3.1 and your detection rules have stopped running with an error similar to the following example, use the *Update API key* option in the Rules and Connectors table (*Stack Management -> Alerts and Insights > Rules and Connectors*) to restore the detection rule to a functional state.
+If you have upgraded to 8.3.0 or 8.3.1 and your detection rules have stopped running with an error similar to the following example, you will need to deactivate affected rules and then reactivate them on to restore them to a functional state.
 
 Example error message::
 
@@ -89,45 +56,12 @@ Example error message::
 
 IMPORTANT: Note that the *Update API key* option forces the detection rule to run with the privileges of the user selecting the option. As such, the user should have the equivalent Kibana roles and privileges that the most recent rule editors had.
 
-*Resolving the error using the {security-app} UI*
-
-If you're unable to access the Rules and Connectors table, and multiple custom and prebuilt rules were affected, you can resolve the error and then restart your rules from the Rules page. Follow these steps:
-
-. Identify affected rules. You can do this manually from the Rules page (*Detect -> Rules*) or by running the following query from Console:
+You can disable and then enable your rules from the Rules page:
+. Go to the *Rules* page (*Detect -> Rules*).
+. Select the affected rules, then click *Bulk actions -> Disable*.
 +
-
-```
-GET .kibana-event-log*/_search
-{
-  "size": 0,
-  "aggs": {
-    "failing_rule_ids": {
-      "terms": {
-        "field": "rule.id",
-        "size": 10000
-      }
-    }
-  },
-  "query": {
-    "query_string": {
-      "query": "Reason: missing authentication credentials for REST request, caused by \"\"",
-      "fields": [
-        "error.message"
-      ]
-    }
-  }
-}
-
-```
-. From the Rules page, select the rules that you want to disable, then click *Bulk actions -> Disable*.
+TIP: Keep track of the rules you disabled. You will need to refer to the list in the next step.
 . Re-select the same rules, then click *Bulk actions -> Enable*.
-
-If _only_ custom rules were affected, follow these steps from the Rules page:
-
-. Select the affected rule, then edit the rule's settings to apply a tag to it. Use a clearly identifiable tag, for example `BEING FIXED`.
-. From the Rules table, filter for the tag you just applied to affected rules.
-. Select all of the filter's results, then click *Bulk actions -> Disable*.
-. Filter for the same tag, select the filter's results and then click *Bulk actions -> Enable*.
 
 [discrete]
 [[breaking-changes-8.3.0]]

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -24,10 +24,12 @@ Example error message::
 IMPORTANT: Note that the *Update API key* option forces the detection rule to run with the privileges of the user selecting the option. As such, the user should have the equivalent Kibana roles and privileges that the most recent rule editors had.
 
 You can disable and then enable your rules from the Rules page:
+
 . Go to the *Rules* page (*Detect -> Rules*).
 . Select the affected rules, then click *Bulk actions -> Disable*.
 +
 TIP: Keep track of the rules you disabled. You will need to refer to the list in the next step.
+
 . Re-select the same rules, then click *Bulk actions -> Enable*.
 
 [discrete]
@@ -57,10 +59,12 @@ Example error message::
 IMPORTANT: Note that the *Update API key* option forces the detection rule to run with the privileges of the user selecting the option. As such, the user should have the equivalent Kibana roles and privileges that the most recent rule editors had.
 
 You can disable and then enable your rules from the Rules page:
+
 . Go to the *Rules* page (*Detect -> Rules*).
 . Select the affected rules, then click *Bulk actions -> Disable*.
 +
 TIP: Keep track of the rules you disabled. You will need to refer to the list in the next step.
+
 . Re-select the same rules, then click *Bulk actions -> Enable*.
 
 [discrete]

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -10,16 +10,7 @@
 [[known-issue-8.3.1]]
 ==== Known issue
 
-8.3.1 has a bug where detection rules that were created or edited in 8.2 will stop running after you upgrade. Because of this, we advise against upgrading from 8.2 to 8.3.1. If you want to upgrade, _we highly recommend that you track your active rules beforehand so you can easily find and re-enable them after you upgrade_. Use the <<rules-api-find, Find rules API>> to capture a list of enabled rules before you upgrade.
-
-NOTE: Use curl or another HTTP tool to run {elastic-sec} API commands.
-
-Here is a curl command that you can run to find enabled rules:
-
-[source,console]
---------------------------------------------------
-GET /api/detection_engine/rules/_find?per_page=10000&filter=alert.attributes.enabled:true
---------------------------------------------------
+8.3.1 has a bug where detection rules that were created or edited in 8.2 will stop running after you upgrade. Because of this, we advise against upgrading from 8.2 to 8.3.1.
 
 If you already upgraded from 8.2 to 8.3.1, detection rules affected by the bug will have stopped running with an error that is similar to the following example:
 
@@ -28,55 +19,35 @@ If you already upgraded from 8.2 to 8.3.1, detection rules affected by the bug w
 <rule-type>:<UUID>: execution failed - security_exception: [security_exception] Reason: missing authentication credentials for REST request [/_security/user/_has_privileges], caused by: ""
 ----
 
-You will need to disable, then re-enable affected rules to restore them to a functional state. These actions generate new API keys using the credentials of the user performing these actions. The rules' statuses are also reset.
+To restore the affected rules and reset their statuses, complete the following.
 
-NOTE: To restore failed custom and prebuilt rules, you need privileges to <<enable-detections-ui, manage rules>>.
+*Restore affected custom and prebuilt rules*
 
-*Restore custom rules*
+IMPORTANT: To restore custom and prebuilt rules, you need privileges to <<enable-detections-ui, manage rules>>.
 
-Follow these steps:
-
-. Go to the *Rules* page (*Detect -> Rules*) and click *Custom rules*.
-. Sort the rules table by the *Enabled* column to show enabled rules.
+. Go to the Rules page (*Detect -> Rules*).
+. Click the *Rows per page* menu under the rules table and select *100 rows*.
+. In the rules table, click the *Rule* column to sort by rule name.
+. Identify affected rules. They will have a `Failed` status in the *Last response* column.
 . Select the affected rules, then click *Bulk actions -> Disable*.
+. Select the same rules, then click *Bulk actions -> Enable*.
 +
-NOTE: Affected rules will have a `Failed` execution status and the aforementioned error message in the rule's details.
+NOTE: After you've re-enabled the affected rules, the rules' *Last Response* values will change to `Pending` and then update to `Active` or `OK`.
 
-. Select the affected rules, then click *Bulk actions -> Tags -> Add Tags*. Add a descriptive tag, for example `rules_to_fix`.
-. Re-select the same rules, then click *Bulk actions -> Enable*.
-. Add a descriptive tag, for example `rules_to_fix`. Adding a tag will generate new API keys and solve the issue.
-. Follow these steps if you don't want to wait until the next scheduled rule execution (optional):
-.. From the rules table, filter for the tag you just applied to your custom rules.
-.. Click *Select all x rules* above the rules table.
-.. Click *Bulk actions -> Disable*.
-.. Filter the rules table for the same tag, re-select the same rules, and then click *Bulk actions -> Enable*.
+. Go to the next page of results for the rules table and repeat steps 1 through 6.
 
-Once the rule runs, the *Last Response* value for the rule will change to `Pending`, and then to `Active` or `OK`.
+*Restore affected custom rules only*
 
-*Restore prebuilt rules*
-
-Follow these steps:
-
-. Use the <<rules-api-find, Find rules API>> to capture a list of enabled rules before you upgrade. Here is a curl command that you can run to find enabled prebuilt rules:
-+
-[source,console]
---------------------------------------------------
-GET api/detection_engine/rules/_find?page=1&per_page=1000&sort_field=name&sort_order=asc&filter=alert.attributes.enabled:true and alert.attributes.params.immutable: true
---------------------------------------------------
+IMPORTANT: To restore custom rules, you need privileges to <<enable-detections-ui, manage rules>>.
 
 . Go to the *Rules* page (*Detect -> Rules*) and click *Elastic rules*.
-. Sort the rules table by the *Enabled* column to show enabled rules.
-. Select the affected rules, then click *Bulk actions -> Disable*.
-+
-NOTE: Affected rules will have a `Failed` execution status and the aforementioned error message in the rule's details.
+. Switch on the *Technical preview* toggle above the table.
+. In the rules table, click *Custom rules*.
+. Sort the rules table by the *Last Response* column to show the latest rule statuses.
+. Select rules with the `Failed` status, then click *Bulk actions -> Tags -> Add Tags*.
+. Add a new tag, for example `rules_to_fix`.
 
-. Re-select the same rules.
-+
-TIP: Click the *Rule* column to sort by rule name and then compare the table results to the results of the API call you ran in step 1.
-
-.  Click *Bulk actions -> Enable*.
-
-Once the rule runs, the *Last Response* value for the rule will change to `Pending`, and then to `Active` or `OK`.
+Adding a tag will generate new API keys and resolve the bug. On the next scheduled rule execution, the *Last Response* value for the rule will change to `Pending`, and then to `Active` or `OK`.
 
 [discrete]
 [[bug-fixes-8.3.1]]
@@ -91,16 +62,7 @@ Once the rule runs, the *Last Response* value for the rule will change to `Pendi
 [[known-issue-8.3.0]]
 ==== Known issue
 
-8.3.0 has a bug where detection rules that were created or edited in 8.2 will stop running after you upgrade. Because of this, we advise against upgrading from 8.2 to 8.3.0. If you want to upgrade, _we highly recommend that you track your active rules beforehand so you can easily find and re-enable them after you upgrade_. Use the <<rules-api-find, Find rules API>> to capture a list of enabled rules before you upgrade.
-
-NOTE: Use curl or another HTTP tool to run {elastic-sec} API commands.
-
-Here is a curl command that you can run to find enabled rules:
-
-[source,console]
---------------------------------------------------
-GET /api/detection_engine/rules/_find?per_page=10000&filter=alert.attributes.enabled:true
---------------------------------------------------
+8.3.0 has a bug where detection rules that were created or edited in 8.2 will stop running after you upgrade. Because of this, we advise against upgrading from 8.2 to 8.3.0.
 
 If you already upgraded from 8.2 to 8.3.0, detection rules affected by the bug will have stopped running with an error that is similar to the following example:
 
@@ -109,55 +71,33 @@ If you already upgraded from 8.2 to 8.3.0, detection rules affected by the bug w
 <rule-type>:<UUID>: execution failed - security_exception: [security_exception] Reason: missing authentication credentials for REST request [/_security/user/_has_privileges], caused by: ""
 ----
 
-You will need to disable, then re-enable affected rules to restore them to a functional state. These actions generate new API keys using the credentials of the user performing these actions. The rules' states are also reset.
+*Restore affected custom and prebuilt rules*
 
-NOTE: To restore failed custom and prebuilt rules, you need privileges to <<enable-detections-ui, manage rules>>.
+IMPORTANT: To restore custom and prebuilt rules, you need privileges to <<enable-detections-ui, manage rules>>.
 
-*Restore custom rules*
-
-Follow these steps:
-
-. Go to the *Rules* page (*Detect -> Rules*) and click *Custom rules*.
-. Sort the rules table by the *Enabled* column to show enabled rules.
+. Go to the Rules page (*Detect -> Rules*).
+. Click the *Rows per page* menu under the rules table and select *100 rows*.
+. In the rules table, click the *Rule* column to sort by rule name.
+. Identify affected rules. They will have a `Failed` status in the *Last response* column.
 . Select the affected rules, then click *Bulk actions -> Disable*.
+. Select the same rules, then click *Bulk actions -> Enable*.
 +
-NOTE: Affected rules will have a `Failed` execution status and the aforementioned error message in the rule's details.
+NOTE: After you've re-enabled the affected rules, the rules' *Last Response* values will change to `Pending` and then update to `Active` or `OK`.
 
-. Select the affected rules, then click *Bulk actions -> Tags -> Add Tags*. Add a descriptive tag, for example `rules_to_fix`.
-. Re-select the same rules, then click *Bulk actions -> Enable*.
-. Add a descriptive tag, for example `rules_to_fix`. Adding a tag will generate new API keys and solve the issue.
-. Follow these steps if you don't want to wait until the next scheduled rule execution (optional):
-.. From the rules table, filter for the tag you just applied to your custom rules.
-.. Click *Select all x rules* above the rules table.
-.. Click *Bulk actions -> Disable*.
-.. Filter the rules table for the same tag, re-select the same rules, and then click *Bulk actions -> Enable*.
+. Go to the next page of results for the rules table and repeat steps 1 through 6.
 
-Once the rule runs, the *Last Response* value for the rule will change to `Pending`, and then to `Active` or `OK`.
+*Restore affected custom rules only*
 
-*Restore prebuilt rules*
-
-Follow these steps:
-
-. Use the <<rules-api-find, Find rules API>> to capture a list of enabled rules before you upgrade. Here is a curl command that you can run to find enabled prebuilt rules:
-+
-[source,console]
---------------------------------------------------
-GET api/detection_engine/rules/_find?page=1&per_page=1000&sort_field=name&sort_order=asc&filter=alert.attributes.enabled:true and alert.attributes.params.immutable: true
---------------------------------------------------
+IMPORTANT: To restore custom rules, you need privileges to <<enable-detections-ui, manage rules>>.
 
 . Go to the *Rules* page (*Detect -> Rules*) and click *Elastic rules*.
-. Sort the rules table by the *Enabled* column to show enabled rules.
-. Select the affected rules, then click *Bulk actions -> Disable*.
-+
-NOTE: Affected rules will have a `Failed` execution status and the aforementioned error message in the rule's details.
+. Switch on the *Technical preview* toggle above the table.
+. In the rules table, click *Custom rules*.
+. Sort the rules table by the *Last Response* column to show the latest rule statuses.
+. Select rules with the `Failed` status, then click *Bulk actions -> Tags -> Add Tags*.
+. Add a new tag, for example `rules_to_fix`.
 
-. Re-select the same rules.
-+
-TIP: Click the *Rule* column to sort by rule name and then compare the table results to the results of the API call you ran in step 1.
-
-.  Click *Bulk actions -> Enable*.
-
-Once the rule runs, the *Last Response* value for the rule will change to `Pending`, and then to `Active` or `OK`.
+Adding a tag will generate new API keys and resolve the bug. On the next scheduled rule execution, the *Last Response* value for the rule will change to `Pending`, and then to `Active` or `OK`.
 
 [discrete]
 [[breaking-changes-8.3.0]]

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -23,6 +23,8 @@ Example error message::
 
 IMPORTANT: Note that the *Update API key* option forces the detection rule to run with the privileges of the user selecting the option. As such, the user should have the equivalent Kibana roles and privileges that the most recent rule editors had.
 
+*Resolving the error using the {security-app} UI*
+
 If you're unable to access the Rules and Connectors table, and multiple custom and prebuilt rules were affected, you can resolve the error and then restart your rules from the Rules page. Follow these steps:
 
 . Identify affected rules. You can do this manually from the Rules page (*Detect -> Rules*) or by running the following query from Console:
@@ -86,6 +88,8 @@ Example error message::
 ----
 
 IMPORTANT: Note that the *Update API key* option forces the detection rule to run with the privileges of the user selecting the option. As such, the user should have the equivalent Kibana roles and privileges that the most recent rule editors had.
+
+*Resolving the error using the {security-app} UI*
 
 If you're unable to access the Rules and Connectors table, and multiple custom and prebuilt rules were affected, you can resolve the error and then restart your rules from the Rules page. Follow these steps:
 

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -109,7 +109,7 @@ If you already upgraded from 8.2 to 8.3.0, detection rules affected by the bug w
 <rule-type>:<UUID>: execution failed - security_exception: [security_exception] Reason: missing authentication credentials for REST request [/_security/user/_has_privileges], caused by: ""
 ----
 
-You will need to disable, then re-enable affected rules to restore them to a functional state. These actions generate a new API key using the credentials of the user performing these actions. The rules' states are also reset.
+You will need to disable, then re-enable affected rules to restore them to a functional state. These actions generate new API keys using the credentials of the user performing these actions. The rules' states are also reset.
 
 NOTE: To restore failed custom and prebuilt rules, you need privileges to <<enable-detections-ui, manage rules>>.
 

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -20,6 +20,7 @@ If you already upgraded from 8.2 to 8.3.1, detection rules affected by the bug w
 ----
 
 To restore the affected rules and reset their statuses, complete the following.
+IMPORTANT: You will need <<enable-detections-ui, manage rules>> privileges.
 
 *Restore affected custom and prebuilt rules*
 

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -45,9 +45,9 @@ IMPORTANT: To restore custom rules, you need privileges to <<enable-detections-u
 . In the rules table, click *Custom rules*.
 . Sort the rules table by the *Last Response* column to show the latest rule statuses.
 . Select rules with the `Failed` status, then click *Bulk actions -> Tags -> Add Tags*.
-. Add a new tag, for example `rules_to_fix`.
+. Add a new tag, for example `rules_to_fix`. This will generate new API keys and resolve the bug.
 
-Adding a tag will generate new API keys and resolve the bug. On the next scheduled rule execution, the *Last Response* value for the rule will change to `Pending`, and then to `Active` or `OK`.
+On the next scheduled rule execution, the *Last Response* value for the rule will change to `Pending`, and then to `Active` or `OK`.
 
 [discrete]
 [[bug-fixes-8.3.1]]
@@ -70,6 +70,8 @@ If you already upgraded from 8.2 to 8.3.0, detection rules affected by the bug w
 ----
 <rule-type>:<UUID>: execution failed - security_exception: [security_exception] Reason: missing authentication credentials for REST request [/_security/user/_has_privileges], caused by: ""
 ----
+
+To restore the affected rules and reset their statuses, complete the following.
 
 *Restore affected custom and prebuilt rules*
 
@@ -95,9 +97,9 @@ IMPORTANT: To restore custom rules, you need privileges to <<enable-detections-u
 . In the rules table, click *Custom rules*.
 . Sort the rules table by the *Last Response* column to show the latest rule statuses.
 . Select rules with the `Failed` status, then click *Bulk actions -> Tags -> Add Tags*.
-. Add a new tag, for example `rules_to_fix`.
+. Add a new tag, for example `rules_to_fix`. This will generate new API keys and resolve the bug.
 
-Adding a tag will generate new API keys and resolve the bug. On the next scheduled rule execution, the *Last Response* value for the rule will change to `Pending`, and then to `Active` or `OK`.
+On the next scheduled rule execution, the *Last Response* value for the rule will change to `Pending`, and then to `Active` or `OK`.
 
 [discrete]
 [[breaking-changes-8.3.0]]

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -8,15 +8,11 @@
 
 [discrete]
 [[known-issue-8.3.1]]
-==== Known issues
+==== Known issue
 
-Detection rule users who are running 8.2 should not upgrade to either 8.3.0 or 8.3.1.
-Both 8.3.0 and 8.3.1 have a bug where detection rules that were created or edited
-in 8.2 will stop running on upgrade.
+Detection rule users who are running 8.2 should not upgrade to either 8.3.0 or 8.3.1. Both 8.3.0 and 8.3.1 have a bug where detection rules that were created or edited in 8.2 will stop running on upgrade.
 
-If you have upgraded to 8.3.0 or 8.3.1 and
-your detection rules have stopped running with an error similar to the following
-example, you will need to deactivate your rules and then reactivate them on to restore them to a functional state.
+If you have upgraded to 8.3.0 or 8.3.1 and your detection rules have stopped running with an error similar to the following example, you will need to deactivate your rules and then reactivate them on to restore them to a functional state.
 
 Example error message::
 
@@ -44,15 +40,11 @@ Alernatively, you can use the <<bulk-actions-rules-api-action, Bulk rule actions
 
 [discrete]
 [[known-issue-8.3.0]]
-==== Known issues
+==== Known issue
 
-Detection rule users who are running 8.2 should not upgrade to either 8.3.0 or 8.3.1.
-Both 8.3.0 and 8.3.1 have a bug where detection rules that were created or edited
-in 8.2 will stop running on upgrade.
+Detection rule users who are running 8.2 should not upgrade to either 8.3.0 or 8.3.1. Both 8.3.0 and 8.3.1 have a bug where detection rules that were created or edited in 8.2 will stop running on upgrade.
 
-If you have upgraded to 8.3.0 or 8.3.1 and
-your detection rules have stopped running with an error similar to the following
-example, you will need to deactivate your rules and then reactivate them on to restore them to a functional state.
+If you have upgraded to 8.3.0 or 8.3.1 and your detection rules have stopped running with an error similar to the following example, you will need to deactivate your rules and then reactivate them on to restore them to a functional state.
 
 Example error message::
 

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -10,9 +10,7 @@
 [[known-issue-8.3.1]]
 ==== Known issue
 
-8.3.1 has a bug where detection rules that were created or edited in 8.2 will stop running after you upgrade. Because of this, we advise against upgrading from 8.2 to 8.3.1.
-
-If you want to upgrade, _we highly recommend that you track your active rules beforehand so you can easily find and re-enable them after you upgrade_. Use the <<rules-api-find, Find rules API>> to capture a list of enabled rules before you upgrade.
+8.3.1 has a bug where detection rules that were created or edited in 8.2 will stop running after you upgrade. Because of this, we advise against upgrading from 8.2 to 8.3.1. If you want to upgrade, _we highly recommend that you track your active rules beforehand so you can easily find and re-enable them after you upgrade_. Use the <<rules-api-find, Find rules API>> to capture a list of enabled rules before you upgrade.
 
 NOTE: Use curl or another HTTP tool to run {elastic-sec} API commands.
 
@@ -23,20 +21,20 @@ Here is a curl command that you can run to find enabled rules:
 GET /api/detection_engine/rules/_find?per_page=10000&filter=alert.attributes.enabled:true
 --------------------------------------------------
 
-After upgrading, detection rules affected by the bug will have stopped running with an error that is similar to the following example:
+If you already upgraded from 8.2 to 8.3.1, detection rules affected by the bug will have stopped running with an error that is similar to the following example:
 
 [source,text]
 ----
 <rule-type>:<UUID>: execution failed - security_exception: [security_exception] Reason: missing authentication credentials for REST request [/_security/user/_has_privileges], caused by: ""
 ----
 
-You will need to disable, then re-enable affected rules to restore them to a functional state. Doing so will generate a new API key using the credentials of the user performing these actions and reset the rule state.
+You will need to disable, then re-enable affected rules to restore them to a functional state. These actions generate new API keys using the credentials of the user performing these actions. The rules' states are also reset.
 
 NOTE: To complete these steps, you need privileges to <<manage rules, enable-detections-ui>>
 
 . Go to the *Rules* page (*Detect -> Rules*).
 . Select the affected rules, then click *Bulk actions -> Disable*.
-. Refer to the list of enabled rules you gathered earlier, re-select them, then click *Bulk actions -> Enable*.
+. Re-select the same rules, then click *Bulk actions -> Enable*.
 
 After you've re-enabled the rules, the *Last Response* value for the rule will change to `Pending`, and then to `Active` or `OK`.
 
@@ -53,9 +51,7 @@ After you've re-enabled the rules, the *Last Response* value for the rule will c
 [[known-issue-8.3.0]]
 ==== Known issue
 
-8.3.0 has a bug where detection rules that were created or edited in 8.2 will stop running after you upgrade. Because of this, we advise against upgrading from 8.2 to 8.3.0.
-
-If you want to upgrade, _we highly recommend that you track your active rules beforehand so you can easily find and re-enable them after you upgrade_. Use the <<rules-api-find, Find rules API>> to capture a list of enabled rules before you upgrade.
+8.3.0 has a bug where detection rules that were created or edited in 8.2 will stop running after you upgrade. Because of this, we advise against upgrading from 8.2 to 8.3.0. If you want to upgrade, _we highly recommend that you track your active rules beforehand so you can easily find and re-enable them after you upgrade_. Use the <<rules-api-find, Find rules API>> to capture a list of enabled rules before you upgrade.
 
 NOTE: Use curl or another HTTP tool to run {elastic-sec} API commands.
 
@@ -66,20 +62,20 @@ Here is a curl command that you can run to find enabled rules:
 GET /api/detection_engine/rules/_find?per_page=10000&filter=alert.attributes.enabled:true
 --------------------------------------------------
 
-After upgrading, detection rules affected by the bug will have stopped running with an error that is similar to the following example:
+If you already upgraded from 8.2 to 8.3.0, detection rules affected by the bug will have stopped running with an error that is similar to the following example:
 
 [source,text]
 ----
 <rule-type>:<UUID>: execution failed - security_exception: [security_exception] Reason: missing authentication credentials for REST request [/_security/user/_has_privileges], caused by: ""
 ----
 
-You will need to disable, then re-enable affected rules to restore them to a functional state. Doing so will generate a new API key using the credentials of the user performing these actions and reset the rule state. 
+You will need to disable, then re-enable affected rules to restore them to a functional state. These actions generate a new API key using the credentials of the user performing these actions. The rules' states are also reset.
 
 NOTE: To complete the following steps, you need privileges to <<manage rules, enable-detections-ui>>
 
 . Go to the *Rules* page (*Detect -> Rules*).
 . Select the affected rules, then click *Bulk actions -> Disable*.
-. Refer to the list of enabled rules you gathered earlier, re-select them, then click *Bulk actions -> Enable*.
+. Re-select the same rules, then click *Bulk actions -> Enable*.
 
 After you've re-enabled the rules, the *Last Response* value for the rule will change to `Pending`, and then to `Active` or `OK`.
 

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -10,9 +10,9 @@
 [[known-issue-8.3.1]]
 ==== Known issue
 
-8.3.1 has a bug where detection rules that were created or edited in 8.2 will stop running after you upgrade. Because of this, we advise against upgrading from 8.2 to 8.3.1.
+8.3.1 has a bug where detection rules that were created or edited in 8.2.x will stop running after you upgrade. Because of this, we advise against upgrading from 8.2.x to 8.3.1.
 
-If you already upgraded from 8.2 to 8.3.1, detection rules affected by the bug will have stopped running with an error that is similar to the following example:
+If you already upgraded from 8.2.x to 8.3.1, detection rules affected by the bug will have stopped running with an error that is similar to the following example:
 
 [source,text]
 ----
@@ -62,9 +62,9 @@ On the next scheduled rule execution, the *Last Response* value for the rule wil
 [[known-issue-8.3.0]]
 ==== Known issue
 
-8.3.0 has a bug where detection rules that were created or edited in 8.2 will stop running after you upgrade. Because of this, we advise against upgrading from 8.2 to 8.3.0.
+8.3.0 has a bug where detection rules that were created or edited in 8.2.x will stop running after you upgrade. Because of this, we advise against upgrading from 8.2.x to 8.3.0.
 
-If you already upgraded from 8.2 to 8.3.0, detection rules affected by the bug will have stopped running with an error that is similar to the following example:
+If you already upgraded from 8.2.x to 8.3.0, detection rules affected by the bug will have stopped running with an error that is similar to the following example:
 
 [source,text]
 ----

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -30,7 +30,7 @@ If you already upgraded from 8.2 to 8.3.1, detection rules affected by the bug w
 
 You will need to disable, then re-enable affected rules to restore them to a functional state. These actions generate new API keys using the credentials of the user performing these actions. The rules' states are also reset.
 
-NOTE: To complete these steps, you need privileges to <<manage rules, enable-detections-ui>>
+NOTE: To complete these steps, you need privileges to <<enable-detections-ui, manage rules>>.
 
 . Go to the *Rules* page (*Detect -> Rules*).
 . Select the affected rules, then click *Bulk actions -> Disable*.
@@ -71,7 +71,7 @@ If you already upgraded from 8.2 to 8.3.0, detection rules affected by the bug w
 
 You will need to disable, then re-enable affected rules to restore them to a functional state. These actions generate a new API key using the credentials of the user performing these actions. The rules' states are also reset.
 
-NOTE: To complete the following steps, you need privileges to <<manage rules, enable-detections-ui>>
+NOTE: To complete the following steps, you need privileges to  <<enable-detections-ui, manage rules>>.
 
 . Go to the *Rules* page (*Detect -> Rules*).
 . Select the affected rules, then click *Bulk actions -> Disable*.


### PR DESCRIPTION
Addresses https://github.com/elastic/security-docs/issues/2180.

Previews:
- [8.3.0 release notes | Known issue](https://security-docs_2181.docs-preview.app.elstc.co/guide/en/security/master/release-notes-header-8.3.0.html#known-issue-8.3.0)
- [8.3.1 release notes | Known issue](https://security-docs_2181.docs-preview.app.elstc.co/guide/en/security/master/release-notes-header-8.3.0.html#known-issue-8.3.1)