### PR TITLE
[BUG] Fixes typo in 8.3.2 release notes

### DIFF
--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -9,7 +9,7 @@
 [[bug-fixes-8.3.2]]
 ==== Bug fixes and enhancements
 * Allows indices created from value lists to be used with indicator match rules ({pull}135128[#135128]).
-* Fixes a bug that prevented the "Create field" button from appearing in the Fields menu when you accessed it from a Timeline created using the Alerts page's "Open in timeline" button. ({pull}135842[#135842])
+* Fixes a bug that prevented the *Create field* button from appearing in the Fields menu when you accessed it from a Timeline created using the Alerts page's *Open in timeline* button ({pull}135842[#135842]).
 
 [discrete]
 [[release-notes-8.3.1]]


### PR DESCRIPTION
Minor editoral fixes. Preview here. 