### PR TITLE
[DOCS] Add #135663 to 8.3.2 release notes

### DIFF
--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -10,7 +10,7 @@
 ==== Bug fixes and enhancements
 * Allows indices created from value lists to be used with indicator match rules ({pull}135128[#135128]).
 * Fixes a bug that prevented the *Create field* button from appearing in the Fields menu when you accessed it from a Timeline created using the Alerts page's *Open in timeline* button ({pull}135842[#135842]).
-* Fixes an issue where detection rules that were created or edited in 8.2.x failed to execute after you upgraded to {stack} to 8.3.0 or 8.3.1 ({pull}135663[#135663]).
+* Fixes an issue where detection rules that were created or edited in 8.2.x failed to execute after you upgraded to {stack} 8.3.0 or 8.3.1 ({pull}135663[#135663]).
 
 ====
 


### PR DESCRIPTION
Addresses https://github.com/elastic/security-docs/issues/2188.

Preview [here](https://security-docs_2189.docs-preview.app.elstc.co/guide/en/security/master/release-notes-header-8.3.0.html#release-notes-8.3.2). 