### PR TITLE
[DOCS] Add stub pages for endpoint docs links

### DIFF
--- a/docs/management/admin/response-actions.asciidoc
+++ b/docs/management/admin/response-actions.asciidoc
@@ -1,0 +1,4 @@
+[[response-actions]]
+= Endpoint response actions
+
+This page is a placeholder for future documentation.

--- a/docs/management/manage-intro.asciidoc
+++ b/docs/management/manage-intro.asciidoc
@@ -5,6 +5,7 @@
 The following section provides an overview of the management tools admins can use to manage endpoints, integration policies, trusted applications, event filters, host isolation exceptions, and blocked applications.
 
 include::{security-docs-root}/docs/management/admin/admin-pg-ov.asciidoc[leveloffset=+1]
+include::{security-docs-root}/docs/management/admin/response-actions.asciidoc[leveloffset=+2]
 include::{security-docs-root}/docs/management/admin/host-isolation-ov.asciidoc[leveloffset=+2]
 include::{security-docs-root}/docs/management/admin/policy-list.asciidoc[leveloffset=+1]
 include::{security-docs-root}/docs/management/admin/trusted-apps.asciidoc[leveloffset=+1]

--- a/docs/troubleshooting/management/ts-management.asciidoc
+++ b/docs/troubleshooting/management/ts-management.asciidoc
@@ -31,3 +31,11 @@ image::images/transforms-start.png[Transforms page with Start option selected]
 . On the confirmation message that displays, click *Start* to restart the transform.
 . The transform’s status changes to `started`. Refresh the page if you don't see the change.
 ====
+
+[discrete]
+[[linux-deadlock]]
+.Disabled to avoid potential system deadlock
+[%collapsible]
+====
+This section is a placeholder for future documentation.
+====


### PR DESCRIPTION
Endpoint & OLM teams need resolvable URLs for a couple of docs links in the UI. This PR creates the needed placeholder stubs, and I'll follow up with complete docs in these issues:

- https://github.com/elastic/security-docs/issues/2211
- https://github.com/elastic/security-docs/issues/2197

Note: These issues aren't necessarily related, but I combined the stub creation into a single PR for convenience. The complete docs will be added in separate PRs.

---

### Previews
- [Endpoint response actions](https://security-docs_2282.docs-preview.app.elstc.co/guide/en/security/master/response-actions.html)
- [Troubleshooting | Management tools | Endpoints | Disabled to avoid potential system deadlock](https://security-docs_2282.docs-preview.app.elstc.co/guide/en/security/master/ts-management.html)