### PR TITLE
[DOCS] Updates Session View topic with links to Kubernetes dashboard topic

### DIFF
--- a/docs/detections/session-view.asciidoc
+++ b/docs/detections/session-view.asciidoc
@@ -33,7 +33,7 @@ fields collected by {endpoint-cloud-sec} when this setting is enabled, refer to 
 [float]
 [[open-session-view]]
 === Open Session View
-Session View is accessible from the **Hosts**, **Alerts**, and **Timelines** pages, as well as the **Kubernetes dashboard**.
+Session View is accessible from the **Hosts**, **Alerts**, and **Timelines** pages, as well as the **Kubernetes** dashboard.
 Events and sessions that you can investigate in Session View have a rectangular
 *Open Session View* button in the *Actions* column. For example:
 

--- a/docs/detections/session-view.asciidoc
+++ b/docs/detections/session-view.asciidoc
@@ -17,6 +17,8 @@ and investigating session activity on your Linux infrastructure and understandin
 * *Nested sessions:* Sessions started by processes descended from the entry session.
 * *Alerts:* Alerts in the context of the processes which caused them.
 
+NOTE: To view Linux session data from your Kubernetes infrastructure, you'll need to set up <<kubernetes-dashboard,the Kubernetes dashboard>>. 
+
 [float]
 [[enable-session-view]]
 === Enable Session View data
@@ -31,7 +33,7 @@ fields collected by {endpoint-cloud-sec} when this setting is enabled, refer to 
 [float]
 [[open-session-view]]
 === Open Session View
-Session View is accessible from the **Hosts**, **Alerts**, and **Timelines** pages.
+Session View is accessible from the **Hosts**, **Alerts**, and **Timelines** pages, as well as the **Kubernetes dashboard**.
 Events and sessions that you can investigate in Session View have a rectangular
 *Open Session View* button in the *Actions* column. For example:
 

--- a/docs/detections/session-view.asciidoc
+++ b/docs/detections/session-view.asciidoc
@@ -17,7 +17,7 @@ and investigating session activity on your Linux infrastructure and understandin
 * *Nested sessions:* Sessions started by processes descended from the entry session.
 * *Alerts:* Alerts in the context of the processes which caused them.
 
-NOTE: To view Linux session data from your Kubernetes infrastructure, you'll need to set up <<kubernetes-dashboard,the Kubernetes dashboard>>. 
+NOTE: To view Linux session data from your Kubernetes infrastructure, you'll need to set up the <<kubernetes-dashboard,Kubernetes dashboard>>. 
 
 [float]
 [[enable-session-view]]


### PR DESCRIPTION
Fixes #2214 by adding links to the Session view page that refer users to the Kubernetes dashboard page so they will know that Session view can help them view Kubernetes data.