### PR TITLE
[7.17] [DOCS] Add notes about security for ML anomaly detection job results (#2288)

### DIFF
--- a/docs/detections/machine-learning/machine-learning.asciidoc
+++ b/docs/detections/machine-learning/machine-learning.asciidoc
@@ -2,9 +2,9 @@
 [role="xpack"]
 = Anomaly Detection with Machine Learning
 
-{kibana-ref}/xpack-ml.html[{ml-cap}] functionality is available when
-you have the *https://www.elastic.co/subscriptions[appropriate license]*, are
-using a *{ess-trial}[cloud deployment]*, or are testing out a *Free Trial*.
+{ml-docs}/ml-overview.html[{ml-cap}] functionality is available when
+you have the appropriate subscription, are using a *{ess-trial}[cloud deployment]*,
+or are testing out a *Free Trial*. Refer to <<ml-requirements>>.
 
 You can view the details of detected anomalies within the `Anomalies` table
 widget shown on the Hosts, Network, and associated details pages, or even narrow

--- a/docs/getting-started/ml-req.asciidoc
+++ b/docs/getting-started/ml-req.asciidoc
@@ -3,7 +3,20 @@
 
 To run and create {ml} jobs and rules, you need all of these:
 
-* The *https://www.elastic.co/subscriptions[appropriate license]*
-* There must be at least one {ml} node in your cluster (see {ml-docs}/setup.html[Set up {ml} features])
-* The `machine_learning_admin` user role (see
-{ref}/built-in-roles.html[Built-in roles])
+* The {subscriptions}[appropriate license]
+* There must be at least one {ml} node in your cluster
+* The `machine_learning_admin` user role
+
+For more information, go to {ml-docs}/setup.html[Set up {ml-features}].
+
+[IMPORTANT]
+====
+The `machine_learning_admin` and `machine_learning_user` built-in roles give
+access to the results of _all_ {anomaly-jobs}, irrespective of whether the user
+has access to the source indices. Likewise, a user who has full or read-only
+access to {ml-features} within a given {kib} space can view the results of _all_
+{anomaly-jobs} that are visible in that space. You must carefully consider who
+is given these roles and feature privileges; {anomaly-job} results may propagate
+field values that contain sensitive information from the source indices to the
+results.
+====


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[DOCS] Add notes about security for ML anomaly detection job results (#2288)](https://github.com/elastic/security-docs/pull/2288)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)