### PR TITLE
[DOCS] 7.17.6 Release notes 

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.17.6, {elastic-sec} version 7.17.6>>
 * <<release-notes-7.17.5, {elastic-sec} version 7.17.5>>
 * <<release-notes-7.17.4, {elastic-sec} version 7.17.4>>
 * <<release-notes-7.17.3, {elastic-sec} version 7.17.3>>

--- a/docs/release-notes/7.17.asciidoc
+++ b/docs/release-notes/7.17.asciidoc
@@ -2,6 +2,16 @@
 == 7.17
 
 [discrete]
+[[release-notes-7.17.6]]
+=== 7.17.6
+
+[discrete]
+[[bug-fixes-7.17.6]]
+==== Bug fixes and enhancements
+
+There are no user-facing changes in the 7.17.6 release.
+
+[discrete]
 [[release-notes-7.17.5]]
 === 7.17.5
 


### PR DESCRIPTION
Addresses https://github.com/elastic/security-docs/issues/2334. 

Previews:
- [Index page](https://security-docs_2350.docs-preview.app.elstc.co/guide/en/security/7.17/release-notes.html)
- [Release notes](https://security-docs_2350.docs-preview.app.elstc.co/guide/en/security/7.17/release-notes-header-7.17.0.html#bug-fixes-7.17.6)