### PR TITLE
Update K8s Dashboard Docs with the correct URL

### DIFF
--- a/docs/dashboards/kubernetes-dashboard.asciidoc
+++ b/docs/dashboards/kubernetes-dashboard.asciidoc
@@ -3,7 +3,7 @@
 
 The Kubernetes dashboard provides insight into Linux process data from your Kubernetes clusters. It shows sessions in detail and in the context of your monitored infrastructure.
 
-image::kubernetes-dashboard.png[The Kubernetes dashboard, with numbered labels 1 through 3 for major sections]
+image::images/kubernetes-dashboard.png[The Kubernetes dashboard, with numbered labels 1 through 3 for major sections]
 The numbered sections are described below:
 
   1. The charts at the top of the dashboard provide an overview of your monitored Kubernetes infrastructure. You can hide them by clicking *Hide charts*.
@@ -22,7 +22,7 @@ From the sessions table's Actions column, you can take the following investigati
 
 Session View displays Kubernetes metadata under the *Metadata* tab of the Detail panel:
 
-image::metadata-tab.png[The Detail panel's metadata tab]
+image::images/metadata-tab.png[The Detail panel's metadata tab]
 
 The *Metadata* tab is organized into these expandable sections:
 
@@ -57,14 +57,14 @@ The DaemonSet integrates {elastic-endpoint} into your Kubernetes cluster. The {a
 
 You first need to download the DaemonSet manifest `.yaml`, then modify it to include your {fleet} URL and Enrollment Token before you deploy it to the clusters you want to monitor.
 
-1. Download the DaemonSet manifest using the command: 
+- Download the DaemonSet manifest using the command: 
 [source,console]
 ----
 curl -L -O https://raw.githubusercontent.com/elastic/endpoint/main/releases/8.4.0/kubernetes/deploy/elastic-endpoint-security.yaml
 ----
-[start=2]
-2. Fill in the manifest's `FLEET_URL` field with your {fleet} server's `Host URL`. To find it, go to **{kib} -> Management -> {fleet} -> Settings**. For more information, refer to {fleet-guide}/fleet-settings.html[Fleet UI settings].
-3. Fill in the manifest's `FLEET_ENROLLMENT_TOKEN` field with a Fleet enrollment token. To find one, go to **{kib} -> Management -> {fleet} -> Enrollment tokens**. For more information, refer to {fleet-guide}/fleet-enrollment-tokens.html[Fleet enrollment tokens].
+
+- Fill in the manifest's `FLEET_URL` field with your {fleet} server's `Host URL`. To find it, go to **{kib} -> Management -> {fleet} -> Settings**. For more information, refer to {fleet-guide}/fleet-settings.html[Fleet UI settings].
+- Fill in the manifest's `FLEET_ENROLLMENT_TOKEN` field with a Fleet enrollment token. To find one, go to **{kib} -> Management -> {fleet} -> Enrollment tokens**. For more information, refer to {fleet-guide}/fleet-enrollment-tokens.html[Fleet enrollment tokens].
 
 
 [discrete]

--- a/docs/dashboards/kubernetes-dashboard.asciidoc
+++ b/docs/dashboards/kubernetes-dashboard.asciidoc
@@ -57,14 +57,15 @@ The DaemonSet integrates {elastic-endpoint} into your Kubernetes cluster. The {a
 
 You first need to download the DaemonSet manifest `.yaml`, then modify it to include your {fleet} URL and Enrollment Token before you deploy it to the clusters you want to monitor.
 
-- Download the DaemonSet manifest using the command: 
+. Download the DaemonSet manifest using this command: 
++
 [source,console]
 ----
 curl -L -O https://raw.githubusercontent.com/elastic/endpoint/main/releases/8.4.0/kubernetes/deploy/elastic-endpoint-security.yaml
 ----
 
-- Fill in the manifest's `FLEET_URL` field with your {fleet} server's `Host URL`. To find it, go to **{kib} -> Management -> {fleet} -> Settings**. For more information, refer to {fleet-guide}/fleet-settings.html[Fleet UI settings].
-- Fill in the manifest's `FLEET_ENROLLMENT_TOKEN` field with a Fleet enrollment token. To find one, go to **{kib} -> Management -> {fleet} -> Enrollment tokens**. For more information, refer to {fleet-guide}/fleet-enrollment-tokens.html[Fleet enrollment tokens].
+. Fill in the manifest's `FLEET_URL` field with your {fleet} server's `Host URL`. To find it, go to **{kib} -> Management -> {fleet} -> Settings**. For more information, refer to {fleet-guide}/fleet-settings.html[Fleet UI settings].
+. Fill in the manifest's `FLEET_ENROLLMENT_TOKEN` field with a Fleet enrollment token. To find one, go to **{kib} -> Management -> {fleet} -> Enrollment tokens**. For more information, refer to {fleet-guide}/fleet-enrollment-tokens.html[Fleet enrollment tokens].
 
 
 [discrete]

--- a/docs/dashboards/kubernetes-dashboard.asciidoc
+++ b/docs/dashboards/kubernetes-dashboard.asciidoc
@@ -57,7 +57,12 @@ The DaemonSet integrates {elastic-endpoint} into your Kubernetes cluster. The {a
 
 You first need to download the DaemonSet manifest `.yaml`, then modify it to include your {fleet} URL and Enrollment Token before you deploy it to the clusters you want to monitor.
 
-1. Download the DaemonSet manifest using the command: `curl -L -O https://raw.githubusercontent.com/elastic/main/releases/8.4.0/kubernetes/deploy/elastic-endpoint-security.yaml`
+1. Download the DaemonSet manifest using the command: 
+[source,console]
+----
+curl -L -O https://raw.githubusercontent.com/elastic/endpoint/main/releases/8.4.0/kubernetes/deploy/elastic-endpoint-security.yaml
+----
+[start=2]
 2. Fill in the manifest's `FLEET_URL` field with your {fleet} server's `Host URL`. To find it, go to **{kib} -> Management -> {fleet} -> Settings**. For more information, refer to {fleet-guide}/fleet-settings.html[Fleet UI settings].
 3. Fill in the manifest's `FLEET_ENROLLMENT_TOKEN` field with a Fleet enrollment token. To find one, go to **{kib} -> Management -> {fleet} -> Enrollment tokens**. For more information, refer to {fleet-guide}/fleet-enrollment-tokens.html[Fleet enrollment tokens].
 


### PR DESCRIPTION
#2368 [DOCS] YAML url needs a correction for k8s dashboard docs

Description:
- Updated the YAML link to the proper link
- Added the source,console block
- Continued the bullet points

Test Cases:
Validated that the URL is correct
Validated that the code block is on a new line
Validated that bullet points continue afterwards

Preview: [Kubernetes dashboard](https://security-docs_2369.docs-preview.app.elstc.co/guide/en/security/master/kubernetes-dashboard.html)