### PR TITLE
[BUG] Leftover text in table for detection privs

### DIFF
--- a/docs/getting-started/detections-req.asciidoc
+++ b/docs/getting-started/detections-req.asciidoc
@@ -80,7 +80,6 @@ a|The `manage`, `write`,`read`, and `view_index_metadata` index privileges for t
 * `.lists-<kib-space>`
 * `.items-<kib-space>`
 
-<<<<<<< HEAD
 | {kib} space `All` privileges for the `Security` feature (see
 {kibana-ref}/xpack-spaces.html#spaces-control-user-access[Feature access based on user privileges])
 


### PR DESCRIPTION
Addresses https://github.com/elastic/security-docs/issues/2370. 

Preview [here](https://security-docs_2371.docs-preview.app.elstc.co/guide/en/security/7.17/detections-permissions-section.html#enable-detections-ui). (Scroll down to row that shows privs for managing rules)