### PR TITLE
[8.2] Adds GitHub action to create preview links (#2391)

### DIFF
--- a/.github/workflows/docs-preview-links.yml
+++ b/.github/workflows/docs-preview-links.yml
@@ -1,0 +1,25 @@
+name: Docs Preview Links
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  doc-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        name: Add doc preview links
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const comment = `Documentation previews:
+              - ✨ [HTML diff](https://${context.repo.repo}_${pr.number}.docs-preview.app.elstc.co/diff)
+              - 📙 [Elastic Security Guide](https://${context.repo.repo}_${pr.number}.docs-preview.app.elstc.co/guide/en/security/master/index.html)`;
+            
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment,
+            });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [Adds GitHub action to create preview links (#2391)](https://github.com/elastic/security-docs/pull/2391)

<!--- Backport version: 8.5.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)