### PR TITLE
Correct 8.4.1 release notes

### DIFF
--- a/docs/release-notes/8.4.asciidoc
+++ b/docs/release-notes/8.4.asciidoc
@@ -9,7 +9,6 @@
 [[bug-fixes-8.4.1]]
 ==== Bug fixes and enhancements
 * Fixes a bug that caused the Rules page to incorrectly notify users that a prebuilt rules update was available, even after rules were fully updated ({pull}139287[#139287]).
-* Fixes bugs in the Rules table that affected the selected rule count and bulk select feature ({pull}139461[#139461]).
 
 [discrete]
 [[release-notes-8.4.0]]


### PR DESCRIPTION
Pull request [139461](https://github.com/elastic/kibana/pull/139461) did not make it to the **Build Candidate #2** for the 8.4.1 release, so it wasn't included in the Public Release.

Correcting the Release Notes to remove this change.

