### PR TITLE
Update unusual-parent-child-relationship.asciidoc

### DIFF
--- a/docs/detections/prebuilt-rules/rule-details/unusual-parent-child-relationship.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/unusual-parent-child-relationship.asciidoc
@@ -128,7 +128,7 @@ process.parent.name:"wininit.exe") or (process.name:"LogonUI.exe"
 and not process.parent.name:("wininit.exe", "winlogon.exe")) or
 (process.name:"services.exe" and not
 process.parent.name:"wininit.exe") or (process.name:"svchost.exe"
-and not process.parent.name:("MsMpEng.exe", "services.exe")) or
+and not process.parent.name:("MsMpEng.exe", "services.exe", "MRT.exe")) or
 (process.name:"spoolsv.exe" and not
 process.parent.name:"services.exe") or (process.name:"taskhost.exe"
 and not process.parent.name:("services.exe", "svchost.exe")) or


### PR DESCRIPTION
The "Microsoft Windows Malicious Software Removal Tool" can call "svchost.exe"