### PR TITLE
[DOCS] 8.4.2 Release notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.4.2, {elastic-sec} version 8.4.2>>
 * <<release-notes-8.4.1, {elastic-sec} version 8.4.1>>
 * <<release-notes-8.4.0, {elastic-sec} version 8.4.0>>
 * <<release-notes-8.3.3, {elastic-sec} version 8.3.3>>

--- a/docs/release-notes/8.4.asciidoc
+++ b/docs/release-notes/8.4.asciidoc
@@ -2,6 +2,21 @@
 == 8.4
 
 [discrete]
+[[release-notes-8.4.2]]
+=== 8.4.2
+
+[discrete]
+[[bug-fixes-8.4.2]]
+==== Bug fixes and enhancements
+* Disables Notes & Pinned tabs for timeline templates ({pull}140478[#140478]).
+* Fixes modal visibility ({pull}139929[#139929]).
+* Fixes selected rules count and clear selection label on bulk unselect rules with checkbox ({pull}139461[#139461]).
+* Fixes a bug that caused the Rules page to incorrectly notify users that a prebuilt rules update was available, even after rules were fully updated ({pull}139287[#139287]).
+* Bulk selection count doesn't get updated and bulk selection retains while user uncheck bulk selected rules checkbox ({pull}136616[#136616]).
+* Drag and drop field is not saved when investigate timeline from alerts table ({pull}132106[#132106]).
+* Fixes a bug that prevented users from accessing alert details if they didn't have the appropriate privileges to view the internal index `.internal.alerts-security.alerts-spaceId`. Now, the Alert details flyout correctly uses the public alias index `.alerts-security,akerts-spaceId` ({pull}138331[#138331]).
+
+[discrete]
 [[release-notes-8.4.1]]
 === 8.4.1
 


### PR DESCRIPTION
Addresses https://github.com/elastic/security-docs/issues/2428.

Previews:
- Index
- Release notes 