### PR TITLE
[8.4] [DOCS] 8.4.2 Release notes (#2455)

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.4.2, {elastic-sec} version 8.4.2>>
 * <<release-notes-8.4.1, {elastic-sec} version 8.4.1>>
 * <<release-notes-8.4.0, {elastic-sec} version 8.4.0>>
 * <<release-notes-8.3.3, {elastic-sec} version 8.3.3>>

--- a/docs/release-notes/8.4.asciidoc
+++ b/docs/release-notes/8.4.asciidoc
@@ -2,6 +2,25 @@
 == 8.4
 
 [discrete]
+[[release-notes-8.4.2]]
+=== 8.4.2
+
+[discrete]
+[[known-issue-8.4.2]]
+==== Known issues
+* A new Lucene 9 validation change may cause event correlation rule (EQL) errors whenever rule queries contain regular expressions using wildcard fields and predefined character classes (for example, `\w`, `\s`, `\d`).
+
+[discrete]
+[[bug-fixes-8.4.2]]
+==== Bug fixes and enhancements
+* Removes access to the **Notes** and **Pinned** tabs in Timeline templates ({pull}140478[#140478]).
+* Fixes a bug with the **Attach to existing case** option in Timeline ({pull}139929[#139929]).
+* Fixes bugs in the Rules table that affected the selected rule count and bulk select feature ({pull}139461[#139461]).
+* Fixes a bug that caused the Rules page to incorrectly notify users that a prebuilt rules update was available, even after rules were fully updated ({pull}139287[#139287]).
+* Fixes a bug that prevented users from accessing alert details if they didn't have the appropriate privileges to view the internal index `.internal.alerts-security.alerts-spaceId`. Now, the Alert details flyout correctly uses the public alias index `.alerts-security.alerts-<Kibana-space>` ({pull}138331[#138331]).
+* Aligns the warning message title on the Rule details page with the warning icon ({pull}140719[#140719]).
+
+[discrete]
 [[release-notes-8.4.1]]
 === 8.4.1
 
@@ -71,7 +90,7 @@ There are no breaking changes in 8.4.0.
 * Fixes an incorrect counter for exported rules ({pull}138598[#138598]).
 * Fixes event filters based on OS version ({pull}138517[#138517]).
 * Fixes a bug that could change the batch size for event search in indicator rules ({pull}138356[#138356]).
-* Fixes a bug that prevented users from accessing alert details if they didn't have the appropriate privileges to view the internal index `.internal.alerts-security.alerts-spaceId`. Now, the Alert details flyout correctly uses the public alias index `.alerts-security,akerts-spaceId` ({pull}138331[#138331]).
+* Fixes a bug that prevented users from accessing alert details if they didn't have the appropriate privileges to view the internal index `.internal.alerts-security.alerts-spaceId`. Now, the Alert details flyout correctly uses the public alias index `.alerts-security.alerts-<Kibana-space>` ({pull}138331[#138331]).
 * Fixes the preview button for {ml} rules ({pull}137878[#137878]).
 * Fixes a bug that could crash the Endpoints list when a policy ID was missing ({pull}137788[#137788]).
 * Fixes a bug that could interfere with opening host or user details pages ({pull}137719[#137719]).


### PR DESCRIPTION
Backports the following commits to 8.4:
 - [DOCS] 8.4.2 Release notes (#2455)