### PR TITLE
[DOCS] Create stub page for Endpoint artifacts clarification page

### DIFF
--- a/docs/management/admin/endpoint-artifacts.asciidoc
+++ b/docs/management/admin/endpoint-artifacts.asciidoc
@@ -1,0 +1,4 @@
+[[endpoint-artifacts]]
+= Optimize {elastic-defend}
+
+This page is a placeholder for future documentation.

--- a/docs/management/manage-intro.asciidoc
+++ b/docs/management/manage-intro.asciidoc
@@ -12,3 +12,4 @@ include::{security-docs-root}/docs/management/admin/trusted-apps.asciidoc[levelo
 include::{security-docs-root}/docs/management/admin/event-filters.asciidoc[leveloffset=+1]
 include::{security-docs-root}/docs/management/admin/host-isolation-exceptions.asciidoc[leveloffset=+1]
 include::{security-docs-root}/docs/management/admin/blocklist.asciidoc[leveloffset=+1]
+include::{security-docs-root}/docs/management/admin/endpoint-artifacts.asciidoc[leveloffset=+1]


### PR DESCRIPTION
OLM team's https://github.com/elastic/kibana/pull/142467 requires a live docs link URL to pass CI. This PR creates a stub page for that URL; the page will be completed with https://github.com/elastic/security-docs/pull/2516.

Preview [here](https://security-docs_2530.docs-preview.app.elstc.co/guide/en/security/master/endpoint-artifacts.html)