### PR TITLE
[DOCS] 7.17.7 Release notes 

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.17.7, {elastic-sec} version 7.17.7>>
 * <<release-notes-7.17.6, {elastic-sec} version 7.17.6>>
 * <<release-notes-7.17.5, {elastic-sec} version 7.17.5>>
 * <<release-notes-7.17.4, {elastic-sec} version 7.17.4>>

--- a/docs/release-notes/7.17.asciidoc
+++ b/docs/release-notes/7.17.asciidoc
@@ -2,6 +2,16 @@
 == 7.17
 
 [discrete]
+[[release-notes-7.17.7]]
+=== 7.17.7
+
+[discrete]
+[[bug-fixes-7.17.7]]
+==== Bug fixes and enhancements
+
+There are no user-facing changes in the 7.17.7 release.
+
+[discrete]
 [[release-notes-7.17.6]]
 === 7.17.6
 

--- a/docs/release-notes/7.17.asciidoc
+++ b/docs/release-notes/7.17.asciidoc
@@ -9,7 +9,7 @@
 [[bug-fixes-7.17.7]]
 ==== Bug fixes and enhancements
 
-* Fixes the bug that sometimes caused {elastic-endpoint} to change to a non-running state on Windows endpoints (https://github.com/elastic/endpoint/issues/29[#29]).
+* Fixes a bug that sometimes caused {elastic-endpoint} to change to a non-running state on Windows endpoints (https://github.com/elastic/endpoint/issues/29[#29]).
 
 [discrete]
 [[release-notes-7.17.6]]

--- a/docs/release-notes/7.17.asciidoc
+++ b/docs/release-notes/7.17.asciidoc
@@ -9,7 +9,7 @@
 [[bug-fixes-7.17.7]]
 ==== Bug fixes and enhancements
 
-There are no user-facing changes in the 7.17.7 release.
+* Fixes the bug that sometimes caused {elastic-endpoint} to change to a non-running state on Windows endpoints (https://github.com/elastic/endpoint/issues/29[#29]).
 
 [discrete]
 [[release-notes-7.17.6]]


### PR DESCRIPTION
Fixes https://github.com/elastic/security-docs/issues/2548.

Previews:
- [Index page](https://security-docs_2549.docs-preview.app.elstc.co/guide/en/security/7.17/release-notes.html)
- [Release notes](https://security-docs_2549.docs-preview.app.elstc.co/guide/en/security/7.17/release-notes-header-7.17.0.html#release-notes-7.17.7)