### PR TITLE
[DOCS] Updates DaemonSet manifest download URL

### DIFF
--- a/docs/dashboards/kubernetes-dashboard.asciidoc
+++ b/docs/dashboards/kubernetes-dashboard.asciidoc
@@ -57,11 +57,11 @@ The DaemonSet integrates {elastic-endpoint} into your Kubernetes cluster. The {a
 
 You first need to download the DaemonSet manifest `.yaml`, then modify it to include your {fleet} URL and Enrollment Token before you deploy it to the clusters you want to monitor.
 
-. Download the DaemonSet manifest using this command: 
+. Download the DaemonSet manifest using this command:
 +
 [source,console]
 ----
-curl -L -O https://raw.githubusercontent.com/elastic/endpoint/main/releases/8.4.0/kubernetes/deploy/elastic-endpoint-security.yaml
+curl -L -O https://raw.githubusercontent.com/elastic/endpoint/main/releases/8.5.0/kubernetes/deploy/elastic-defend.yaml
 ----
 
 . Fill in the manifest's `FLEET_URL` field with your {fleet} server's `Host URL`. To find it, go to **{kib} -> Management -> {fleet} -> Settings**. For more information, refer to {fleet-guide}/fleet-settings.html[Fleet UI settings].


### PR DESCRIPTION
Fixes #2606 

Updates the DaemonSet manifest URL in the K8s Dashboard instructions (`curl` command) to refer to the latest version of the manifest, located at: https://raw.githubusercontent.com/elastic/endpoint/main/releases/8.5.0/kubernetes/deploy/elastic-defend.yaml