### PR TITLE
[DOCS] [RE-DO v2] Update prebuilt rules before upgrading Kibana to 8.x +

### DIFF
--- a/docs/upgrade/upgrade-security.asciidoc
+++ b/docs/upgrade/upgrade-security.asciidoc
@@ -11,13 +11,13 @@ NOTE: For detailed information about the 8.0 release, check out the <<release-no
 
 [discrete]
 [[upgrade-8.1.1]]
-== Upgrade to 8.1.1
+== Avoid upgrading to 8.1.1
 
-IMPORTANT: There is a known issue that significantly impacts UI responsiveness. Therefore, we recommend to skip upgrading to this version.
+IMPORTANT: There is a known issue that significantly impacts UI responsiveness. Therefore, we recommend you skip this version.
 
 [discrete]
 [[upgrade-reqs]]
-== Upgrade to an earlier 8.x version
+== Upgrade to other 8.x versions
 
 [float]
 [[upgrade-agents]]
@@ -26,6 +26,14 @@ IMPORTANT: There is a known issue that significantly impacts UI responsiveness. 
 Upgrade your {stack} and {agent}s to 7.17 first (refer to {fleet-guide}/upgrade-elastic-agent.html[Upgrade Fleet-managed Elastic Agents]). Afterwards, you can {stack-ref}/upgrading-elastic-stack.html[upgrade the {stack}] to 8.x. Initially, {agent}s will be version 7.17; this is fine because {elastic-sec} 8.x supports the last minor release in 7.x (7.17) and any subsequent {elastic-endpoint} versions in 8.x. After the {stack} upgrade, you can decide whether to upgrade {agent}s to 8.0, which is recommended to ensure you get the latest features.
 
 NOTE: You do not need to shut down your {agent}s or endpoints to upgrade the {stack}.
+
+[float]
+[[update-prebuilt-rules]]
+=== Update prebuilt detection rules before upgrading to {stack} 8.0 or 8.1
+
+If you're upgrading to {stack} 8.0.x or 8.1.x, you must update your Elastic prebuilt detection rules _while your {stack} is at 7.17_. To update Elastic prebuilt rules, go to the *Rules* page and select *Update _x_ Elastic prebuilt rules*. This ensures that you have the latest prebuilt rules before upgrading the {stack}.
+
+This step isn't required if you're upgrading to {stack} 8.2 or later. If you're unable to update your prebuilt rules at 7.17, upgrade to {stack} 8.2 or later.
 
 [float]
 [[track-rules-upgrade]]


### PR DESCRIPTION
Resolves #2443.

Replaces #2628 -- that PR was based on `main`, but we only want to update `8.1` and `8.0` branches.
Also replaces #2642, which attempted cherry-picking but created too many merge conflicts.