### PR TITLE
[8.0] [DOCS] [RE-DO v2] Update prebuilt rules before upgrading Kibana to 8.x +

### DIFF
--- a/docs/upgrade/upgrade-security.asciidoc
+++ b/docs/upgrade/upgrade-security.asciidoc
@@ -22,6 +22,14 @@ Upgrade your {stack} and {agent}s to 7.17 first (refer to {fleet-guide}/upgrade-
 NOTE: You do not need to shut down your {agent}s or endpoints to upgrade the {stack}.
 
 [float]
+[[update-prebuilt-rules]]
+=== Update prebuilt detection rules before upgrading to {stack} 8.0 or 8.1
+
+If you're upgrading to {stack} 8.0.x or 8.1.x, you must update your Elastic prebuilt detection rules _while your {stack} is at 7.17_. To update Elastic prebuilt rules, go to the *Rules* page and select *Update _x_ Elastic prebuilt rules*. This ensures that you have the latest prebuilt rules before upgrading the {stack}.
+
+This step isn't required if you're upgrading to {stack} 8.2 or later. If you're unable to update your prebuilt rules at 7.17, upgrade to {stack} 8.2 or later.
+
+[float]
 [[track-rules-upgrade]]
 === Track rules that are automatically disabled when upgrading
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.1` to `8.0`:
 - [All the changes from #2628 (#2643)](https://github.com/elastic/security-docs/pull/2643)

<!--- Backport version: 8.5.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)