### PR TITLE
Update links to agent monitoring docs

### DIFF
--- a/docs/detections/alerts-run-osquery.asciidoc
+++ b/docs/detections/alerts-run-osquery.asciidoc
@@ -6,7 +6,7 @@ Run live queries on hosts associated with alerts to learn more about your infras
 [sidebar]
 --
 * The {kibana-ref}/manage-osquery-integration.html[Osquery manager integration] must be installed.
-* {agent}'s {fleet-guide}/view-elastic-agent-status.html[status] must be `Healthy`. Refer to {fleet-guide}/fleet-troubleshooting.html[{fleet} Troubleshooting] if it isn't.
+* {agent}'s {fleet-guide}/monitor-elastic-agent.html[status] must be `Healthy`. Refer to {fleet-guide}/fleet-troubleshooting.html[{fleet} Troubleshooting] if it isn't.
 * Your role must have {kibana-ref}/osquery.html[Osquery feature privileges].
 --
 

--- a/docs/detections/invest-guide-run-osquery.asciidoc
+++ b/docs/detections/invest-guide-run-osquery.asciidoc
@@ -6,7 +6,7 @@ Detection rule investigation guides suggest steps for triaging, analyzing, and r
 [sidebar]
 --
 * The {kibana-ref}/manage-osquery-integration.html[Osquery manager integration] must be installed.
-* {agent}'s {fleet-guide}/view-elastic-agent-status.html[status] must be `Healthy`. Refer to {fleet-guide}/fleet-troubleshooting.html[{fleet} Troubleshooting] if it isn't.
+* {agent}'s {fleet-guide}/monitor-elastic-agent.html[status] must be `Healthy`. Refer to {fleet-guide}/fleet-troubleshooting.html[{fleet} Troubleshooting] if it isn't.
 * Your role must have {kibana-ref}/osquery.html[Osquery feature privileges].
 --
 

--- a/docs/detections/osquery-response-action.asciidoc
+++ b/docs/detections/osquery-response-action.asciidoc
@@ -9,7 +9,7 @@ Osquery Response Actions allow you to add live queries to custom query rules so 
 --
 * Osquery Response Actions require a https://www.elastic.co/pricing[Platinum or Enterprise subscription].
 * The {kibana-ref}/manage-osquery-integration.html[Osquery manager integration] must be installed.
-* {agent}'s {fleet-guide}/view-elastic-agent-status.html[status] must be `Healthy`. Refer to {fleet-guide}/fleet-troubleshooting.html[{fleet} Troubleshooting] if it isn't.
+* {agent}'s {fleet-guide}/monitor-elastic-agent.html[status] must be `Healthy`. Refer to {fleet-guide}/fleet-troubleshooting.html[{fleet} Troubleshooting] if it isn't.
 * Your role must have {kibana-ref}/osquery.html[Osquery feature privileges].
 --
 


### PR DESCRIPTION
Updates doc links to match changes in https://github.com/elastic/observability-docs/pull/2334.

