### PR TITLE
[DOCS] Fixes K8s dashboard docs bug

### DIFF
--- a/docs/dashboards/kubernetes-dashboard.asciidoc
+++ b/docs/dashboards/kubernetes-dashboard.asciidoc
@@ -78,7 +78,7 @@ You can repeat the following steps for multiple contexts.
 
 **Example:**
 
-- Apply the manifest to a cluster: `kubectl apply -f elastic-endpoint-security.yaml`
+- Apply the manifest to a cluster: `kubectl apply -f elastic-defend.yaml`
 - Check the DaemonSet’s status: `kubectl get pods -A`
 
 Once the DaemonSet is running, Elastic Endpoint will start sending Linux session data from Kubernetes to {kib}. You can then view that data from the Kubernetes dashboard.


### PR DESCRIPTION
Fixes #2729 by referencing the correct file name in the example commands on the K8s dashboard page.

[Preview](https://security-docs_2730.docs-preview.app.elstc.co/guide/en/security/master/kubernetes-dashboard.html)