### PR TITLE
[DOCS] 7.17.8 Release notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.17.8, {elastic-sec} version 7.17.8>>
 * <<release-notes-7.17.7, {elastic-sec} version 7.17.7>>
 * <<release-notes-7.17.6, {elastic-sec} version 7.17.6>>
 * <<release-notes-7.17.5, {elastic-sec} version 7.17.5>>

--- a/docs/release-notes/7.17.asciidoc
+++ b/docs/release-notes/7.17.asciidoc
@@ -2,13 +2,21 @@
 == 7.17
 
 [discrete]
+[[release-notes-7.17.8]]
+=== 7.17.7
+
+[discrete]
+[[bug-fixes-7.17.8]]
+==== Bug fixes and enhancements
+* Fixes a bug that caused {elastic-endpoint} to crash when running on busy Linux systems and when protection features for network events and malicious behavior were enabled.
+
+[discrete]
 [[release-notes-7.17.7]]
 === 7.17.7
 
 [discrete]
 [[bug-fixes-7.17.7]]
 ==== Bug fixes and enhancements
-
 * Fixes a bug that sometimes caused {elastic-endpoint} to change to a non-running state on Windows endpoints (https://github.com/elastic/endpoint/issues/29[#29]).
 
 [discrete]


### PR DESCRIPTION
Addresses https://github.com/elastic/security-docs/issues/2747

Previews:
- Index file
- Release notes