### PR TITLE
[DOCS] Add server.publicBaseUrl to case setup

### DIFF
--- a/docs/getting-started/cases-req.asciidoc
+++ b/docs/getting-started/cases-req.asciidoc
@@ -10,8 +10,15 @@
 You can create roles and define feature privileges at different levels to manage feature access in {kib}. {kib} privileges grant access to features within a specified {kib} space, and you can grant full or partial access. For more information, see
 {kibana-ref}/xpack-spaces.html#spaces-control-user-access[Feature access based on user privileges].
 
-NOTE: To send cases to external systems, you need the
-{subscriptions}[appropriate license].
+[NOTE]
+====
+To send cases to external systems, you need the {subscriptions}[appropriate license].
+
+If you are using an on-premises {kib} deployment and you want the email
+notifications and the external incident management systems to contain links back
+to {kib}, you must configure the 
+{kibana-ref}/settings.html#server-publicBaseUrl[server.publicBaseUrl] setting.
+====
 
 To grant access to cases, set the {kib} space privileges for the *Cases* and *{connectors-feature}* features as follows:
 


### PR DESCRIPTION
Relates to https://github.com/elastic/kibana/issues/141059, https://github.com/elastic/kibana/issues/141061

This PR updates the documentation for the [case requirements](https://www.elastic.co/guide/en/security/master/case-permissions.html) to include mention of the server.publicBaseUrl setting.