### PR TITLE
[BUG] Clarify that Elastic Defend requries Fleet

### DIFF
--- a/docs/getting-started/install-endpoint.asciidoc
+++ b/docs/getting-started/install-endpoint.asciidoc
@@ -1,11 +1,13 @@
 [[install-endpoint]]
 = Configure and install the {elastic-defend} integration
 
-Like other Elastic integrations, {elastic-defend} can be integrated into the {agent} using {fleet-guide}/fleet-overview.html[{fleet}]. Upon configuration, the integration allows the {agent} to monitor events on your host and send data to the {security-app}.
+Like other Elastic integrations, {elastic-defend} is integrated into the {agent} using {fleet-guide}/fleet-overview.html[{fleet}]. Upon configuration, the integration allows the {agent} to monitor events on your host and send data to the {security-app}.
 
 .Requirements
 [sidebar]
 --
+* {fleet} is required for {elastic-defend}.
+
 * To configure the {elastic-defend} integration on the {agent}, you must have permission to use {fleet} in {kib}. 
 
 * You must have the `superuser` {ref}/built-in-roles.html[built-in user role] to configure an integration policy and to access the **Endpoints** page in the {security-app}.


### PR DESCRIPTION
Resolves #2803.

Preview: [Configure and install the Elastic Defend integration](https://security-docs_2809.docs-preview.app.elstc.co/guide/en/security/master/install-endpoint.html)

REVIEWERS: Please let me know if the new statement in the Requirements sidebar needs more detail — I was going for short & sweet for impact, but we can expand if necessary. The existing section [Configure and enroll the Elastic Agent](https://security-docs_2809.docs-preview.app.elstc.co/guide/en/security/master/install-endpoint.html#enroll-security-agent) (lower on the same page) also explains the Fleet requirement with a bit more detail.