### PR TITLE
[8.6] [DOCS] 8.5.3 Release notes (#2756)

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.5.3, {elastic-sec} version 8.5.3>>
 * <<release-notes-8.5.2, {elastic-sec} version 8.5.2>>
 * <<release-notes-8.5.1, {elastic-sec} version 8.5.1>>
 * <<release-notes-8.5.0, {elastic-sec} version 8.5.0>>

--- a/docs/release-notes/8.5.asciidoc
+++ b/docs/release-notes/8.5.asciidoc
@@ -2,6 +2,17 @@
 == 8.5
 
 [discrete]
+[[release-notes-8.5.3]]
+=== 8.5.3
+
+[discrete]
+[[bug-fixes-8.5.3]]
+==== Bug fixes and enhancements
+* Fixes a bug that caused {elastic-endpoint} to crash when running on busy Linux systems, and when network event collection or malicious behavior protection was enabled.
+* Fixes a bug that prevented Osquery packs from being ran outside of the default {kib} space ({pull}146410[#146410]).
+* Improves the "permissions required" message that appears on Cloud Posture pages for users without necessary permissions ({pull}145794[#145794]).
+
+[discrete]
 [[release-notes-8.5.2]]
 === 8.5.2
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [[DOCS] 8.5.3 Release notes (#2756)](https://github.com/elastic/security-docs/pull/2756)

<!--- Backport version: 8.5.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)