### PR TITLE
[OSQuery] Add a known issue to the release notes for the 8.6.0 OSQuery Manager integration

### DIFF
--- a/docs/release-notes/8.6.asciidoc
+++ b/docs/release-notes/8.6.asciidoc
@@ -8,7 +8,7 @@
 [discrete]
 [[known-issue-8.6.0]]
 ==== Known issues
-* When using the Osquery Manager integration with {agent}, Osquery results aren't properly written to {es} and therefore aren't viewable in Kibana ( https://github.com/elastic/beats/issues/34250)[#34250]). We recommend that Osquery users skip {stack} 8.6.0 and upgrade to {stack} 8.6.1 or later when available.
+* When using the Osquery Manager integration with {agent}, Osquery results aren't properly written to {es} and, therefore, cannot be viewed in Kibana (https://github.com/elastic/beats/issues/34250)[#34250]). We recommend that Osquery users skip {stack} version 8.6.0 and upgrade to {stack} version 8.6.1 or later when available.
 * Osquery investigation guides may not render correctly if they include an escaped character (such as `\"`). To avoid breaking the query syntax, copy and paste affected queries directly into the investigation guide instead of importing them ( https://github.com/elastic/detection-rules/pull/2447[#2447]).
 
 [discrete]

--- a/docs/release-notes/8.6.asciidoc
+++ b/docs/release-notes/8.6.asciidoc
@@ -8,7 +8,7 @@
 [discrete]
 [[known-issue-8.6.0]]
 ==== Known issues
-There is an issue with using the OSQuery Manager integration with the Agent which causes OSQuery results to not be properly written to Elasticsearch ahd, therefore, not viewable in Kibana (issue: https://github.com/elastic/beats/issues/34250).  It is recommended that OSQuery users not upgrade to 8.6.0 and wait for the 8.6.1 patch release.
+There is an issue with using the OSQuery Manager integration with the Agent which causes OSQuery results to not be properly written to Elasticsearch and, therefore, not viewable in Kibana (issue: https://github.com/elastic/beats/issues/34250).  It is recommended that OSQuery users not upgrade to 8.6.0 and wait for the 8.6.1 patch release.
 
 [discrete]
 [[breaking-changes-8.6.0]]

--- a/docs/release-notes/8.6.asciidoc
+++ b/docs/release-notes/8.6.asciidoc
@@ -8,7 +8,7 @@
 [discrete]
 [[known-issue-8.6.0]]
 ==== Known issues
-There are no known issues in 8.6.0.
+There is an issue with using the OSQuery Manager integration with the Agent which causes OSQuery results to not be properly written to Elasticsearch ahd, therefore, not viewable in Kibana (issue: https://github.com/elastic/beats/issues/34250).  It is recommended that OSQuery users not upgrade to 8.6.0 and wait for the 8.6.1 patch release.
 
 [discrete]
 [[breaking-changes-8.6.0]]

--- a/docs/release-notes/8.6.asciidoc
+++ b/docs/release-notes/8.6.asciidoc
@@ -9,7 +9,7 @@
 [[known-issue-8.6.0]]
 ==== Known issues
 * When using the Osquery Manager integration with {agent}, Osquery results aren't properly written to {es} and, therefore, cannot be viewed in Kibana (https://github.com/elastic/beats/issues/34250)[#34250]). We recommend that Osquery users skip {stack} version 8.6.0 and upgrade to {stack} version 8.6.1 or later when available.
-* Osquery investigation guides may not render correctly if they include an escaped character (such as `\"`). To avoid breaking the query syntax, copy and paste affected queries directly into the investigation guide instead of importing them ( https://github.com/elastic/detection-rules/pull/2447[#2447]).
+* Investigation guides for some prebuilt rules may not render correctly if they include an escaped character (such as `\"`). To resolve this, update your prebuilt rules once you receive a rule update prompt on the Rules page (https://github.com/elastic/detection-rules/pull/2447[#2447]).
 
 [discrete]
 [[breaking-changes-8.6.0]]

--- a/docs/release-notes/8.6.asciidoc
+++ b/docs/release-notes/8.6.asciidoc
@@ -8,7 +8,7 @@
 [discrete]
 [[known-issue-8.6.0]]
 ==== Known issues
-There is an issue with using the OSQuery Manager integration with the Agent which causes OSQuery results to not be properly written to Elasticsearch and, therefore, not viewable in Kibana (issue: https://github.com/elastic/beats/issues/34250).  It is recommended that OSQuery users not upgrade to 8.6.0 and wait for the 8.6.1 patch release.
+When using the Osquery Manager integration with {agent}, Osquery results aren't properly written to {es} and therefore aren't viewable in Kibana ( https://github.com/elastic/beats/issues/34250)[#34250]. We recommend that Osquery users skip {stack} 8.6.0 and upgrade to {stack} 8.6.1 instead when it is released.
 
 [discrete]
 [[breaking-changes-8.6.0]]

--- a/docs/release-notes/8.6.asciidoc
+++ b/docs/release-notes/8.6.asciidoc
@@ -8,7 +8,8 @@
 [discrete]
 [[known-issue-8.6.0]]
 ==== Known issues
-When using the Osquery Manager integration with {agent}, Osquery results aren't properly written to {es} and therefore aren't viewable in Kibana ( https://github.com/elastic/beats/issues/34250)[#34250]. We recommend that Osquery users skip {stack} 8.6.0 and upgrade to {stack} 8.6.1 instead when it is released.
+* When using the Osquery Manager integration with {agent}, Osquery results aren't properly written to {es} and therefore aren't viewable in Kibana ( https://github.com/elastic/beats/issues/34250)[#34250]). We recommend that Osquery users skip {stack} 8.6.0 and upgrade to {stack} 8.6.1 or later when available.
+* Osquery investigation guides may not render correctly if they include an escaped character (such as `\"`). To avoid breaking the query syntax, copy and paste affected queries directly into the investigation guide instead of importing them ( https://github.com/elastic/detection-rules/pull/2447[#2447]).
 
 [discrete]
 [[breaking-changes-8.6.0]]


### PR DESCRIPTION
There is a known issue in the 8.6.0 Agent that we found today that we want to add to the release notes for the 8.6.0 release.