### PR TITLE
[DOCS] Adds note about disabled Endpoint features in K8s

### DIFF
--- a/docs/cloud-native-security/cloud-nat-sec-kubernetes-dashboard.asciidoc
+++ b/docs/cloud-native-security/cloud-nat-sec-kubernetes-dashboard.asciidoc
@@ -53,7 +53,7 @@ To collect session data for the dashboard, you'll deploy a Kubernetes DaemonSet 
 |**GKE**| Regular (default channel): 1.21 and 1.22; Stable: 1.20 and 1.21; Rapid: 1.22 and 1.23 | Container-optimized OS (COS), Ubuntu
 |=====================
 
-NOTE: When running within Kubernetes, {elastic-endpoint}'s <<host-isolation-ov,Host Isolation>> and <<malware-proection,Malware Protection>> features are disabled.
+NOTE: When running within Kubernetes, {elastic-endpoint}'s <<host-isolation-ov,host isolation>> and <<malware-proection,malware protection>> features are disabled.
 
 [discrete]
 === Download and modify the DaemonSet manifest

--- a/docs/cloud-native-security/cloud-nat-sec-kubernetes-dashboard.asciidoc
+++ b/docs/cloud-native-security/cloud-nat-sec-kubernetes-dashboard.asciidoc
@@ -53,7 +53,7 @@ To collect session data for the dashboard, you'll deploy a Kubernetes DaemonSet 
 |**GKE**| Regular (default channel): 1.21 and 1.22; Stable: 1.20 and 1.21; Rapid: 1.22 and 1.23 | Container-optimized OS (COS), Ubuntu
 |=====================
 
-NOTE: When running within Kubernetes, {elastic-endpoint}'s <<host-isolation-ov,host isolation>> and <<malware-proection,malware protection>> features are disabled.
+NOTE: When running within Kubernetes, {elastic-endpoint}'s <<host-isolation-ov,host isolation>> and <<malware-protection,malware protection>> features are disabled.
 
 [discrete]
 === Download and modify the DaemonSet manifest

--- a/docs/cloud-native-security/cloud-nat-sec-kubernetes-dashboard.asciidoc
+++ b/docs/cloud-native-security/cloud-nat-sec-kubernetes-dashboard.asciidoc
@@ -53,6 +53,8 @@ To collect session data for the dashboard, you'll deploy a Kubernetes DaemonSet 
 |**GKE**| Regular (default channel): 1.21 and 1.22; Stable: 1.20 and 1.21; Rapid: 1.22 and 1.23 | Container-optimized OS (COS), Ubuntu
 |=====================
 
+NOTE: When running within Kubernetes, {elastic-endpoint}'s <<host-isolation-ov,Host Isolation>> and <<malware-proection,Malware Protection>> features are disabled.
+
 [discrete]
 === Download and modify the DaemonSet manifest
 The DaemonSet integrates {elastic-endpoint} into your Kubernetes cluster. The {agent} is enrolled to a running {fleet-server} using the `FLEET_URL` parameter, and connected to a specific {agent} policy using the `FLEET_ENROLLMENT_TOKEN`.

--- a/docs/dashboards/kubernetes-dashboard.asciidoc
+++ b/docs/dashboards/kubernetes-dashboard.asciidoc
@@ -54,7 +54,7 @@ To collect session data for the dashboard, you'll deploy a Kubernetes DaemonSet 
 |**GKE**| Regular (default channel): 1.21 and 1.22; Stable: 1.20 and 1.21; Rapid: 1.22 and 1.23 | Container-optimized OS (COS), Ubuntu
 |=====================
 
-NOTE: When running within Kubernetes, {elastic-endpoint}'s <<host-isolation-ov,Host Isolation>> and <<malware-proection,Malware Protection>> features are disabled.
+NOTE: When running within Kubernetes, {elastic-endpoint}'s <<host-isolation-ov,host isolation>> and <<malware-proection,malware protection>> features are disabled.
 
 [discrete]
 === Download and modify the DaemonSet manifest

--- a/docs/dashboards/kubernetes-dashboard.asciidoc
+++ b/docs/dashboards/kubernetes-dashboard.asciidoc
@@ -54,7 +54,7 @@ To collect session data for the dashboard, you'll deploy a Kubernetes DaemonSet 
 |**GKE**| Regular (default channel): 1.21 and 1.22; Stable: 1.20 and 1.21; Rapid: 1.22 and 1.23 | Container-optimized OS (COS), Ubuntu
 |=====================
 
-NOTE: When running within Kubernetes, {elastic-endpoint}'s <<host-isolation-ov,host isolation>> and <<malware-proection,malware protection>> features are disabled.
+NOTE: When running within Kubernetes, {elastic-endpoint}'s <<host-isolation-ov,host isolation>> and <<malware-protection,malware protection>> features are disabled.
 
 [discrete]
 === Download and modify the DaemonSet manifest

--- a/docs/dashboards/kubernetes-dashboard.asciidoc
+++ b/docs/dashboards/kubernetes-dashboard.asciidoc
@@ -54,6 +54,8 @@ To collect session data for the dashboard, you'll deploy a Kubernetes DaemonSet 
 |**GKE**| Regular (default channel): 1.21 and 1.22; Stable: 1.20 and 1.21; Rapid: 1.22 and 1.23 | Container-optimized OS (COS), Ubuntu
 |=====================
 
+NOTE: When running within Kubernetes, {elastic-endpoint}'s <<host-isolation-ov,Host Isolation>> and <<malware-proection,Malware Protection>> features are disabled.
+
 [discrete]
 === Download and modify the DaemonSet manifest
 The DaemonSet integrates {elastic-endpoint} into your Kubernetes cluster. The {agent} is enrolled to a running {fleet-server} using the `FLEET_URL` parameter, and connected to a specific {agent} policy using the `FLEET_ENROLLMENT_TOKEN`.


### PR DESCRIPTION
Fixes #2801 by adding a note that mentions that when Elastic Endpoint is running in Kubernetes, the Malware Prevention and Host Isolation features are disabled.

Preview: [Kubernetes dashboard ](https://security-docs_2890.docs-preview.app.elstc.co/guide/en/security/master/cloud-nat-sec-kubernetes-dashboard.html)