### PR TITLE
[8.3] Adding Documents for v8.3.4 Pre-Built Detection Rules Integration Release

### DIFF
--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-4/prebuilt-rule-8-3-4-exchange-mailbox-export-via-powershell.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-4/prebuilt-rule-8-3-4-exchange-mailbox-export-via-powershell.asciidoc
@@ -1,0 +1,119 @@
+[[prebuilt-rule-8-3-4-exchange-mailbox-export-via-powershell]]
+=== Exchange Mailbox Export via PowerShell
+
+Identifies the use of the Exchange PowerShell cmdlet, New-MailBoxExportRequest, to export the contents of a primary mailbox or archive to a .pst file. Adversaries may target user email to collect sensitive information.
+
+*Rule type*: query
+
+*Rule indices*: 
+
+* winlogbeat-*
+* logs-windows.*
+
+*Severity*: medium
+
+*Risk score*: 47
+
+*Runs every*: 5m
+
+*Searches indices from*: now-9m ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
+
+*Maximum alerts per execution*: 100
+
+*References*: 
+
+* https://www.volexity.com/blog/2020/12/14/dark-halo-leverages-solarwinds-compromise-to-breach-organizations/
+* https://docs.microsoft.com/en-us/powershell/module/exchange/new-mailboxexportrequest?view=exchange-ps
+* https://www.elastic.co/security-labs/siestagraph-new-implant-uncovered-in-asean-member-foreign-ministry
+
+*Tags*: 
+
+* Elastic
+* Host
+* Windows
+* Threat Detection
+* Collection
+* Investigation Guide
+* PowerShell
+
+*Version*: 1
+
+*Rule authors*: 
+
+* Elastic
+
+*Rule license*: Elastic License v2
+
+
+==== Investigation guide
+
+
+[source, markdown]
+----------------------------------
+## Triage and analysis
+
+### Investigating Exchange Mailbox Export via PowerShell
+
+The `New-MailBoxExportRequest` cmdlet is used to begin the process of exporting contents of a primary mailbox or archive to a .pst file. Note that this is done on a per-mailbox basis and this cmdlet is available only in on-premises Exchange.
+Attackers can abuse this functionality in preparation for exfiltrating contents, which is likely to contain sensitive and strategic data.
+
+#### Possible investigation steps
+
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate other alerts associated with the user/host during the past 48 hours.
+- Investigate the export operation:
+  - Identify the user account that performed the action and whether it should perform this kind of action.
+  - Contact the account owner and confirm whether they are aware of this activity.
+  - Check if this operation was approved and performed according to the organization's change management policy.
+  - Retrieve the operation status and use the `Get-MailboxExportRequest` cmdlet to review previous requests.
+  - By default, no group in Exchange has the privilege to import or export mailboxes. Investigate administrators that assigned the "Mailbox Import Export" privilege for abnormal activity.
+- Investigate if there is a significant quantity of export requests in the alert timeframe. This operation is done on a per-mailbox basis and can be part of a mass export.
+- If the operation was completed successfully:
+  - Check if the file is on the path specified in the command.
+  - Investigate if the file was compressed, archived, or retrieved by the attacker for exfiltration.
+
+### False positive analysis
+
+- This mechanism can be used legitimately. Analysts can dismiss the alert if the administrator is aware of the activity and it is done with proper approval.
+
+### Response and remediation
+
+- Initiate the incident response process based on the outcome of the triage.
+- If the involved host is not the Exchange server, isolate the host to prevent further post-compromise behavior.
+- Use the `Remove-MailboxExportRequest` cmdlet to remove fully or partially completed export requests.
+- Prioritize cases that involve personally identifiable information (PII) or other classified data.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Review the privileges of users with the "Mailbox Import Export" privilege to ensure that the least privilege principle is being followed.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+
+----------------------------------
+
+==== Rule query
+
+
+[source, js]
+----------------------------------
+event.category:process and powershell.file.script_block_text : "New-MailboxExportRequest"
+
+----------------------------------
+
+*Framework*: MITRE ATT&CK^TM^
+
+* Tactic:
+** Name: Collection
+** ID: TA0009
+** Reference URL: https://attack.mitre.org/tactics/TA0009/
+* Technique:
+** Name: Email Collection
+** ID: T1114
+** Reference URL: https://attack.mitre.org/techniques/T1114/
+* Sub-technique:
+** Name: Local Email Collection
+** ID: T1114.001
+** Reference URL: https://attack.mitre.org/techniques/T1114/001/
+* Sub-technique:
+** Name: Remote Email Collection
+** ID: T1114.002
+** Reference URL: https://attack.mitre.org/techniques/T1114/002/

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-4/prebuilt-rule-8-3-4-exporting-exchange-mailbox-via-powershell.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-4/prebuilt-rule-8-3-4-exporting-exchange-mailbox-via-powershell.asciidoc
@@ -1,0 +1,122 @@
+[[prebuilt-rule-8-3-4-exporting-exchange-mailbox-via-powershell]]
+=== Exporting Exchange Mailbox via PowerShell
+
+Identifies the use of the Exchange PowerShell cmdlet, New-MailBoxExportRequest, to export the contents of a primary mailbox or archive to a .pst file. Adversaries may target user email to collect sensitive information.
+
+*Rule type*: eql
+
+*Rule indices*: 
+
+* logs-endpoint.events.*
+* winlogbeat-*
+* logs-windows.*
+* endgame-*
+
+*Severity*: medium
+
+*Risk score*: 47
+
+*Runs every*: 5m
+
+*Searches indices from*: now-9m ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
+
+*Maximum alerts per execution*: 100
+
+*References*: 
+
+* https://www.volexity.com/blog/2020/12/14/dark-halo-leverages-solarwinds-compromise-to-breach-organizations/
+* https://docs.microsoft.com/en-us/powershell/module/exchange/new-mailboxexportrequest?view=exchange-ps
+
+*Tags*: 
+
+* Elastic
+* Host
+* Windows
+* Threat Detection
+* Collection
+* Investigation Guide
+* Elastic Endgame
+
+*Version*: 104
+
+*Rule authors*: 
+
+* Elastic
+
+*Rule license*: Elastic License v2
+
+
+==== Investigation guide
+
+
+[source, markdown]
+----------------------------------
+## Triage and analysis
+
+### Investigating Exporting Exchange Mailbox via PowerShell
+
+The `New-MailBoxExportRequest` cmdlet is used to begin the process of exporting contents of a primary mailbox or archive to a .pst file. Note that this is done on a per-mailbox basis and this cmdlet is available only in on-premises Exchange.
+
+Attackers can abuse this functionality in preparation for exfiltrating contents, which is likely to contain sensitive and strategic data.
+
+#### Possible investigation steps
+
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate other alerts associated with the user/host during the past 48 hours.
+- Investigate the export operation:
+  - Identify the user account that performed the action and whether it should perform this kind of action.
+  - Contact the account owner and confirm whether they are aware of this activity.
+  - Check if this operation was approved and performed according to the organization's change management policy.
+  - Retrieve the operation status and use the `Get-MailboxExportRequest` cmdlet to review previous requests.
+  - By default, no group in Exchange has the privilege to import or export mailboxes. Investigate administrators that assigned the "Mailbox Import Export" privilege for abnormal activity.
+- Investigate if there is a significant quantity of export requests in the alert timeframe. This operation is done on a per-mailbox basis and can be part of a mass export.
+- If the operation was completed successfully:
+  - Check if the file is on the path specified in the command.
+  - Investigate if the file was compressed, archived, or retrieved by the attacker for exfiltration.
+
+### False positive analysis
+
+- This mechanism can be used legitimately. Analysts can dismiss the alert if the administrator is aware of the activity and it is done with proper approval.
+
+### Response and remediation
+
+- Initiate the incident response process based on the outcome of the triage.
+- If the involved host is not the Exchange server, isolate the host to prevent further post-compromise behavior.
+- Use the `Remove-MailboxExportRequest` cmdlet to remove fully or partially completed export requests.
+- Prioritize cases that involve personally identifiable information (PII) or other classified data.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Review the privileges of users with the "Mailbox Import Export" privilege to ensure that the least privilege principle is being followed.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+----------------------------------
+
+==== Rule query
+
+
+[source, js]
+----------------------------------
+process where event.type == "start" and
+  process.name: ("powershell.exe", "pwsh.exe", "powershell_ise.exe") and 
+  process.command_line : ("*MailboxExportRequest*", "*-Mailbox*-ContentFilter*")
+
+----------------------------------
+
+*Framework*: MITRE ATT&CK^TM^
+
+* Tactic:
+** Name: Collection
+** ID: TA0009
+** Reference URL: https://attack.mitre.org/tactics/TA0009/
+* Technique:
+** Name: Data from Local System
+** ID: T1005
+** Reference URL: https://attack.mitre.org/techniques/T1005/
+* Technique:
+** Name: Email Collection
+** ID: T1114
+** Reference URL: https://attack.mitre.org/techniques/T1114/
+* Sub-technique:
+** Name: Remote Email Collection
+** ID: T1114.002
+** Reference URL: https://attack.mitre.org/techniques/T1114/002/

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-4/prebuilt-rule-8-3-4-multiple-alerts-in-different-att-ck-tactics-on-a-single-host.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-4/prebuilt-rule-8-3-4-multiple-alerts-in-different-att-ck-tactics-on-a-single-host.asciidoc
@@ -1,0 +1,46 @@
+[[prebuilt-rule-8-3-4-multiple-alerts-in-different-att-ck-tactics-on-a-single-host]]
+=== Multiple Alerts in Different ATT&CK Tactics on a Single Host
+
+This rule uses alert data to determine when multiple alerts in different phases of an attack involving the same host are triggered. Analysts can use this to prioritize triage and response, as these hosts are more likely to be compromised.
+
+*Rule type*: threshold
+
+*Rule indices*: 
+
+* .alerts-security.*
+
+*Severity*: high
+
+*Risk score*: 73
+
+*Runs every*: 1h
+
+*Searches indices from*: now-24h ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
+
+*Maximum alerts per execution*: 100
+
+*References*: None
+
+*Tags*: 
+
+* Elastic
+* Threat Detection
+* Higher-Order Rules
+
+*Version*: 3
+
+*Rule authors*: 
+
+* Elastic
+
+*Rule license*: Elastic License v2
+
+
+==== Rule query
+
+
+[source, js]
+----------------------------------
+signal.rule.name:* and kibana.alert.rule.threat.tactic.id:*
+
+----------------------------------

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-4/prebuilt-rule-8-3-4-multiple-alerts-involving-a-user.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-4/prebuilt-rule-8-3-4-multiple-alerts-involving-a-user.asciidoc
@@ -1,0 +1,46 @@
+[[prebuilt-rule-8-3-4-multiple-alerts-involving-a-user]]
+=== Multiple Alerts Involving a User
+
+This rule uses alert data to determine when multiple different alerts involving the same user are triggered. Analysts can use this to prioritize triage and response, as these users are more likely to be compromised.
+
+*Rule type*: threshold
+
+*Rule indices*: 
+
+* .alerts-security.*
+
+*Severity*: high
+
+*Risk score*: 73
+
+*Runs every*: 1h
+
+*Searches indices from*: now-24h ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
+
+*Maximum alerts per execution*: 100
+
+*References*: None
+
+*Tags*: 
+
+* Elastic
+* Threat Detection
+* Higher-Order Rules
+
+*Version*: 2
+
+*Rule authors*: 
+
+* Elastic
+
+*Rule license*: Elastic License v2
+
+
+==== Rule query
+
+
+[source, js]
+----------------------------------
+signal.rule.name:* and user.name:* and not user.id:("S-1-5-18" or "S-1-5-19" or "S-1-5-20")
+
+----------------------------------

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-4/prebuilt-rule-8-3-4-suspicious-werfault-child-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-4/prebuilt-rule-8-3-4-suspicious-werfault-child-process.asciidoc
@@ -1,0 +1,83 @@
+[[prebuilt-rule-8-3-4-suspicious-werfault-child-process]]
+=== Suspicious WerFault Child Process
+
+A suspicious WerFault child process was detected, which may indicate an attempt to run via the SilentProcessExit registry key manipulation. Verify process details such as command line, network connections and file writes.
+
+*Rule type*: eql
+
+*Rule indices*: 
+
+* winlogbeat-*
+* logs-endpoint.events.*
+* logs-windows.*
+* endgame-*
+
+*Severity*: medium
+
+*Risk score*: 47
+
+*Runs every*: 5m
+
+*Searches indices from*: now-9m ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
+
+*Maximum alerts per execution*: 100
+
+*References*: 
+
+* https://www.hexacorn.com/blog/2019/09/19/silentprocessexit-quick-look-under-the-hood/
+* https://www.hexacorn.com/blog/2019/09/20/werfault-command-line-switches-v0-1/
+* https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Persistence/persistence_SilentProcessExit_ImageHijack_sysmon_13_1.evtx
+* https://blog.menasec.net/2021/01/
+
+*Tags*: 
+
+* Elastic
+* Host
+* Windows
+* Threat Detection
+* Defense Evasion
+* Elastic Endgame
+
+*Version*: 104
+
+*Rule authors*: 
+
+* Elastic
+
+*Rule license*: Elastic License v2
+
+
+==== Investigation guide
+
+
+[source, markdown]
+----------------------------------
+
+----------------------------------
+
+==== Rule query
+
+
+[source, js]
+----------------------------------
+process where event.type == "start" and 
+
+  process.parent.name : "WerFault.exe" and 
+  
+  /* args -s and -t used to execute a process via SilentProcessExit mechanism */
+  (process.parent.args : "-s" and process.parent.args : "-t" and process.parent.args : "-c") and 
+  
+  not process.executable : ("?:\\Windows\\SysWOW64\\Initcrypt.exe", "?:\\Program Files (x86)\\Heimdal\\Heimdal.Guard.exe")
+
+----------------------------------
+
+*Framework*: MITRE ATT&CK^TM^
+
+* Tactic:
+** Name: Defense Evasion
+** ID: TA0005
+** Reference URL: https://attack.mitre.org/tactics/TA0005/
+* Technique:
+** Name: Masquerading
+** ID: T1036
+** Reference URL: https://attack.mitre.org/techniques/T1036/

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-4/prebuilt-rules-8-3-4-appendix.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-4/prebuilt-rules-8-3-4-appendix.asciidoc
@@ -1,0 +1,11 @@
+["appendix",role="exclude",id="prebuilt-rule-8-3-4-prebuilt-rules-8-3-4-appendix"]
+= Downloadable rule update v8.3.4
+
+This section lists all updates associated with version 8.3.4 of the Fleet integration *Prebuilt Security Detection Rules*.
+
+
+include::prebuilt-rule-8-3-4-exchange-mailbox-export-via-powershell.asciidoc[]
+include::prebuilt-rule-8-3-4-multiple-alerts-in-different-att-ck-tactics-on-a-single-host.asciidoc[]
+include::prebuilt-rule-8-3-4-multiple-alerts-involving-a-user.asciidoc[]
+include::prebuilt-rule-8-3-4-exporting-exchange-mailbox-via-powershell.asciidoc[]
+include::prebuilt-rule-8-3-4-suspicious-werfault-child-process.asciidoc[]

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-4/prebuilt-rules-8-3-4-summary.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-4/prebuilt-rules-8-3-4-summary.asciidoc
@@ -1,0 +1,22 @@
+[[prebuilt-rule-8-3-4-prebuilt-rules-8-3-4-summary]]
+[role="xpack"]
+== Update v8.3.4
+
+This section lists all updates associated with version 8.3.4 of the Fleet integration *Prebuilt Security Detection Rules*.
+
+
+[width="100%",options="header"]
+|==============================================
+|Rule |Description |Status |Version
+
+|<<prebuilt-rule-8-3-4-exchange-mailbox-export-via-powershell, Exchange Mailbox Export via PowerShell>> | Identifies the use of the Exchange PowerShell cmdlet, New-MailBoxExportRequest, to export the contents of a primary mailbox or archive to a .pst file. Adversaries may target user email to collect sensitive information. | new | 1 
+
+|<<prebuilt-rule-8-3-4-multiple-alerts-in-different-att-ck-tactics-on-a-single-host, Multiple Alerts in Different ATT&CK Tactics on a Single Host>> | This rule uses alert data to determine when multiple alerts in different phases of an attack involving the same host are triggered. Analysts can use this to prioritize triage and response, as these hosts are more likely to be compromised. | update | 3 
+
+|<<prebuilt-rule-8-3-4-multiple-alerts-involving-a-user, Multiple Alerts Involving a User>> | This rule uses alert data to determine when multiple different alerts involving the same user are triggered. Analysts can use this to prioritize triage and response, as these users are more likely to be compromised. | update | 2 
+
+|<<prebuilt-rule-8-3-4-exporting-exchange-mailbox-via-powershell, Exporting Exchange Mailbox via PowerShell>> | Identifies the use of the Exchange PowerShell cmdlet, New-MailBoxExportRequest, to export the contents of a primary mailbox or archive to a .pst file. Adversaries may target user email to collect sensitive information. | update | 104 
+
+|<<prebuilt-rule-8-3-4-suspicious-werfault-child-process, Suspicious WerFault Child Process>> | A suspicious WerFault child process was detected, which may indicate an attempt to run via the SilentProcessExit registry key manipulation. Verify process details such as command line, network connections and file writes. | update | 104 
+
+|==============================================

--- a/docs/detections/prebuilt-rules/prebuilt-rules-downloadable-updates.asciidoc
+++ b/docs/detections/prebuilt-rules/prebuilt-rules-downloadable-updates.asciidoc
@@ -13,7 +13,7 @@ To download the latest updates, follow the instructions in <<download-prebuilt-r
 
 |<<prebuilt-rule-8-3-4-prebuilt-rules-8-3-4-summary, 8.3.4>> | 24 Jan 2023 | 1 | 4 |
 This release includes new rules for Windows regarding Microsoft Exchange interaction via PowerShell.
-A new rule for multiple alerts with different ATT&CK tactics on a single host has also been included.
+A new rule for multiple alerts with different MITRE ATT&CK tactics on a single host has also been included.
 Additionally, a new rule for multiple alerts involving a single user has been added.
 This release also includes rule tuning for suspicious Windows Error Reporting child processes.
 

--- a/docs/detections/prebuilt-rules/prebuilt-rules-downloadable-updates.asciidoc
+++ b/docs/detections/prebuilt-rules/prebuilt-rules-downloadable-updates.asciidoc
@@ -11,6 +11,12 @@ To download the latest updates, follow the instructions in <<download-prebuilt-r
 |==============================================
 |Update version |Date | New rules | Updated rules | Notes
 
+|<<prebuilt-rule-8-3-4-prebuilt-rules-8-3-4-summary, 8.3.4>> | 24 Jan 2023 | 1 | 4 |
+This release includes new rules for Windows regarding Microsoft Exchange interaction via PowerShell.
+A new rule for multiple alerts with different ATT&CK tactics on a single host has also been included.
+Additionally, a new rule for multiple alerts involving a single user has been added.
+This release also includes rule tuning for suspicious Windows Error Reporting child processes.
+
 |<<prebuilt-rule-8-3-3-prebuilt-rules-8-3-3-summary, 8.3.3>> | 19 Jan 2023 | 17 | 500 |
 This release includes new rules for Windows regarding Microsoft Exchange interaction via PowerShell.
 Additionally, significant rule tuning for Windows rules has been added for better rule efficacy.
@@ -85,4 +91,5 @@ include::downloadable-packages/8-2-1/prebuilt-rules-8-2-1-summary.asciidoc[level
 include::downloadable-packages/8-3-1/prebuilt-rules-8-3-1-summary.asciidoc[leveloffset=+1]
 include::downloadable-packages/8-3-2/prebuilt-rules-8-3-2-summary.asciidoc[leveloffset=+1]
 include::downloadable-packages/8-3-3/prebuilt-rules-8-3-3-summary.asciidoc[leveloffset=+1]
+include::downloadable-packages/8-3-4/prebuilt-rules-8-3-4-summary.asciidoc[leveloffset=+1]
 include::downloadable-packages/8-4-1/prebuilt-rules-8-4-1-summary.asciidoc[leveloffset=+1]

--- a/docs/detections/prebuilt-rules/prebuilt-rules-downloadable-updates.asciidoc
+++ b/docs/detections/prebuilt-rules/prebuilt-rules-downloadable-updates.asciidoc
@@ -13,7 +13,7 @@ To download the latest updates, follow the instructions in <<download-prebuilt-r
 
 |<<prebuilt-rule-8-3-4-prebuilt-rules-8-3-4-summary, 8.3.4>> | 24 Jan 2023 | 1 | 4 |
 This release includes new rules for Windows regarding Microsoft Exchange interaction via PowerShell.
-A new rule for multiple alerts with different MITRE ATT&CK tactics on a single host has also been included.
+A new rule for multiple alerts with different ATT&CK tactics on a single host has also been included.
 Additionally, a new rule for multiple alerts involving a single user has been added.
 This release also includes rule tuning for suspicious Windows Error Reporting child processes.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -79,3 +79,5 @@ include::detections/prebuilt-rules/downloadable-packages/8-3-2/prebuilt-rules-8-
 include::detections/prebuilt-rules/downloadable-packages/8-4-1/prebuilt-rules-8-4-1-appendix.asciidoc[]
 
 include::detections/prebuilt-rules/downloadable-packages/8-3-3/prebuilt-rules-8-3-3-appendix.asciidoc[]
+
+include::detections/prebuilt-rules/downloadable-packages/8-3-4/prebuilt-rules-8-3-4-appendix.asciidoc[]


### PR DESCRIPTION
Release Issue:
* https://github.com/elastic/ia-trade-team/issues/91

Security Doc updates for prebuilt security rule integration package version v8.3.4. Please note these are meant to merge into main for 8.x series only and backport to 8.3, 8.4, 8.5 and 8.6.

Important Checks:

- [x]  index.asciidoc added
- [x]  index.asciidoc contains prebuilt-rules-8-3-3-appendix.asciidoc[] entry
- [x]  prebuilt-rules-downloadable-updates.asciidoc added
- [x]  prebuilt-rules-downloadable-updates.asciidoc contains new entry for 8.3.3 and includes summary asciidoc reference
- [x]  if 8.x series, merge points to main

For grammar, punctuation, spelling and related changes, please open a rule tuning PR in [detection rules](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md). When merged, security docs will be updated next OOB release.