### PR TITLE
Replace outdated ingest-guide attribute

### DIFF
--- a/docs/es-overview.asciidoc
+++ b/docs/es-overview.asciidoc
@@ -88,7 +88,7 @@ and maps.
 The Elastic https://www.elastic.co/endpoint-security/[Endpoint Security agent integration]
 provides capabilities such as collecting events, detecting and preventing
 malicious activity, exceptions, and artifact delivery. The
-{ingest-guide}/ingest-management-overview.html[Ingest Manager] is used to
+{fleet-guide}/ingest-management-overview.html[Ingest Manager] is used to
 install and manage Elastic agents and integrations on your hosts.
 
 [discrete]

--- a/docs/getting-started/advanced-setting.asciidoc
+++ b/docs/getting-started/advanced-setting.asciidoc
@@ -52,7 +52,7 @@ NOTE: Index patterns use wildcards to specify a set of indices. For example, the
 available in the {es-sec-app}.
 
 All of the default index patterns match {beats-ref}/beats-reference.html[{beats}] and 
-{ingest-guide}/ingest-management-overview.html[{agent}] indices. This means all
+{fleet-guide}/ingest-management-overview.html[{agent}] indices. This means all
 data shipped via {beats} and the {agent} is automatically added to the
 {es-sec-app}.
 

--- a/docs/getting-started/install-endpoint.asciidoc
+++ b/docs/getting-started/install-endpoint.asciidoc
@@ -5,7 +5,7 @@
 beta[]
 
 
-Like other Elastic integrations, Elastic Endpoint Security can be integrated into the Elastic Agent through {ingest-guide}/ingest-management-overview.html[Ingest Manager]. Upon configuration, the integration allows the Elastic Agent to monitor for events on your host and send data to the Elastic Security app.
+Like other Elastic integrations, Elastic Endpoint Security can be integrated into the Elastic Agent through {fleet-guide}/ingest-management-overview.html[Ingest Manager]. Upon configuration, the integration allows the Elastic Agent to monitor for events on your host and send data to the Elastic Security app.
 
 NOTE: Configuring the Endpoint Integration on the Elastic Agent requires that the user have permission to use Ingest Manager in Kibana.
 
@@ -25,7 +25,7 @@ If you're using the Elastic Agent on macOS Mojave (10.14) or later, ensure that 
 image::images/install-endpoint/security-integration.png[]
 +
 2. On the Administration page of the security app or the Elastic Endpoint Security integration page in Ingest Manager, select **Add Endpoint Security**. The integration configuration page appears.
-3. Select a configuration for the Elastic Agent. You can use either the **Default config**, or adds security integration to a custom or existing configuration. For more details on Elastic Agent configuration settings, see {ingest-guide}/elastic-agent-configuration.html[Configuration settings].
+3. Select a configuration for the Elastic Agent. You can use either the **Default config**, or adds security integration to a custom or existing configuration. For more details on Elastic Agent configuration settings, see {fleet-guide}/elastic-agent-configuration.html[Configuration settings].
 4. Configure the Elastic Endpoint Security integration with a name and optional description. When done configuring, select **Save integration**. Kibana redirects you back to the administration section of the security app.
 +
 [role="screenshot"]
@@ -57,7 +57,7 @@ image::images/install-endpoint/endpoint-configuration.png[]
 
 After you have enrolled the Elastic Agent on your host, select **Continue**. The host now appears on the Hosts view page inside the Elastic Security app.
 
-To unenroll an agent from your host, see {ingest-guide}/unenroll-elastic-agent.html[Unenroll Elastic Agent].
+To unenroll an agent from your host, see {fleet-guide}/unenroll-elastic-agent.html[Unenroll Elastic Agent].
 
 [discrete]
 [[enable-kernel-extension]]

--- a/docs/management/admin/admin-pg-ov.asciidoc
+++ b/docs/management/admin/admin-pg-ov.asciidoc
@@ -74,4 +74,4 @@ image::images/config-status.png[Config status details]
 
 Expand each section and subsection to view individual responses from the agent.
 
-TIP: If you need help troubleshooting a configuration failure, see the {ingest-guide}/ingest-management-troubleshooting.html[Ingest Manager troubleshooting topic].
+TIP: If you need help troubleshooting a configuration failure, see the {fleet-guide}/ingest-management-troubleshooting.html[Ingest Manager troubleshooting topic].


### PR DESCRIPTION
This pre-emptively fixes broken links that will occur when the docs shared `ingest-guide` attribute is repurposed.

```
15:24:17 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/security/7.9/admin-page-ov.html contains broken links to:
15:24:17 INFO:build_docs:   - en/ingest/7.9/ingest-management-troubleshooting.html
15:24:17 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/security/7.9/advanced-settings.html contains broken links to:
15:24:17 INFO:build_docs:   - en/ingest/7.9/ingest-management-overview.html
15:24:17 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/security/7.9/es-overview.html contains broken links to:
15:24:17 INFO:build_docs:   - en/ingest/7.9/ingest-management-overview.html
15:24:17 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/security/7.9/install-endpoint.html contains broken links to:
15:24:17 INFO:build_docs:   - en/ingest/7.9/elastic-agent-configuration.html
15:24:17 INFO:build_docs:   - en/ingest/7.9/ingest-management-overview.html
15:24:17 INFO:build_docs:   - en/ingest/7.9/unenroll-elastic-agent.html
```
