### PR TITLE
[BUG] Update .alerts-security.alerts-default index name

### DIFF
--- a/docs/getting-started/detections-req.asciidoc
+++ b/docs/getting-started/detections-req.asciidoc
@@ -117,8 +117,8 @@ a| {kib} space `All` privileges for the `Security` feature (refer to
 a|The `maintenance`, `write`,`read`, and `view_index_metadata` index privileges for the following system indices, where `<space-id>` is the {kib} space name:
 
 * `.alerts-security.alerts-<space-id>`
-* `.internal.alerts-security.alerts-<space-id>`
-* `.siem-signals-<space-id>`^!^
+* `.internal.alerts-security.alerts-<space-id>-*`
+* `.siem-signals-<space-id>`^1^
 * `.lists-<space-id>`
 * `.items-<space-id>`
 


### PR DESCRIPTION
Fixes https://github.com/elastic/security-docs/issues/2937.

Preview [here](https://security-docs_2938.docs-preview.app.elstc.co/guide/en/security/master/detections-permissions-section.html#enable-detections-ui).