### PR TITLE
fix air-gapped artifact download commands

### DIFF
--- a/docs/getting-started/offline-endpoint.asciidoc
+++ b/docs/getting-started/offline-endpoint.asciidoc
@@ -106,9 +106,15 @@ This example script starts an Nginx Docker image and configures it as a file ser
 [source,sh]
 ----
 cat > nginx.conf << EOF
+# set compatible etag format
+map $sent_http_etag $elastic_etag {
+  "~(.*)-(.*)" "$1$2";
+}
 server {
   root /app/static;
-  location / {}
+  location / {
+    add_header ETag "$elastic_etag";
+  }
 }
 EOF
 docker run -v "$PWD"/nginx.conf:/etc/nginx/conf.d/default.conf:ro -v "$PWD"/static:/app/static:ro -p 80:80 nginx

--- a/docs/getting-started/offline-endpoint.asciidoc
+++ b/docs/getting-started/offline-endpoint.asciidoc
@@ -131,7 +131,12 @@ This example script starts an Apache httpd Docker image and configures it as a f
 
 [source,sh]
 ----
-docker run -p 80:80 -v "$PWD":/usr/local/apache2/htdocs/ httpd
+docker run --rm httpd cat /usr/local/apache2/conf/httpd.conf > my-httpd.conf
+cat >> my-httpd.conf << 'EOF'
+# set compatible etag format
+FileETag MTime
+EOF
+docker run -p 80:80 -v "$PWD/static":/usr/local/apache2/htdocs/ -v "$PWD"/my-httpd.conf:/usr/local/apache2/conf/httpd.conf:ro httpd
 ----
 
 IMPORTANT: This example script is not appropriate for production environments. We recommend configuring httpd to use https://httpd.apache.org/docs/trunk/ssl/ssl_howto.html[TLS] according to your IT policies. Refer to https://httpd.apache.org[Apache documentation] for more information on downloading and configuring Apache httpd.

--- a/docs/getting-started/offline-endpoint.asciidoc
+++ b/docs/getting-started/offline-endpoint.asciidoc
@@ -105,7 +105,7 @@ This example script starts an Nginx Docker image and configures it as a file ser
 
 [source,sh]
 ----
-cat > nginx.conf << EOF
+cat > nginx.conf << 'EOF'
 # set compatible etag format
 map $sent_http_etag $elastic_etag {
   "~(.*)-(.*)" "$1$2";

--- a/docs/getting-started/offline-endpoint.asciidoc
+++ b/docs/getting-started/offline-endpoint.asciidoc
@@ -152,7 +152,7 @@ Below is an example script that downloads all the global artifact updates. There
 
 [source,sh,subs="attributes"]
 ----
-export ENDPOINT_VERSION={version} && wget -P downloads/endpoint/manifest https://artifacts.security.elastic.co/downloads/endpoint/manifest/artifacts-$ENDPOINT_VERSION.zip && zcat -q downloads/endpoint/manifest/artifacts-$ENDPOINT_VERSION.zip | jq -r --arg root "https://artifacts.security.elastic.co" '.artifacts | to_entries[] | $root + .value.relative_url' | xargs wget -P downloads/endpoint -c
+export ENDPOINT_VERSION={version} && wget -P downloads/endpoint/manifest https://artifacts.security.elastic.co/downloads/endpoint/manifest/artifacts-$ENDPOINT_VERSION.zip && zcat -q downloads/endpoint/manifest/artifacts-$ENDPOINT_VERSION.zip | jq -r '.artifacts | to_entries[] | .value.relative_url' | xargs -I@ curl "https://artifacts.security.elastic.co@" --create-dirs -o ".@"
 ----
 
 This command will download files and directory structure that should be directly copied to the file server.


### PR DESCRIPTION
During testing I found an error in the sample command we provide as part of these new 8.6 docs. The previous script downloaded some files to an incorrect file path which caused Elastic Endpoint to ignore the artifact update.

Also during testing, I found an Endpoint bug https://github.com/elastic/endpoint-dev/issues/12382 which causes Endpoint to reject some requests from nginx artifact servers. So I updated the example configuration with a workaround.

I tested these updated commands as well as the nginx configuration and httpd configuration on a Windows 10 VM and confirmed Endpoint downloads and installed the updated artifacts using this download script 🚀 