### PR TITLE
[bug] Add 5 missing fields to Alerts schema

### DIFF
--- a/docs/reference/alert-schema.asciidoc
+++ b/docs/reference/alert-schema.asciidoc
@@ -145,7 +145,7 @@ Type: flattened
 |N/A | `kibana.alert.suppression.terms.field` | The fields used to group alerts for suppression.
 
 Type:	keyword
-|N/A | `kibana.alert.suppression.terms.value` | The value(s) in the suppression fields.
+|N/A | `kibana.alert.suppression.terms.value` | The values in the suppression fields.
 
 Type: keyword
 |N/A | `kibana.alert.suppression.start`| The timestamp of the first document in the suppression group.

--- a/docs/reference/alert-schema.asciidoc
+++ b/docs/reference/alert-schema.asciidoc
@@ -142,4 +142,19 @@ Type: flattened
 |N/A | `kibana.alert.rule.producer` | Type: keyword
 |N/A | `kibana.alert.rule.rule_type_id` | Type: keyword
 
+|N/A | `kibana.alert.suppression.terms.field` | The field(s) used to group alerts for suppression.
+
+Type:	keyword
+|N/A | `kibana.alert.suppression.terms.value` | The value(s) in the suppression fields.
+
+Type: keyword
+|N/A | `kibana.alert.suppression.start`| The timestamp of the first document in the suppression group.
+
+Type: date
+|N/A | `kibana.alert.suppression.end` | The timestamp of the last document in the suppression group.
+
+Type: date
+|N/A | `kibana.alert.suppression.docs_count` | The number of suppressed alerts.
+
+Type: long
 |==============================================

--- a/docs/reference/alert-schema.asciidoc
+++ b/docs/reference/alert-schema.asciidoc
@@ -142,7 +142,7 @@ Type: flattened
 |N/A | `kibana.alert.rule.producer` | Type: keyword
 |N/A | `kibana.alert.rule.rule_type_id` | Type: keyword
 
-|N/A | `kibana.alert.suppression.terms.field` | The field(s) used to group alerts for suppression.
+|N/A | `kibana.alert.suppression.terms.field` | The fields used to group alerts for suppression.
 
 Type:	keyword
 |N/A | `kibana.alert.suppression.terms.value` | The value(s) in the suppression fields.


### PR DESCRIPTION
Fixes #3007 by adding missing fields to the Alerts schema

Preview: [Alert schema](https://security-docs_3008.docs-preview.app.elstc.co/guide/en/security/master/alert-schema.html)