### PR TITLE
Update K8d dashboard instructions to avoid double install of agent 

### DIFF
--- a/docs/cloud-native-security/cloud-nat-sec-kubernetes-dashboard.asciidoc
+++ b/docs/cloud-native-security/cloud-nat-sec-kubernetes-dashboard.asciidoc
@@ -39,12 +39,16 @@ The *Metadata* tab is organized into these expandable sections:
 == Setup
 To collect session data for the dashboard, you'll deploy a Kubernetes DaemonSet to your clusters that implements the {elastic-defend} integration.
 
-**Prerequisites**:
-
+.Requirements
+[sidebar]
+--
 - This feature requires Elastic Stack version 8.4 or newer.
 - You need an active {fleet-guide}/fleet-overview.html[{fleet} Server].
 - Your Elastic deployment must have the {elastic-defend} integration <<install-endpoint,enabled>>.
 - The {elastic-defend} integration policy must have **Include session data** set to `true`. To modify this setting, go to **Manage -> Policies**, select your policy, and find `Include session data` near the bottom of the `Policy settings` tab.
+--
+
+WARNING: Do not install the {elastic-defend} DaemonSet on hosts already running the {agent} DaemonSet. The {elastic-defend} DaemonSet deploys the {agent}, so trying to install both can cause problems since only one {agent} should run on each host.
 
 **Support matrix**: This feature is currently available on GKE and EKS using Linux hosts and Kubernetes versions that match the following specifications:
 |=====================

--- a/docs/dashboards/kubernetes-dashboard.asciidoc
+++ b/docs/dashboards/kubernetes-dashboard.asciidoc
@@ -40,12 +40,16 @@ The *Metadata* tab is organized into these expandable sections:
 == Setup
 To collect session data for the dashboard, you'll deploy a Kubernetes DaemonSet to your clusters that implements the {elastic-defend} integration.
 
-**Prerequisites**:
-
+.Requirements
+[sidebar]
+--
 - This feature requires Elastic Stack version 8.4 or newer.
 - You need an active {fleet-guide}/fleet-overview.html[{fleet} Server].
 - Your Elastic deployment must have the {elastic-defend} integration <<install-endpoint,enabled>>.
 - The {elastic-defend} integration policy must have **Include session data** set to `true`. To modify this setting, go to **Manage -> Policies**, select your policy, and find `Include session data` near the bottom of the `Policy settings` tab.
+--
+
+WARNING: Do not install the {elastic-defend} DaemonSet on hosts already running the {agent} DaemonSet. The {elastic-defend} DaemonSet deploys the {agent}, so trying to install both can cause problems since only one {agent} should run on each host.
 
 **Support matrix**: This feature is currently available on GKE and EKS using Linux hosts and Kubernetes versions that match the following specifications:
 |=====================


### PR DESCRIPTION
Fixes #2901 by adding a warning telling users not to install the Elastic Agent and Elastic Defend DaemonSets in parallel. This is intended to resolve the problem described here: https://discuss.elastic.co/t/native-vs-daemonset-deployment-for-integrations-defend-kubernetes-kspm/323535 

Preview: K8s dashboard