### PR TITLE
Remove link to `ecs-mapper` from ECS field reference

### DIFF
--- a/docs/reference/field-ref.asciidoc
+++ b/docs/reference/field-ref.asciidoc
@@ -5,7 +5,7 @@
 This section lists {ecs-ref}[Elastic Common Schema] (ECS) fields used by {elastic-sec} to provide an optimal SIEM and security analytics experience to users. These fields are used to display data, provide rule previews, enable detection by prebuilt detection rules, provide context during rule triage and investigation, escalate to cases, and more.
 
 IMPORTANT: We recommend you use {agent} integrations or {beats}  to ship your data to {elastic-sec}. {agent} integrations and Beat modules (for example, {filebeat-ref}/filebeat-modules.html[{filebeat} modules]) are ECS-compliant, which means data they ship to {elastic-sec} will automatically populate the relevant ECS fields.
-If you plan to use a custom implementation to map your data to ECS fields (see {ecs-ref}/ecs-converting.html[how to map data to ECS]), ensure the <<siem-always-required-fields, always required fields>> are populated. Ideally, all relevant ECS fields should be populated as well. You can also try out the experimental https://github.com/elastic/ecs-mapper[ECS Mapper tool] to create your custom implementation.
+If you plan to use a custom implementation to map your data to ECS fields (see {ecs-ref}/ecs-converting.html[how to map data to ECS]), ensure the <<siem-always-required-fields, always required fields>> are populated. Ideally, all relevant ECS fields should be populated as well.
 
 [float]
 [[siem-always-required-fields]]


### PR DESCRIPTION
The [elastic/ecs-mapper](https://github.com/elastic/ecs-mapper) project was archived some time back, and we should remove the link from the Field Reference guide.

The [Create Pipeline from CSV](https://www.elastic.co/guide/en/ecs/current/ecs-converting.html#ecs-map-custom-data-to-ecs-es-pipeline) feature in Kibana replaces `ecs-mapper`. We're already linking to the same ECS page (`see {ecs-ref}/ecs-converting.html[how to map data to ECS]`) earlier in this section, so I think it's ok to remove the last sentence entirely.