### PR TITLE
[Security Solution] Add a known issue for Agent upgrade bug that affects osquery

### DIFF
--- a/docs/release-notes/8.7.asciidoc
+++ b/docs/release-notes/8.7.asciidoc
@@ -9,6 +9,11 @@
 [[known-issue-8.7.0]]
 ==== Known issues
 * After alerts are generated for the first time, you may have to refresh your browser before your alert data appears on pages that use data views (for example, Timeline). Navigating between pages will not work (https://github.com/elastic/security-docs/issues/3046[#3046]).
+* There is a known issue when upgrading Agents to 8.7.0 that are running Osquery.  It is possible that Agents can get stuck in an "Updating" state.  This is only known to occur if Agents have the Osquery Manager integration installed (https://github.com/elastic/elastic-agent/issues/2433[#2433]).  Users can do the following work around the issue.
+   * Wait for the 8.7.1 release to upgrade Agents to the 8.7.x line.
+   * Remove the Osquery Manager ingegration before upgrading.  After the Agent is upgraded to 8.7.0, add the Osquery Manager integration back to the Agent.
+   * If you encounter this issue and Agents are stuck in "Updating", remove the Osquery Manager integration, upgrade, and then add it back.
+      * Note, you may need to use the (https://petstore.swagger.io/?url=https://raw.githubusercontent.com/elastic/kibana/8.7/x-pack/plugins/fleet/common/openapi/bundled.json#/default/upgrade-agent[Agent upgrade API]) in this scenario over the UI.
 
 [discrete]
 [[breaking-changes-8.7.0]]

--- a/docs/release-notes/8.7.asciidoc
+++ b/docs/release-notes/8.7.asciidoc
@@ -10,10 +10,10 @@
 ==== Known issues
 * After alerts are generated for the first time, you may have to refresh your browser before your alert data appears on pages that use data views (for example, Timeline). Navigating between pages will not work (https://github.com/elastic/security-docs/issues/3046[#3046]).
 * There is a known issue when upgrading Agents to 8.7.0 that are running Osquery.  It is possible that Agents can get stuck in an "Updating" state.  This is only known to occur if Agents have the Osquery Manager integration installed (https://github.com/elastic/elastic-agent/issues/2433[#2433]).  Users can do the following work around the issue.
-   * Wait for the 8.7.1 release to upgrade Agents to the 8.7.x line.
-   * Remove the Osquery Manager ingegration before upgrading.  After the Agent is upgraded to 8.7.0, add the Osquery Manager integration back to the Agent.
-   * If you encounter this issue and Agents are stuck in "Updating", remove the Osquery Manager integration, upgrade, and then add it back.
-      * Note, you may need to use the (https://petstore.swagger.io/?url=https://raw.githubusercontent.com/elastic/kibana/8.7/x-pack/plugins/fleet/common/openapi/bundled.json#/default/upgrade-agent[Agent upgrade API]) in this scenario over the UI.
+  * Wait for the 8.7.1 release to upgrade Agents to the 8.7.x line.
+  * Remove the Osquery Manager ingegration before upgrading.  After the Agent is upgraded to 8.7.0, add the Osquery Manager integration back to the Agent.
+  * If you encounter this issue and Agents are stuck in "Updating", remove the Osquery Manager integration, upgrade, and then add it back.
+    * Note, you may need to use the (https://petstore.swagger.io/?url=https://raw.githubusercontent.com/elastic/kibana/8.7/x-pack/plugins/fleet/common/openapi/bundled.json#/default/upgrade-agent[Agent upgrade API]) in this scenario over the UI.
 
 [discrete]
 [[breaking-changes-8.7.0]]

--- a/docs/release-notes/8.7.asciidoc
+++ b/docs/release-notes/8.7.asciidoc
@@ -13,7 +13,7 @@
   * Wait for the 8.7.1 release to upgrade Agents to the 8.7.x line.
   * Remove the Osquery Manager ingegration before upgrading.  After the Agent is upgraded to 8.7.0, add the Osquery Manager integration back to the Agent.
   * If you encounter this issue and Agents are stuck in "Updating", remove the Osquery Manager integration, upgrade, and then add it back.
-    * Note, you may need to use the (https://petstore.swagger.io/?url=https://raw.githubusercontent.com/elastic/kibana/8.7/x-pack/plugins/fleet/common/openapi/bundled.json#/default/upgrade-agent[Agent upgrade API]) in this scenario over the UI.
+    * Note, you may need to use the https://petstore.swagger.io/?url=https://raw.githubusercontent.com/elastic/kibana/8.7/x-pack/plugins/fleet/common/openapi/bundled.json#/default/upgrade-agent[Agent upgrade API] in this scenario over the UI.
 
 [discrete]
 [[breaking-changes-8.7.0]]

--- a/docs/release-notes/8.7.asciidoc
+++ b/docs/release-notes/8.7.asciidoc
@@ -9,7 +9,9 @@
 [[known-issue-8.7.0]]
 ==== Known issues
 * After alerts are generated for the first time, you may have to refresh your browser before your alert data appears on pages that use data views (for example, Timeline). Navigating between pages will not work (https://github.com/elastic/security-docs/issues/3046[#3046]).
-* There is a known issue when upgrading Agents to 8.7.0 that are running Osquery.  It is possible that Agents can get stuck in an "Updating" state.  This is only known to occur if Agents have the Osquery Manager integration installed (https://github.com/elastic/elastic-agent/issues/2433[#2433]).  Users can do the following work around the issue.
+* After you upgrade to {stack} 8.7.0, {agents} that are running the Osquery Manager integration might get stuck in the `Updating` state. (https://github.com/elastic/elastic-agent/issues/2433[#2433]). To prevent this, remove the Osquery Manager integration from your {agents} before upgrading them to 8.7.0, then re-add the integration after you finish upgrading. This workaround will also work if you already upgraded and your {agents} are stuck in the `Updating` state. 
++
+NOTE: If you are unable to resolve this issue using the {fleet-guide}/upgrade-elastic-agent.html[Fleet UI], you may need to use the https://petstore.swagger.io/?url=https://raw.githubusercontent.com/elastic/kibana/8.7/x-pack/plugins/fleet/common/openapi/bundled.json#/default/upgrade-agent[Agent upgrade API] instead. 
   * Wait for the 8.7.1 release to upgrade Agents to the 8.7.x line.
   * Remove the Osquery Manager ingegration before upgrading.  After the Agent is upgraded to 8.7.0, add the Osquery Manager integration back to the Agent.
   * If you encounter this issue and Agents are stuck in "Updating", remove the Osquery Manager integration, upgrade, and then add it back.


### PR DESCRIPTION
Adds a known issue to the 8.7.0 release notes for this Agent upgrade issue: https://github.com/elastic/elastic-agent/issues/2433

Preview [here](https://security-docs_3115.docs-preview.app.elstc.co/guide/en/security/8.7/release-notes-header-8.7.0.html#known-issue-8.7.0).