### PR TITLE
Updates k8d dash refs to 8.6 to 8.7

### DIFF
--- a/docs/cloud-native-security/cloud-nat-sec-kubernetes-dashboard.asciidoc
+++ b/docs/cloud-native-security/cloud-nat-sec-kubernetes-dashboard.asciidoc
@@ -69,7 +69,7 @@ You first need to download the DaemonSet manifest `.yaml`, then modify it to inc
 +
 [source,console]
 ----
-curl -L -O https://raw.githubusercontent.com/elastic/endpoint/main/releases/8.6.0/kubernetes/deploy/elastic-defend.yaml
+curl -L -O https://raw.githubusercontent.com/elastic/endpoint/main/releases/8.7.0/kubernetes/deploy/elastic-defend.yaml
 ----
 
 . Fill in the manifest's `FLEET_URL` field with your {fleet} server's `Host URL`. To find it, go to **{kib} -> Management -> {fleet} -> Settings**. For more information, refer to {fleet-guide}/fleet-settings.html[Fleet UI settings].

--- a/docs/dashboards/kubernetes-dashboard.asciidoc
+++ b/docs/dashboards/kubernetes-dashboard.asciidoc
@@ -70,7 +70,7 @@ You first need to download the DaemonSet manifest `.yaml`, then modify it to inc
 +
 [source,console]
 ----
-curl -L -O https://raw.githubusercontent.com/elastic/endpoint/main/releases/8.6.0/kubernetes/deploy/elastic-defend.yaml
+curl -L -O https://raw.githubusercontent.com/elastic/endpoint/main/releases/8.7.0/kubernetes/deploy/elastic-defend.yaml
 ----
 
 . Fill in the manifest's `FLEET_URL` field with your {fleet} server's `Host URL`. To find it, go to **{kib} -> Management -> {fleet} -> Settings**. For more information, refer to {fleet-guide}/fleet-settings.html[Fleet UI settings].


### PR DESCRIPTION
A new daemonset .yaml version was just added to the endpoint repo for version 8.7. We can now update the 8.7 version of deployment instructions to link to it.