### PR TITLE
Shared exception lists can be duplicated 

### DIFF
--- a/docs/detections/shared-exception-lists.asciidoc
+++ b/docs/detections/shared-exception-lists.asciidoc
@@ -119,7 +119,7 @@ If no attribute is selected, the app searches the list name by default.
 [[manage-exception-lists]]
 === Manage shared exception lists
 
-You can edit, export, import, and delete shared exception lists from the Shared Exception Lists page.  
+You can edit, export, import, duplicate, and delete shared exception lists from the Shared Exception Lists page.  
 
 NOTE: Exception lists created in 8.5 and earlier become shared exception lists in 8.6 or later. You can access all shared exception lists from the Shared Exception Lists page.    
 


### PR DESCRIPTION
Fixes https://github.com/elastic/security-docs/issues/3219.

Preview [here](https://security-docs_3249.docs-preview.app.elstc.co/guide/en/security/master/shared-exception-lists.html#manage-exception-lists).