### PR TITLE
[BUG] Document required Security privs for cases

### DIFF
--- a/docs/getting-started/cases-req.asciidoc
+++ b/docs/getting-started/cases-req.asciidoc
@@ -20,6 +20,8 @@ to {kib}, you must configure the
 {kibana-ref}/settings.html#server-publicBaseUrl[server.publicBaseUrl] setting.
 ====
 
+IMPORTANT: Additional privileges and certain licenses might be required to manage case attachments. For example, to add alerts to cases, you must have privilges for <<enable-detections-ui,managing alerts>>. 
+
 To grant access to cases, set the {kib} space privileges for the *Cases* and *{connectors-feature}* features as follows:
 
 [discrete]

--- a/docs/getting-started/cases-req.asciidoc
+++ b/docs/getting-started/cases-req.asciidoc
@@ -20,7 +20,7 @@ to {kib}, you must configure the
 {kibana-ref}/settings.html#server-publicBaseUrl[server.publicBaseUrl] setting.
 ====
 
-IMPORTANT: Additional privileges and certain licenses might be required to manage case attachments. For example, to add alerts to cases, you must have privilges for <<enable-detections-ui,managing alerts>>. 
+IMPORTANT: Certain subscriptions and privileges might be required to manage case attachments. For example, to add alerts to cases, you must have privileges for <<enable-detections-ui,managing alerts>>. 
 
 To grant access to cases, set the {kib} space privileges for the *Cases* and *{connectors-feature}* features as follows:
 


### PR DESCRIPTION
Fixes https://github.com/elastic/security-docs/issues/3239.

Added note to the Cases topic that tells users they might need additional feature privs manage case attachments. Preview [here](https://security-docs_3261.docs-preview.app.elstc.co/guide/en/security/master/case-permissions.html).