### PR TITLE
Alerts can be shared via a shareable URL #3184

### DIFF
--- a/docs/detections/alerts-view-details.asciidoc
+++ b/docs/detections/alerts-view-details.asciidoc
@@ -1,10 +1,14 @@
 [[view-alert-details]]
 == View detection alert details
 
-To inspect a detection alert, click the *View details* button from the Alerts table. The alert details flyout appears with several options to view alert data.
+To inspect a detection alert, click the *View details* button from the Alerts table. The alert details flyout appears with a way to share the alert and several options to view alert data.
 
 [role="screenshot"]
 image::images/view-alert-details.png[View details button, 200]
+
+To share an alert, click the **Share alert** link in the upper right corner of the flyout. This gives you a shareable URL that you can send to others or paste into a browser.  
+
+NOTE: If you've set the {kibana-ref}/settings.html#server-publicBaseUrl[`server.publicBaseUrl`] configuration setting in the `kibana.yml` file, you can also find the shareable URL in the `kibana.alert.url` field. You can find the field by going the *Table* tab and searching for `kibana.alert.url`. 
 
 The alert details flyout contains these informational tabs:
 

--- a/docs/reference/alert-schema.asciidoc
+++ b/docs/reference/alert-schema.asciidoc
@@ -157,4 +157,10 @@ Type: date
 |N/A | `kibana.alert.suppression.docs_count` | The number of suppressed alerts.
 
 Type: long
+
+|N/A | `kibana.alert.url` a| The shareable URL for the alert.
+
+NOTE: This field only appears if you've set the {kibana-ref}/settings.html#server-publicBaseUrl[`server.publicBaseUrl`] configuration setting in the `kibana.yml` file. 
+
+Type: long
 |==============================================


### PR DESCRIPTION
Fixes https://github.com/elastic/security-docs/issues/3184.

Previews:
- View detection alert details: Added explanation of how to use the Share alert button and the new `kibana.alert.url` field. Also refreshed screenshot.
- Alert schema: Added the new `kibana.alert.url` field.