### PR TITLE
The max_signals field for rules can support up to 1000 alerts 

### DIFF
--- a/docs/detections/api/rules/rules-api-create.asciidoc
+++ b/docs/detections/api/rules/rules-api-create.asciidoc
@@ -280,8 +280,10 @@ means the rule runs every hour. Defaults to `5m` (5 minutes).
 
 |license |String |The rule's license.
 
-|max_signals |Integer |Maximum number of alerts the rule can create during a
+|max_signals |Integer a|Maximum number of alerts the rule can create during a
 single execution. Defaults to `100`.
+
+*NOTE*: To avoid rule failures, do not set the `max_signals` value higher than {kibana-ref}/alert-action-settings-kb.html#alert-settings[`xpack.alerting.rules.run.alerts.max`] value. 
 
 |meta |Object a|Placeholder for metadata about the rule.
 


### PR DESCRIPTION
Fixes https://github.com/elastic/security-docs/issues/3254.

Preview here.