### PR TITLE
[BUG] Re-add note about escaping special characters

### DIFF
--- a/docs/detections/add-exceptions.asciidoc
+++ b/docs/detections/add-exceptions.asciidoc
@@ -84,6 +84,8 @@ Fields with conflicts are marked with a warning icon (image:images/field-warning
 =======
     * `matches` | `does not match` — Allows you to use wildcards in *Value*, such as `C:\path\*\app.exe`. Available wildcards are `?` (match one character) and `*` (match zero or more characters). The selected *Field* data type must be {ref}/keyword.html#keyword-field-type[keyword], {ref}/text.html#text-field-type[text], or {ref}/keyword.html#wildcard-field-type[wildcard].
 +
+NOTE: Some characters must be escaped with a backslash, such as `\\` for a literal backslash, `\*` for an asterisk, and `\?` for a question mark. Windows paths must be divided with double backslashes (for example, `C:\\Windows\\explorer.exe`), and paths that already include double backslashes might require four backslashes for each divider.
++
 IMPORTANT: Using wildcards can impact performance. To create a more efficient exception using wildcards, use multiple conditions and make them as specific as possible. For example, adding conditions using `process.name` or `file.name` can help limit the scope of wildcard matching.
 
   .. *Value*: Enter the value associated with the *Field*. To enter multiple values (when using `is one of` or `is not one of`), enter each value, then press **Return**.

--- a/docs/detections/add-exceptions.asciidoc
+++ b/docs/detections/add-exceptions.asciidoc
@@ -82,7 +82,7 @@ Fields with conflicts are marked with a warning icon (image:images/field-warning
 * Wildcards are not supported in value lists.
 * If a value list can't be used due to <<manage-value-lists,size or data type>>, it'll be unavailable in the *Value* menu.
 =======
-    * `matches` | `does not match` — Allows you to use wildcards in *Value*, such as `C:\path\*\app.exe`. Available wildcards are `?` (match one character) and `*` (match zero or more characters). The selected *Field* data type must be {ref}/keyword.html#keyword-field-type[keyword], {ref}/text.html#text-field-type[text], or {ref}/keyword.html#wildcard-field-type[wildcard].
+    * `matches` | `does not match` — Allows you to use wildcards in *Value*, such as `C:\\path\\*\\app.exe`. Available wildcards are `?` (match one character) and `*` (match zero or more characters). The selected *Field* data type must be {ref}/keyword.html#keyword-field-type[keyword], {ref}/text.html#text-field-type[text], or {ref}/keyword.html#wildcard-field-type[wildcard].
 +
 NOTE: Some characters must be escaped with a backslash, such as `\\` for a literal backslash, `\*` for an asterisk, and `\?` for a question mark. Windows paths must be divided with double backslashes (for example, `C:\\Windows\\explorer.exe`), and paths that already include double backslashes might require four backslashes for each divider.
 +


### PR DESCRIPTION
Fixes https://github.com/elastic/security-docs/issues/3301.

Preview [here](https://security-docs_3302.docs-preview.app.elstc.co/guide/en/security/master/add-exceptions.html) - Updates description for the `matches | does not match` options and re-adds the note after the description. 