### PR TITLE
[BUG][8.3-8.7] Add note that alerts attached to cases are not exported

### DIFF
--- a/docs/cases/cases-manage.asciidoc
+++ b/docs/cases/cases-manage.asciidoc
@@ -163,6 +163,8 @@ Use the *Export* option to move cases between different Kibana instances. When y
 * Case alerts
 * Lens visualizations (exported as JSON blobs).
 
+NOTE: Alerts attached to cases are not exported. You must re-add them after importing cases.
+
 To export a case:
 
 . Open the main menu, go to *Stack Management -> {kib}*, then select the *Saved Objects* tab.


### PR DESCRIPTION
Fixes https://github.com/elastic/security-docs/issues/3206.

Preview [here](https://security-docs_3311.docs-preview.app.elstc.co/guide/en/security/8.7/cases-open-manage.html#cases-export-import): Added note to convey that alerts aren't exported with cases.