### PR TITLE
[8.5] [BUG][8.8] Add note that alerts attached to cases are not exported (#3310)

### DIFF
--- a/docs/cases/cases-manage.asciidoc
+++ b/docs/cases/cases-manage.asciidoc
@@ -149,6 +149,8 @@ Use the *Export* option to move cases between different Kibana instances. When y
 * Case alerts
 * Lens visualizations (exported as JSON blobs).
 
+NOTE: Alerts attached to cases are not exported. You must re-add them after importing cases.
+
 To export a case:
 
 . Open the main menu, go to *Stack Management -> {kib}*, then select the *Saved Objects* tab.


### PR DESCRIPTION
Backports the following commits to 8.5:
 - [BUG][8.8] Add note that alerts attached to cases are not exported (#3310)