### PR TITLE
[BUG] Adding discrete tag to 8.0 header

### DIFF
--- a/docs/release-notes/8.8.asciidoc
+++ b/docs/release-notes/8.8.asciidoc
@@ -1,6 +1,7 @@
 [[release-notes-header-8.8.0]]
 == 8.8
 
+[discrete]
 [[release-notes-8.8.0]]
 === 8.8.0
 


### PR DESCRIPTION
Adds a discrete tag so the 8.8 release notes don't appear as a sub-page in the TOC.