### PR TITLE
Change 'ISO timezone' to 'IANA timezone' in conditional actions docs

### DIFF
--- a/docs/detections/api/rules/rules-api-bulk-actions.asciidoc
+++ b/docs/detections/api/rules/rules-api-bulk-actions.asciidoc
@@ -426,7 +426,7 @@ saved object ID of the action.
 *** `start` (String, required)
 *** `end` (String, required)
 
-** `timezone` (String, required): An ISO timezone name, such as `Europe/Madrid` or `America/New_York`. Specific offsets such as `UTC` or `UTC+1` will also work, but lack built-in DST.
+** `timezone` (String, required): An IANA timezone name, such as `Europe/Madrid` or `America/New_York`. Specific offsets such as `UTC` or `UTC+1` will also work, but lack built-in DST.
 
 * `query` (Object, optional): Object containing a query filter that gets applied to an action to determine whether the action should run. 
 ** `kql` (String, required): A KQL string.


### PR DESCRIPTION
I made a mistake when drafting these docs for @nastasha-solomon, timezone names like `Europe/Madrid` or `America/New_York` are actually called IANA timezones, not ISO. Small error but we want to be clear on this.