### PR TITLE
Fields browser is causing all field types to display as the "unknown"

### DIFF
--- a/docs/release-notes/8.8.asciidoc
+++ b/docs/release-notes/8.8.asciidoc
@@ -12,7 +12,7 @@ To view a detailed summary of new features and enhancements we've documented thi
 ==== Known issues
 
 * Setting the `max_signals` value higher than the {kibana-ref}/alert-action-settings-kb.html#alert-settings[`xpack.alerting.rules.run.alerts.max`] value will lead to rule failure.
-* All field types in the the **Fields** browser display as the `unknown` field type.
+* All field types in the **Fields** browser appear as `unknown`.
 
 [discrete]
 [[breaking-changes-8.8.0]]

--- a/docs/release-notes/8.8.asciidoc
+++ b/docs/release-notes/8.8.asciidoc
@@ -12,7 +12,7 @@ To view a detailed summary of new features and enhancements we've documented thi
 ==== Known issues
 
 * Setting the `max_signals` value higher than the {kibana-ref}/alert-action-settings-kb.html#alert-settings[`xpack.alerting.rules.run.alerts.max`] value will lead to rule failure.
-* All field types in the the **Fields** browser display as unknown field types.
+* All field types in the the **Fields** browser display as the `unknown` field type.
 
 [discrete]
 [[breaking-changes-8.8.0]]

--- a/docs/release-notes/8.8.asciidoc
+++ b/docs/release-notes/8.8.asciidoc
@@ -12,6 +12,7 @@ To view a detailed summary of new features and enhancements we've documented thi
 ==== Known issues
 
 * Setting the `max_signals` value higher than the {kibana-ref}/alert-action-settings-kb.html#alert-settings[`xpack.alerting.rules.run.alerts.max`] value will lead to rule failure.
+* All field types in the the **Fields** browser display as unknown field types.
 
 [discrete]
 [[breaking-changes-8.8.0]]


### PR DESCRIPTION
Fixes https://github.com/elastic/security-docs/issues/3375.

Preview [here](https://security-docs_3376.docs-preview.app.elstc.co/guide/en/security/master/release-notes-header-8.8.0.html#known-issue-8.8.0).