### PR TITLE
Users can now use FQDN names for their hosts

### DIFF
--- a/docs/release-notes/8.8.asciidoc
+++ b/docs/release-notes/8.8.asciidoc
@@ -5,7 +5,7 @@
 [[release-notes-8.8.0]]
 === 8.8.0
 
-To view a detailed summary of new features and enhancements we've documented this release, check out our {security-guide}/whats-new.html[{minor-version} release highlights].
+To view a detailed summary of the latest features and enhancements, check out our {security-guide}/whats-new.html[release highlights].
 
 [discrete]
 [[known-issue-8.8.0]]

--- a/docs/release-notes/8.8.asciidoc
+++ b/docs/release-notes/8.8.asciidoc
@@ -79,7 +79,7 @@ To view a detailed summary of the latest features and enhancements, check out ou
 * Session view: Makes the row representing the session leader remain visible when you scroll past it, and adds a button to this row that allows you to collapse child processes ({pull}154982[#154982]).
 * Reduces Linux process event volume by about 50% by combining `fork`, `exec`, and `end` events when they occur around the same time (does not affect queries of this data) ({pull}153213[#153213]).
 * Updates where the technical preview tags appear for host risk score features ({pull}156659[#156659], {pull}156514[#156514]).
-* You can now use fully qualified domain names (FQDNs) for hosts. To learn how to enable the FQDN feature flag, refer to {fleet-guide}/elastic-agent-standalone-feature-flags.html[Configure feature flags for standalone {agents}]. To learn how to set host names in {fleet}, refer to {fleet-guide}/fleet-settings.html#fleet-agent-hostname-format-settings[Agent Binary Download {fleet} settings]. 
+* Allows you to use fully qualified domain names (FQDNs) for hosts. To learn how to enable the FQDN feature flag, refer to {fleet-guide}/elastic-agent-standalone-feature-flags.html[Configure feature flags for standalone {agents}]. To learn how to set host names in {fleet}, refer to {fleet-guide}/fleet-settings.html#fleet-agent-hostname-format-settings[Agent Binary Download {fleet} settings]. 
 
 [discrete]
 [[bug-fixes-8.8.0]]

--- a/docs/release-notes/8.8.asciidoc
+++ b/docs/release-notes/8.8.asciidoc
@@ -5,7 +5,7 @@
 [[release-notes-8.8.0]]
 === 8.8.0
 
-To view a detailed summary of new features and enhancements we've documented this release, check out our {security-guide}/whats-new.html[8.8 release highlights].
+To view a detailed summary of new features and enhancements we've documented this release, check out our {security-guide}/whats-new.html[{minor-version} release highlights].
 
 [discrete]
 [[known-issue-8.8.0]]
@@ -79,6 +79,7 @@ To view a detailed summary of new features and enhancements we've documented thi
 * Session view: Makes the row representing the session leader remain visible when you scroll past it, and adds a button to this row that allows you to collapse child processes ({pull}154982[#154982]).
 * Reduces Linux process event volume by about 50% by combining `fork`, `exec`, and `end` events when they occur around the same time (does not affect queries of this data) ({pull}153213[#153213]).
 * Updates where the technical preview tags appear for host risk score features ({pull}156659[#156659], {pull}156514[#156514]).
+* You can now use fully qualified domain names (FQDN) for hosts. To learn how to enable the FQDN feature flag, refer to {fleet-guide}/elastic-agent-standalone-feature-flags.html[Configure feature flags for standalone Elastic Agents]. To learn how to set host names in Fleet, refer to {fleet-guide}/fleet-settings.html#fleet-agent-hostname-format-settings[Agent Binary Download Fleet settings]. 
 
 [discrete]
 [[bug-fixes-8.8.0]]

--- a/docs/release-notes/8.8.asciidoc
+++ b/docs/release-notes/8.8.asciidoc
@@ -79,7 +79,7 @@ To view a detailed summary of new features and enhancements we've documented thi
 * Session view: Makes the row representing the session leader remain visible when you scroll past it, and adds a button to this row that allows you to collapse child processes ({pull}154982[#154982]).
 * Reduces Linux process event volume by about 50% by combining `fork`, `exec`, and `end` events when they occur around the same time (does not affect queries of this data) ({pull}153213[#153213]).
 * Updates where the technical preview tags appear for host risk score features ({pull}156659[#156659], {pull}156514[#156514]).
-* You can now use fully qualified domain names (FQDN) for hosts. To learn how to enable the FQDN feature flag, refer to {fleet-guide}/elastic-agent-standalone-feature-flags.html[Configure feature flags for standalone Elastic Agents]. To learn how to set host names in Fleet, refer to {fleet-guide}/fleet-settings.html#fleet-agent-hostname-format-settings[Agent Binary Download Fleet settings]. 
+* You can now use fully qualified domain names (FQDNs) for hosts. To learn how to enable the FQDN feature flag, refer to {fleet-guide}/elastic-agent-standalone-feature-flags.html[Configure feature flags for standalone {agents}]. To learn how to set host names in {fleet}, refer to {fleet-guide}/fleet-settings.html#fleet-agent-hostname-format-settings[Agent Binary Download {fleet} settings]. 
 
 [discrete]
 [[bug-fixes-8.8.0]]


### PR DESCRIPTION
Fixes https://github.com/elastic/security-docs/issues/3391.

Preview [here](https://security-docs_3393.docs-preview.app.elstc.co/guide/en/security/master/release-notes-header-8.8.0.html#enhancements-8.8.0).