### PR TITLE
Fix link to obs guide topic about Splunk

### DIFF
--- a/docs/getting-started/ingest-data.asciidoc
+++ b/docs/getting-started/ingest-data.asciidoc
@@ -7,7 +7,7 @@ To ingest data, you can use:
 your hosts and sends logs, metrics, and endpoint security data to {elastic-sec}. See <<install-endpoint>>.
 * The {agent} with integrations, which are available in the {fleet-guide}/fleet-overview.html#package-registry-intro[Elastic Package Registry (EPR)]. To install an integration that works with {elastic-sec}, go to the {kib} Home page or main navigation menu and click *Add integrations*. On the Integrations page, click the *Security* category filter, then select an integration to view the installation instructions. For more information on integrations, refer to {integrations-docs}[{integrations}].
 * *{beats}* shippers installed for each system you want to monitor.
-* The {agent} to send data from Splunk to {elastic-sec}. See {observability-guide}/ingest-splunk.html[Ingest data from Splunk].
+* The {agent} to send data from Splunk to {elastic-sec}. See {observability-guide}/splunk-get-started.html[Get started with data from Splunk].
 * Third-party collectors configured to ship ECS-compliant data.
 <<siem-field-reference>> provides a list of ECS fields used in {elastic-sec}.
 


### PR DESCRIPTION
Updates the name and URL of the Splunk topic.

Fixes link error in https://github.com/elastic/observability-docs/pull/2990