### PR TITLE
Add stub page for Security Assistant

### DIFF
--- a/docs/assistant/security-assistant.asciidoc
+++ b/docs/assistant/security-assistant.asciidoc
@@ -1,0 +1,5 @@
+[[security-assistant]]
+[chapter]
+= Security Assistant
+
+This page is a placeholder for future documentation.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -28,6 +28,8 @@ include::getting-started/index.asciidoc[]
 
 include::getting-started/security-ui.asciidoc[]
 
+include::assistant/security-assistant.asciidoc[]
+
 include::dashboards/dashboards-overview.asciidoc[]
 
 include::getting-started/explore-intro.asciidoc[]


### PR DESCRIPTION
Adds stub page for Security Assistant (https://github.com/elastic/security-docs/issues/3420). Docs to follow in a separate PR.