### PR TITLE
Remove 8.8.0 BC tag

### DIFF
--- a/docs/release-notes/8.8.asciidoc
+++ b/docs/release-notes/8.8.asciidoc
@@ -19,6 +19,8 @@
 // NOTE: The breaking-changes tagged regions are reused in the Elastic Installation and Upgrade Guide. The pull attribute is defined within this snippet so it properly resolves in the output.
 // THIS ALSO MEANS IF YOU USE LINKS HERE, THEY SHOULD BE FULL URLS WITH NO ATTRIBUTES
 
+:pull: https://github.com/elastic/kibana/pull/
+
 There are no breaking changes in 8.8.1.
 
 //end::breaking-changes[]
@@ -58,9 +60,6 @@ To view a detailed summary of the latest features and enhancements, check out ou
 [[breaking-changes-8.8.0]]
 ==== Breaking changes
 
-// NOTE: The breaking-changes tagged regions are reused in the Elastic Installation and Upgrade Guide. The pull attribute is defined within this snippet so it properly resolves in the output.
-// THIS ALSO MEANS IF YOU USE LINKS HERE, THEY SHOULD BE FULL URLS WITH NO ATTRIBUTES
-:pull: https://github.com/elastic/kibana/pull/
 * The privileges for attaching alerts to cases have changed. Now, you need at least `Read` privileges for Security and `All` privileges for Cases ({pull}147985[#147985]).
 * Adds conditional actions to the rules API. In {elastic-sec} 8.7 and earlier, action frequencies were set on a rule level by defining the `throttle` field. In 8.8 and later, action frequencies are set at the action level, and the `throttle` field is replaced by the `frequency` and `alert_filters` fields. The following APIs are affected:
 ** https://www.elastic.co/guide/en/security/8.8/rules-api-get.html[Get rule]
@@ -68,7 +67,6 @@ To view a detailed summary of the latest features and enhancements, check out ou
 ** https://www.elastic.co/guide/en/security/8.8/rules-api-create.html#optional-actions-fields-rule-create[Create rule]
 ** https://www.elastic.co/guide/en/security/8.8/rules-api-update.html#optional-actions-fields-rule-update[Update rule]
 ** https://www.elastic.co/guide/en/security/8.8/bulk-actions-rules-api.html#optional-actions-fields-bulk-update[Bulk rule actions]
-
 
 [discrete]
 [[deprecations-8.8.0]]

--- a/docs/release-notes/8.8.asciidoc
+++ b/docs/release-notes/8.8.asciidoc
@@ -58,7 +58,6 @@ To view a detailed summary of the latest features and enhancements, check out ou
 [[breaking-changes-8.8.0]]
 ==== Breaking changes
 
-//tag::breaking-changes[]
 // NOTE: The breaking-changes tagged regions are reused in the Elastic Installation and Upgrade Guide. The pull attribute is defined within this snippet so it properly resolves in the output.
 // THIS ALSO MEANS IF YOU USE LINKS HERE, THEY SHOULD BE FULL URLS WITH NO ATTRIBUTES
 :pull: https://github.com/elastic/kibana/pull/
@@ -69,8 +68,6 @@ To view a detailed summary of the latest features and enhancements, check out ou
 ** https://www.elastic.co/guide/en/security/8.8/rules-api-create.html#optional-actions-fields-rule-create[Create rule]
 ** https://www.elastic.co/guide/en/security/8.8/rules-api-update.html#optional-actions-fields-rule-update[Update rule]
 ** https://www.elastic.co/guide/en/security/8.8/bulk-actions-rules-api.html#optional-actions-fields-bulk-update[Bulk rule actions]
-
-//end::breaking-changes[]
 
 
 [discrete]


### PR DESCRIPTION
Removes the breaking changes tag from the 8.8.0 breaking changes section in the Security release notes. This ensures the 8.8 [Elastic Security breaking changes](https://www.elastic.co/guide/en/elastic-stack/current/security-breaking-changes.html) page reflects the 8.8.1 breaking changes tagged region in the `8.8.asciidoc` file.

