### PR TITLE
[BUG] Remove advanced sorting toggle on Rules page [8.0]

### DIFF
--- a/docs/detections/rules-ui-manage.asciidoc
+++ b/docs/detections/rules-ui-manage.asciidoc
@@ -9,8 +9,6 @@ image::images/all-rules.png[The Rules page]
 
 You can sort the rules by clicking the *Rule*, *Last updated*, or *Enabled* column header.
 
-TIP: To sort by any other column, switch on the *Technical preview* toggle above the table. This experimental table view allows advanced sorting capabilities. If you experience performance issues when working with the table, you can turn this setting off.
-
 On the Rules page, you can:
 
 * <<load-prebuilt-rules>>


### PR DESCRIPTION
Fixes 8.0 for #3462.

Preview: [Manage detection rules](https://security-docs_3463.docs-preview.app.elstc.co/guide/en/security/8.0/rules-ui-management.html)