### PR TITLE
[7.17] Remove advanced sorting toggle on Rules page (#3463)

### DIFF
--- a/docs/detections/rules-ui-manage.asciidoc
+++ b/docs/detections/rules-ui-manage.asciidoc
@@ -9,8 +9,6 @@ image::images/all-rules.png[The Rules page]
 
 You can sort the rules by clicking the *Rule*, *Last updated*, or *Enabled* column header.
 
-TIP: To sort by any other column, switch on the *Technical preview* toggle above the table. This experimental table view allows advanced sorting capabilities. If you experience performance issues when working with the table, you can turn this setting off.
-
 On the Rules page, you can:
 
 * <<load-prebuilt-rules>>


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.0` to `7.17`:
 - [Remove advanced sorting toggle on Rules page (#3463)](https://github.com/elastic/security-docs/pull/3463)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)