### PR TITLE
Update .gitignore folder for `7.17` branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+docs/html_docs
+/html_docs


### PR DESCRIPTION
Adds `docs/html_docs`, `/html_docs` to `gitignore` folder. 