### PR TITLE
Add ETag information to self-hosted artifact sections

### DIFF
--- a/docs/getting-started/offline-endpoint.asciidoc
+++ b/docs/getting-started/offline-endpoint.asciidoc
@@ -22,6 +22,8 @@ Complete these steps:
 
 Set up and configure an HTTP reverse proxy to forward requests to https://artifacts.security.elastic.co and include response headers from the elastic.co server when proxying.
 
+IMPORTANT: The entity tag (Etag) header is a mandatory HTTP response header that you _must_ set in your server configuration file. {elastic-endpoint} uses the Etag header to determine whether your global artifacts have been updated since they were last downloaded. If your server configuration file does not contain an ETag header, {elastic-endpoint} won't download new artifacts when they're available.
+
 [discrete]
 ._Example: Nginx_
 [%collapsible]
@@ -96,6 +98,8 @@ Complete these steps:
 === Step 1: Deploy an HTTP file server
 
 Deploy an HTTP file server to serve files from a local directory, which will be filled with artifact update files in a later step.
+
+IMPORTANT: The entity tag (Etag) header is a mandatory HTTP response header that you _must_ set in your server configuration file. {elastic-endpoint} uses the Etag header to determine whether your global artifacts have been updated since they were last downloaded. If your server configuration file does not contain an ETag header, {elastic-endpoint} won't download new artifacts when they're available.
 
 [discrete]
 ._Example: Nginx_

--- a/docs/getting-started/offline-endpoint.asciidoc
+++ b/docs/getting-started/offline-endpoint.asciidoc
@@ -22,7 +22,7 @@ Complete these steps:
 
 Set up and configure an HTTP reverse proxy to forward requests to https://artifacts.security.elastic.co and include response headers from the elastic.co server when proxying.
 
-IMPORTANT: The entity tag (Etag) header is a mandatory HTTP response header that you _must_ set in your server configuration file. {elastic-endpoint} uses the Etag header to determine whether your global artifacts have been updated since they were last downloaded. If your server configuration file does not contain an ETag header, {elastic-endpoint} won't download new artifacts when they're available.
+IMPORTANT: The entity tag (`Etag`) header is a mandatory HTTP response header that you _must_ set in your server configuration file. {elastic-endpoint} uses the `Etag` header to determine whether your global artifacts have been updated since they were last downloaded. If your server configuration file does not contain an `ETag` header, {elastic-endpoint} won't download new artifacts when they're available.
 
 [discrete]
 ._Example: Nginx_

--- a/docs/getting-started/offline-endpoint.asciidoc
+++ b/docs/getting-started/offline-endpoint.asciidoc
@@ -99,7 +99,7 @@ Complete these steps:
 
 Deploy an HTTP file server to serve files from a local directory, which will be filled with artifact update files in a later step.
 
-IMPORTANT: The entity tag (Etag) header is a mandatory HTTP response header that you _must_ set in your server configuration file. {elastic-endpoint} uses the Etag header to determine whether your global artifacts have been updated since they were last downloaded. If your server configuration file does not contain an ETag header, {elastic-endpoint} won't download new artifacts when they're available.
+IMPORTANT: The entity tag (`Etag`) header is a mandatory HTTP response header that you _must_ set in your server configuration file. {elastic-endpoint} uses the `Etag` header to determine whether your global artifacts have been updated since they were last downloaded. If your server configuration file does not contain an `ETag` header, {elastic-endpoint} won't download new artifacts when they're available.
 
 [discrete]
 ._Example: Nginx_


### PR DESCRIPTION
Fixes https://github.com/elastic/security-docs/issues/3429.

NOTE: The note I added to both sections is the same, so you really only need to review one. I'll apply whatever feedback you have to the other section.

Preview:
- [Host an Elastic Endpoint artifact mirror | Step 1](https://security-docs_3476.docs-preview.app.elstc.co/guide/en/security/master/offline-endpoint.html#_step_1_deploy_an_http_reverse_proxy_server)
- [Host an air-gapped Elastic Endpoint artifact server | Step 1](https://security-docs_3476.docs-preview.app.elstc.co/guide/en/security/master/offline-endpoint.html#_step_1_deploy_an_http_file_server)