### PR TITLE
Backport updates to compatibility callout - investigation guides

### DIFF
--- a/docs/experimental-features/investigation-guide-actions.asciidoc
+++ b/docs/experimental-features/investigation-guide-actions.asciidoc
@@ -1,7 +1,7 @@
 [[interactive-investigation-guides]]
 == Interactive investigation guides
 
-IMPORTANT: This feature is available for {stack} versions 8.6.0 and newer. Additionally, interactive investigation guides are not compatible between release versions, so query buttons created in 8.6.0 won't render correctly in {version} and vice versa.
+IMPORTANT: Interactive investigation guides are compatible between {stack} versions 8.7.0 and later. Query buttons created in 8.6.x use different syntax and won't render correctly in later versions, and vice versa.
 
 Detection rule investigation guides suggest steps for triaging, analyzing, and responding to potential security issues. For custom rules, you can create an interactive investigation guide that includes buttons for launching runtime queries in <<timelines-ui,Timeline>>, using alert data and hard-coded literal values. This allows you to start detailed Timeline investigations directly from an alert using relevant data. 
 

--- a/docs/experimental-features/investigation-guide-actions.asciidoc
+++ b/docs/experimental-features/investigation-guide-actions.asciidoc
@@ -1,9 +1,9 @@
 [[interactive-investigation-guides]]
 == Interactive investigation guides
 
-IMPORTANT: Interactive investigation guides are compatible between {stack} versions 8.7.0 and later. Query buttons created in 8.6.x use different syntax and won't render correctly in later versions, and vice versa.
-
 Detection rule investigation guides suggest steps for triaging, analyzing, and responding to potential security issues. For custom rules, you can create an interactive investigation guide that includes buttons for launching runtime queries in <<timelines-ui,Timeline>>, using alert data and hard-coded literal values. This allows you to start detailed Timeline investigations directly from an alert using relevant data. 
+
+IMPORTANT: Interactive investigation guides are compatible between {stack} versions 8.7.0 and later. Query buttons created in 8.6.x use different syntax and won't render correctly in later versions, and vice versa.
 
 [role="screenshot"]
 image::images/ig-alert-flyout.png[Alert details flyout with interactive investigation guide,550]


### PR DESCRIPTION
Backports the revised compatibility callout as part of #3188.

Doing this manually because the file `investigation-guide-actions.asciidoc` was moved in the main/8.9 PR (#3503), along with several other non-backportable changes that make it difficult to use Mergify or backport tool. Once this PR is merged to `8.8`, then I should be able to use the backport tool to update `8.7` and `8.6`. 🤞

[Preview](https://security-docs_3505.docs-preview.app.elstc.co/guide/en/security/8.8/interactive-investigation-guides.html)