### PR TITLE
[BUG] Adds missing timeline templates

### DIFF
--- a/docs/events/timeline-templates.asciidoc
+++ b/docs/events/timeline-templates.asciidoc
@@ -24,6 +24,8 @@ NOTE: For information on how to add Timeline templates to rules, refer to <<crea
 
 When you load {elastic-sec} prebuilt rules, {elastic-sec} also loads a selection of prebuilt Timeline templates, which you can attach to detection rules. *Generic* templates use broad KQL queries to retrieve event data, and *Comprehensive* templates use detailed KQL queries to retrieve additional information. The following prebuilt templates appear by default:
 
+* *Alerts Involving a Single Host Timeline*: Investigate detection alerts involving a single host.
+* *Alerts Involving a Single User Timeline*: Investigate detection alerts involving a single user.
 * *Generic Endpoint Timeline*: Investigate {elastic-endpoint} detection alerts.
 * *Generic Network Timeline*: Investigate network-related detection alerts.
 * *Generic Process Timeline*: Investigate process-related detection alerts.


### PR DESCRIPTION
Fixes [#3526](https://github.com/elastic/security-docs/issues/3526).

Adds two missing timeline templates to 'About Timeline templates' page.

Preview: [About Timeline Templates](https://security-docs_3534.docs-preview.app.elstc.co/guide/en/security/master/timeline-templates-ui.html)
