### PR TITLE
[8.6] Prebuilt rules tags documentation (backport #3625)

### DIFF
--- a/docs/detections/rules-ui-manage.asciidoc
+++ b/docs/detections/rules-ui-manage.asciidoc
@@ -12,6 +12,7 @@ On the Rules page, you can:
 * <<sort-filter-rules>>
 * <<rule-status>>
 * <<load-prebuilt-rules>>
+* <<prebuilt-rule-tags>>
 * <<select-all-prebuilt-rules>>
 * <<download-prebuilt-rules>>
 * <<rule-prerequisites>>
@@ -63,6 +64,30 @@ default. If you want to modify a prebuilt rule, you must first duplicate it, the
 
 To learn how to enable detection rules in Elastic Security, watch the <<enable-detection-rules, tutorial>> at the end of this topic.
 ==============
+
+[float]
+[[prebuilt-rule-tags]]
+=== Prebuilt rule tags
+
+Each prebuilt rule includes several tags identifying the rule's purpose, detection method, associated resources, and other information to help categorize your rules. These tags are category-value pairs; for example, `OS: Windows` indicates rules designed for Windows endpoints. Categories include:
+
+* `Data Source`: The application, cloud provider, data shipper, or Elastic integration providing data for the rule.
+* `Domain`: A general category of data source types (such as cloud, endpoint, or network).
+* `OS`: The host operating system, which could be considered another data source type.
+* `Resources`: Additional rule resources such as investigation guides.
+* `Rule Type`: Identifies if the rule depends on specialized resources (such as machine learning jobs or threat intelligence indicators), or if it's a higher-order rule built from other rules' alerts.
+* `Tactic`: MITRE ATT&CK tactics that the rule addresses.
+* `Threat`: Specific threats the rule detects (such as Cobalt Strike or BPFDoor).
+* `Use Case`: The type of activity the rule detects and its purpose. Use cases include:
+** `Active Directory Monitoring`: Detects changes related to Active Directory.
+** `Asset Visibility`: Detects changes to specified asset types.
+** `Configuration Audit`: Detects undesirable configuration changes.
+** `Guided Onboarding`: Example rule, used for {elastic-sec}'s guided onboarding tour.
+** `Identity and Access Audit`: Detects activity related to identity and access management (IAM).
+** `Log Auditing`: Detects activity on log configurations or storage.
+** `Network Security Monitoring`: Detects network security configuration activity.
+** `Threat Detection`: Detects threats.
+** `Vulnerability`: Detects exploitation of specific vulnerabilities.
 
 [float]
 [[select-all-prebuilt-rules]]


### PR DESCRIPTION
Backports the following commits to 8.6:
 - add prebuilt rules tags section (#3625)