### PR TITLE
Update siem-ui.asciidoc

### DIFF
--- a/docs/getting-started/siem-ui.asciidoc
+++ b/docs/getting-started/siem-ui.asciidoc
@@ -1,4 +1,4 @@
-[[es-ui-overview]]
+[[siem-ui-overview]]
 [role="xpack"]
 = Elastic Security user interface overview
 


### PR DESCRIPTION
Fix duplicate page tag - from `es-ui-overview` to `siem-ui-overview`. 

The original tag is also used in `security-ui.asciidoc`, and we suspect this could be causing the migration tool to migrate the wrong page.