### PR TITLE
Remove breaking changes tags

### DIFF
--- a/docs/release-notes/8.0.asciidoc
+++ b/docs/release-notes/8.0.asciidoc
@@ -103,7 +103,6 @@ A new Lucene 9 validation change may cause event correlation (EQL) rule errors w
 [[breaking-changes-8.0.0]]
 ==== Breaking Changes
 
-:pull: https://github.com/elastic/kibana/pull/
 * Removes the trusted application API. The trusted application interface retains current functionality, but now uses the exception list API ({pull}120134[#120134]).
 * Removes the list endpoint metadata API ({pull}119401[#119401]).
 * Lets you grant privileges for cases separately from {elastic-sec} privileges ({pull}113573[#113573], {pull}112980[#112980]). As a result of this change, you must update case privileges for existing roles _before_ upgrading to {stack} 8.0.0. Follow these steps:

--- a/docs/release-notes/8.0.asciidoc
+++ b/docs/release-notes/8.0.asciidoc
@@ -102,7 +102,7 @@ A new Lucene 9 validation change may cause event correlation (EQL) rule errors w
 [discrete]
 [[breaking-changes-8.0.0]]
 ==== Breaking Changes
-// tag::breaking-changes[]
+
 :pull: https://github.com/elastic/kibana/pull/
 * Removes the trusted application API. The trusted application interface retains current functionality, but now uses the exception list API ({pull}120134[#120134]).
 * Removes the list endpoint metadata API ({pull}119401[#119401]).
@@ -111,7 +111,6 @@ A new Lucene 9 validation change may cause event correlation (EQL) rule errors w
 . From the Upgrade Assistant page, review the Kibana deprecation warnings. A message prompts you to update role privileges because of changes to the {elastic-sec} Cases feature.
 . Click the message to open it, then click *Quick resolve*.
 . Refresh the page to verify the deprecation was resolved, then return to the guided steps on the Upgrade Assistant page.
-// end::breaking-changes[]
 
 [discrete]
 [[deprecations-8.0.0]]

--- a/docs/release-notes/8.1.asciidoc
+++ b/docs/release-notes/8.1.asciidoc
@@ -65,7 +65,6 @@
 [[breaking-changes-8.1.0]]
 ==== Breaking changes
 
-:pull: https://github.com/elastic/kibana/pull/
 There are no breaking changes in 8.1.0.
 
 [discrete]

--- a/docs/release-notes/8.1.asciidoc
+++ b/docs/release-notes/8.1.asciidoc
@@ -64,11 +64,9 @@
 [discrete]
 [[breaking-changes-8.1.0]]
 ==== Breaking changes
-// tag::breaking-changes[]
-// NOTE: The breaking-changes tagged regions are re-used in the Elastic Installation and Upgrade Guide. The pull attribute is defined within this snippet so it properly resolves in the output.
+
 :pull: https://github.com/elastic/kibana/pull/
 There are no breaking changes in 8.1.0.
-// end::breaking-changes[]
 
 [discrete]
 [[features-8.1.0]]

--- a/docs/release-notes/8.2.asciidoc
+++ b/docs/release-notes/8.2.asciidoc
@@ -73,11 +73,9 @@ To avoid breakage, we recommend using the <<bulk-actions-rules-api,bulk rule act
 [discrete]
 [[breaking-changes-8.2.0]]
 ==== Breaking changes
-// tag::breaking-changes[]
-// NOTE: The breaking-changes tagged regions are reused in the Elastic Installation and Upgrade Guide. The pull attribute is defined within this snippet so it properly resolves in the output.
+
 :pull: https://github.com/elastic/kibana/pull/
 There are no breaking changes in 8.2.0.
-// end::breaking-changes[]
 
 [discrete]
 [[features-8.2.0]]

--- a/docs/release-notes/8.2.asciidoc
+++ b/docs/release-notes/8.2.asciidoc
@@ -74,7 +74,6 @@ To avoid breakage, we recommend using the <<bulk-actions-rules-api,bulk rule act
 [[breaking-changes-8.2.0]]
 ==== Breaking changes
 
-:pull: https://github.com/elastic/kibana/pull/
 There are no breaking changes in 8.2.0.
 
 [discrete]

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -170,11 +170,9 @@ A new Lucene 9 validation change may cause event correlation rule (EQL) errors w
 [discrete]
 [[breaking-changes-8.3.0]]
 ==== Breaking changes
-// tag::breaking-changes[]
-// NOTE: The breaking-changes tagged regions are reused in the Elastic Installation and Upgrade Guide. The pull attribute is defined within this snippet so it properly resolves in the output.
+
 :pull: https://github.com/elastic/kibana/pull/
 * Updates Elastic prebuilt {ml} detection rules for some Windows and Linux anomalies with new `v3` {ml} jobs. A confirmation modal is displayed when updating rules if `v1`/`v2` jobs are installed. If you're using 8.2 or earlier versions of {beats} or {agent}, you may need to duplicate prebuilt rules or create new custom rules _before_ you update the prebuilt rules. Once you update the prebuilt rules, they will only use `v3` {ml} jobs. Refer to {security-guide}/alerts-ui-monitor.html#ml-job-compatibility[Troubleshoot missing alerts for machine learning jobs] for more information ({pull}128334[#128334]).
-// end::breaking-changes[]
 
 [discrete]
 [[features-8.3.0]]

--- a/docs/release-notes/8.3.asciidoc
+++ b/docs/release-notes/8.3.asciidoc
@@ -171,7 +171,6 @@ A new Lucene 9 validation change may cause event correlation rule (EQL) errors w
 [[breaking-changes-8.3.0]]
 ==== Breaking changes
 
-:pull: https://github.com/elastic/kibana/pull/
 * Updates Elastic prebuilt {ml} detection rules for some Windows and Linux anomalies with new `v3` {ml} jobs. A confirmation modal is displayed when updating rules if `v1`/`v2` jobs are installed. If you're using 8.2 or earlier versions of {beats} or {agent}, you may need to duplicate prebuilt rules or create new custom rules _before_ you update the prebuilt rules. Once you update the prebuilt rules, they will only use `v3` {ml} jobs. Refer to {security-guide}/alerts-ui-monitor.html#ml-job-compatibility[Troubleshoot missing alerts for machine learning jobs] for more information ({pull}128334[#128334]).
 
 [discrete]

--- a/docs/release-notes/8.4.asciidoc
+++ b/docs/release-notes/8.4.asciidoc
@@ -161,7 +161,6 @@ NOTE: Uninstalling the {endpoint-cloud-sec} integration may put {agent}  in an `
 [[breaking-changes-8.4.0]]
 ==== Breaking changes
 
-:pull: {pull}
 There are no breaking changes in 8.4.0.
 
 [discrete]

--- a/docs/release-notes/8.4.asciidoc
+++ b/docs/release-notes/8.4.asciidoc
@@ -160,11 +160,9 @@ NOTE: Uninstalling the {endpoint-cloud-sec} integration may put {agent}  in an `
 [discrete]
 [[breaking-changes-8.4.0]]
 ==== Breaking changes
-// tag::breaking-changes[]
-// NOTE: The breaking-changes tagged regions are reused in the Elastic Installation and Upgrade Guide. The pull attribute is defined within this snippet so it properly resolves in the output.
+
 :pull: {pull}
 There are no breaking changes in 8.4.0.
-// end::breaking-changes[]
 
 [discrete]
 [[features-8.4.0]]

--- a/docs/release-notes/8.5.asciidoc
+++ b/docs/release-notes/8.5.asciidoc
@@ -74,11 +74,9 @@ Upgrading to 8.6 or higher resolves this issue. If you’d prefer to stay on 8.5
 [discrete]
 [[breaking-changes-8.5.0]]
 ==== Breaking changes
-// tag::breaking-changes[]
-// NOTE: The breaking-changes tagged regions are reused in the Elastic Installation and Upgrade Guide. The pull attribute is defined within this snippet so it properly resolves in the output.
+
 :pull: https://github.com/elastic/kibana/pull/
 * Host and user risk score features that were installed in 8.4 or earlier are not ECS-compatible and, therefore, cannot generate new risk scores in 8.5. Before upgrading, users can archive their existing risk indices if they want to keep their old host and user risk scores. Otherwise, new risk indices will be generated once users upgrade host and user risk score features ({pull}140377[#140377]).
-// end::breaking-changes[]
 
 [discrete]
 [[deprecations-8.5.0]]

--- a/docs/release-notes/8.5.asciidoc
+++ b/docs/release-notes/8.5.asciidoc
@@ -75,7 +75,6 @@ Upgrading to 8.6 or higher resolves this issue. If you’d prefer to stay on 8.5
 [[breaking-changes-8.5.0]]
 ==== Breaking changes
 
-:pull: https://github.com/elastic/kibana/pull/
 * Host and user risk score features that were installed in 8.4 or earlier are not ECS-compatible and, therefore, cannot generate new risk scores in 8.5. Before upgrading, users can archive their existing risk indices if they want to keep their old host and user risk scores. Otherwise, new risk indices will be generated once users upgrade host and user risk score features ({pull}140377[#140377]).
 
 [discrete]

--- a/docs/release-notes/8.6.asciidoc
+++ b/docs/release-notes/8.6.asciidoc
@@ -36,12 +36,7 @@
 [[breaking-changes-8.6.0]]
 ==== Breaking changes
 
-// tag::breaking-changes[]
-// NOTE: The breaking-changes tagged regions are reused in the Elastic Installation and Upgrade Guide. The pull attribute is defined within this snippet so it properly resolves in the output.
-:pull: https://github.com/elastic/kibana/pull/
 There are no breaking changes in 8.6.0.
-// end::breaking-changes[]
-
 
 [discrete]
 [[deprecations-8.6.0]]

--- a/docs/release-notes/8.8.asciidoc
+++ b/docs/release-notes/8.8.asciidoc
@@ -15,8 +15,6 @@
 [[breaking-changes-8.8.2]]
 ==== Breaking changes
 
-:pull: https://github.com/elastic/kibana/pull/
-
 There are no breaking changes in 8.8.2.
 
 [discrete]

--- a/docs/release-notes/8.9.asciidoc
+++ b/docs/release-notes/8.9.asciidoc
@@ -17,8 +17,6 @@
 [[breaking-changes-8.9.0]]
 ==== Breaking changes
 
-:pull: https://github.com/elastic/kibana/pull/
-
 There are no breaking changes in 8.9.0.
 
 [discrete]

--- a/docs/release-notes/8.9.asciidoc
+++ b/docs/release-notes/8.9.asciidoc
@@ -16,15 +16,10 @@
 [discrete]
 [[breaking-changes-8.9.0]]
 ==== Breaking changes
-//tag::breaking-changes[]
-// NOTE: The breaking-changes tagged regions are reused in the Elastic Installation and Upgrade Guide. The pull attribute is defined within this snippet so it properly resolves in the output.
-// THIS ALSO MEANS IF YOU USE LINKS HERE, THEY SHOULD BE FULL URLS WITH NO ATTRIBUTES
 
 :pull: https://github.com/elastic/kibana/pull/
 
 There are no breaking changes in 8.9.0.
-
-//end::breaking-changes[]
 
 [discrete]
 [[deprecations-8.9.0]]


### PR DESCRIPTION
With https://github.com/elastic/stack-docs/pull/2495 merged, we no longer need tags to reuse breaking changes in the Stack Install/Upgrade guide.