### PR TITLE
[BUG][8.6] Re-add the beta tag to docs for the Alerts related by process ancestry section

### DIFF
--- a/docs/detections/alerts-view-details.asciidoc
+++ b/docs/detections/alerts-view-details.asciidoc
@@ -71,6 +71,8 @@ If you have a https://www.elastic.co/pricing[Platinum or higher subscription], t
 
 * *Alerts related by session ID* - Shows the ten most recent alerts generated during the same <<session-view, session>>. These alerts share the same session ID, which is a unique ID for tracking a given Linux session. To use this feature, you must enable the *Include session data* setting in your {elastic-defend} integration policy. Refer to <<enable-session-view, Enable Session View data>> for more information.
 * *Alerts related by process ancestry* - Shows alerts that are related by process events on the same linear branch. Note that alerts generated from processes on child or related branches are not shown. To further examine alerts, click *Investigate in timeline*.
++
+beta::[]
 
 [discrete]
 [[alerts-enrich-host-user-risk-score]]


### PR DESCRIPTION
Fixes https://github.com/elastic/security-docs/issues/3041.

[Preview](https://security-docs_3681.docs-preview.app.elstc.co/guide/en/security/8.6/view-alert-details.html#alert-details-insights) - Re-added the beta tag to docs for the Alerts related by process ancestry section.