### PR TITLE
[BUG] Mention limited preview options for Threshold and Event Correlation rules

### DIFF
--- a/docs/detections/rules-ui-create.asciidoc
+++ b/docs/detections/rules-ui-create.asciidoc
@@ -268,8 +268,14 @@ To preview a rule:
 . Write the rule query.
 . Select a timeframe of data to preview query results -- *Last hour*, *Last day*, or *Last month* -- from the *Quick query preview* drop-down.
 +
-NOTE: For threshold rules, you can only preview rule results from the last hour. For
-Event Correlation rules, you can only preview rule results from the last hour and the last day.
+[NOTE] 
+=====
+Some rules have timeframe limitations:
+
+- *Threshold rules*: You can only preview query results from the last hour.
+- *Event Correlation rules*: You can only preview query results from the last hour and the last day.
+=====
+
 . Click *Preview results*. The rule preview shows a histogram and alerts table with the alerts you can expect, based on the defined rule parameters and historical events in your indices. You can view the details of a particular alert by clicking the *View details* button in the alerts table.
 +
 NOTE: The preview excludes the effects of rule exceptions and timestamp overrides. In the preview histogram, alerts are stacked by `event.category` (or `host.name` for machine learning rules), and events with multiple values are counted more than once.

--- a/docs/detections/rules-ui-create.asciidoc
+++ b/docs/detections/rules-ui-create.asciidoc
@@ -273,7 +273,7 @@ To preview a rule:
 Some rules have timeframe limitations:
 
 - *Threshold rules*: You can only preview query results from the last hour.
-- *Event Correlation rules*: You can only preview query results from the last hour and the last day.
+- *Event correlation rules*: You can only preview query results from the last hour and the last day.
 =====
 
 . Click *Preview results*. The rule preview shows a histogram and alerts table with the alerts you can expect, based on the defined rule parameters and historical events in your indices. You can view the details of a particular alert by clicking the *View details* button in the alerts table.

--- a/docs/detections/rules-ui-create.asciidoc
+++ b/docs/detections/rules-ui-create.asciidoc
@@ -266,9 +266,10 @@ NOTE: To preview rules, you need the `read` privilege for the `.preview.alerts-s
 To preview a rule:
 
 . Write the rule query.
-+
 . Select a timeframe of data to preview query results -- *Last hour*, *Last day*, or *Last month* -- from the *Quick query preview* drop-down.
 +
+NOTE: For threshold rules, you can only preview rule results from the last hour. For
+Event Correlation rules, you can only preview rule results from the last hour and the last day.
 . Click *Preview results*. The rule preview shows a histogram and alerts table with the alerts you can expect, based on the defined rule parameters and historical events in your indices. You can view the details of a particular alert by clicking the *View details* button in the alerts table.
 +
 NOTE: The preview excludes the effects of rule exceptions and timestamp overrides. In the preview histogram, alerts are stacked by `event.category` (or `host.name` for machine learning rules), and events with multiple values are counted more than once.


### PR DESCRIPTION
Fixes https://github.com/elastic/security-docs/issues/2238.

[Preview](https://security-docs_3683.docs-preview.app.elstc.co/guide/en/security/8.3/rules-ui-create.html#preview-rules) - Added note under step 2.