### PR TITLE
Get started with D4C - enable prebuilt rule details

### DIFF
--- a/docs/cloud-native-security/d4c-get-started.asciidoc
+++ b/docs/cloud-native-security/d4c-get-started.asciidoc
@@ -43,13 +43,14 @@ One of the <<d4c-default-policies, default D4C policies>> sends process telemetr
 
 In order to detect threats using this data, you'll need active <<detection-engine-overview, detection rules>>. Elastic has prebuilt detection rules designed for this data. (You can also create your own <<rules-ui-create, custom rules>>.)
 
-To install and enable Elastic's prebuilt rules:
+To install and enable the prebuilt rules:
 
 . Go to *Security > Manage > Rules*, then click *Add Elastic rules*.
-. Use the *Tags* selector to search for `container`. Select the `Data Source: Elastic Defend for Containers` tag. The rules table displays relevant rules.
-. Select all the displayed rules and click *Install _x_ selected rule(s)*.
-. Once the rules have loaded, you will see the Rules management page. Use the *Tags* selector to search for `container`. Select the `Container Workload Protection` tag.
+. Use the *Tags* selector to search for `container`. Select the `Data Source: Elastic Defend for Containers` tag.
+. Select all the displayed rules, then click *Install _x_ selected rule(s)*.
+. Return to the Rules page. Use the *Tags* selector to search for `container`. Select the `Data Source: Elastic Defend for Containers` tag.
 . Select all the rules with the tag, and then click *Bulk actions > Enable*.
+
 
 [[d4c-get-started-drift]]
 [discrete]
@@ -57,9 +58,13 @@ To install and enable Elastic's prebuilt rules:
 
 {elastic-sec} defines container drift as creating a new executable or modifying an existing executable within a container. Blocking drift restricts the number of attack vectors available to bad actors by prohibiting them from using external tools.
 
-One of the <<d4c-default-policies, default D4C policies>> creates alerts in {elastic-sec} when container drift is detected. Before you enable blocking, we strongly recommend that you observe a production workload using the default policy to ensure that the workload does not create or modify executables as part of its normal operation.
+To enable drift detection, you can use the default D4C policy:
 
-To enable blocking:
+. Make sure the <<d4c-default-policies, default policy>> has not been deleted and remains active.
+. Make sure you enabled at least the "Cloud Workload Protection" rule, by following the steps to install prebuilt rules, above.
+
+
+To enable drift prevention, create a new policy:
 
 . Add a new selector called `blockDrift`.
 . Go to *Security > Manage > Container Workload Protection > Your integration name*.
@@ -69,6 +74,8 @@ To enable blocking:
 . Under *Match selectors*, add the name of your new selector, for example: `blockDrift`.
 . Select the *Alert* and *Block* actions.
 . Click *Save integration*.
+
+IMPORTANT: Before you enable blocking, we strongly recommend that you observe a production workload using the default policy to ensure that the workload does not create or modify executables as part of its normal operation.
 
 [[d4c-get-started-validation]]
 [discrete]


### PR DESCRIPTION
Resolves #3654 by adding information to the Getting started with D4C page that tells users to enable the Container Workload Protection prebuilt rule in order to complete set up of "Drift prevention". The Container Workload Protection rule creates detection alerts when the D4C integration creates alerts (it writes them to a different index).

Preview: Get started with D4C 