### PR TITLE
Add sorting to Endpoint Metadata routes

### DIFF
--- a/docs/management/api/get-endpoint-api.asciidoc
+++ b/docs/management/api/get-endpoint-api.asciidoc
@@ -29,7 +29,6 @@ GET /api/endpoint/metadata/ed518850-681a-4d60-bb98-e22640cae2a8
 {
     "host_status": "healthy",
     "last_checkin": "2023-07-04T15:48:57.360Z",
-    "enrolled_at": "2023-07-03T12:36:13.765Z",
     "metadata": {
         "@timestamp": "2023-07-04T15:48:57.3609346Z",
         "Endpoint": {

--- a/docs/management/api/get-endpoint-api.asciidoc
+++ b/docs/management/api/get-endpoint-api.asciidoc
@@ -29,6 +29,7 @@ GET /api/endpoint/metadata/ed518850-681a-4d60-bb98-e22640cae2a8
 {
     "host_status": "healthy",
     "last_checkin": "2023-07-04T15:48:57.360Z",
+    "enrolled_at": "2023-07-03T12:36:13.765Z",
     "metadata": {
         "@timestamp": "2023-07-04T15:48:57.3609346Z",
         "Endpoint": {

--- a/docs/management/api/list-endpoints-api.asciidoc
+++ b/docs/management/api/list-endpoints-api.asciidoc
@@ -21,8 +21,7 @@ All parameters are optional:
 |`kuery` |string |A KQL string. |
 |`hostStatuses` |string[] a|A set of agent health statuses to filter by.
 
-Accepted host status values are:
-
+.Accepted host status values are:
 * `healthy`
 * `unhealthy`
 * `offline`
@@ -33,8 +32,7 @@ Accepted host status values are:
 |
 |`sortField` |string a|Determines which field is used to sort the results.
 
-Accepted field values are:
-
+.Accepted field values are:
 * `metadata.host.hostname`
 * `host_status`
 * `metadata.Endpoint.policy.applied.name`

--- a/docs/management/api/list-endpoints-api.asciidoc
+++ b/docs/management/api/list-endpoints-api.asciidoc
@@ -31,7 +31,7 @@ Accepted host status values are:
 * `unenrolled`
 
 |
-|`sortField` |string |Determines which field is used to sort the results.
+|`sortField` |string a|Determines which field is used to sort the results.
 
 Accepted field values are:
 

--- a/docs/management/api/list-endpoints-api.asciidoc
+++ b/docs/management/api/list-endpoints-api.asciidoc
@@ -89,7 +89,6 @@ GET /api/endpoint/metadata?hostStatuses=["healthy", "updating"]
         {
             "host_status": "healthy",
             "last_checkin": "2023-07-04T15:47:57.432Z",
-            "enrolled_at": "2023-07-03T12:36:13.765Z",
             "metadata": {
                 "@timestamp": "2023-07-04T15:47:57.432173535Z",
                 "Endpoint": {
@@ -200,7 +199,6 @@ GET /api/endpoint/metadata?hostStatuses=["healthy", "updating"]
         {
             "host_status": "healthy",
             "last_checkin": "2023-07-04T15:44:31.491Z",
-            "enrolled_at": "2023-07-03T12:36:13.765Z",
             "metadata": {
                 "@timestamp": "2023-07-04T15:44:31.4917849Z",
                 "Endpoint": {

--- a/docs/management/api/list-endpoints-api.asciidoc
+++ b/docs/management/api/list-endpoints-api.asciidoc
@@ -31,6 +31,22 @@ Accepted host status values are:
 * `unenrolled`
 
 |
+|`sortField` |string |Determines which field is used to sort the results.
+
+Accepted field values are:
+
+* `metadata.host.hostname`
+* `host_status`
+* `metadata.Endpoint.policy.applied.name`
+* `metadata.Endpoint.policy.applied.status`
+* `metadata.host.os.name`
+* `metadata.host.ip`
+* `metadata.agent.version`
+* `last_checkin`
+* `enrolled_at`
+
+|`enrolled_at`
+|`sortDirection` |string |Determines the sort order, which can be `desc` or `asc`. |`desc`
 |==============================================
 
 
@@ -75,6 +91,7 @@ GET /api/endpoint/metadata?hostStatuses=["healthy", "updating"]
         {
             "host_status": "healthy",
             "last_checkin": "2023-07-04T15:47:57.432Z",
+            "enrolled_at": "2023-07-03T12:36:13.765Z",
             "metadata": {
                 "@timestamp": "2023-07-04T15:47:57.432173535Z",
                 "Endpoint": {
@@ -185,6 +202,7 @@ GET /api/endpoint/metadata?hostStatuses=["healthy", "updating"]
         {
             "host_status": "healthy",
             "last_checkin": "2023-07-04T15:44:31.491Z",
+            "enrolled_at": "2023-07-03T12:36:13.765Z",
             "metadata": {
                 "@timestamp": "2023-07-04T15:44:31.4917849Z",
                 "Endpoint": {
@@ -295,6 +313,8 @@ GET /api/endpoint/metadata?hostStatuses=["healthy", "updating"]
     ],
     "total": 2,
     "page": 0,
-    "pageSize": 10
+    "pageSize": 10,
+    "sortField": "enrolled_at",
+    "sortDirection": "desc"
 }
 --------------------------------------------------


### PR DESCRIPTION
fixes #3684 

Update the docs with the modifications of PR https://github.com/elastic/kibana/pull/162142.

It adds:
- sorting to the list endpoints API
- ~`enrolled_at` field to the response of the list endpoints API and get endpoint API~