### PR TITLE
[DOCS] Remove content reuse for cases

### DIFF
--- a/docs/cases/cases-manage.asciidoc
+++ b/docs/cases/cases-manage.asciidoc
@@ -41,7 +41,36 @@ image::images/cases-ui-open.png[Shows an open case]
 [[cases-ui-notifications]]
 == Add email notifications
 
-include::{kibana-dir}/management/cases/manage-cases.asciidoc[tag=case-notifications]
+You can configure email notifications that occur when users are assigned to
+cases.
+
+For hosted {kib} on {ess}:
+
+. Add the email addresses to the monitoring email allowlist. Follow the steps in
+{cloud}/ec-watcher.html#ec-watcher-allowlist[Send alerts by email].
++
+--
+You do not need to take any more steps to configure an email connector or update
+{kib} user settings, since the preconfigured Elastic-Cloud-SMTP connector is
+used by default.
+--
+
+For self-managed {kib}:
+
+. Create a preconfigured email connector.
++
+--
+NOTE: At this time, email notifications support only preconfigured connectors,
+which are defined in the `kibana.yml` file. For examples, refer to
+{kibana-ref}/email-action-type.html#preconfigured-email-configuration[Preconfigured email connector]
+and {kibana-ref}/email-action-type.html#configuring-email[Configuring email connectors for well-known services].
+--
+. Set the `notifications.connectors.default.email` {kib} setting to the name of
+your email connector.
+. If you want the email notifications to contain links back to the case, you
+must configure the {kibana-ref}/settings.html#server-publicBaseUrl[server.publicBaseUrl] setting.
+
+When you subsequently add assignees to cases, they receive an email.
 
 [float]
 [[cases-ui-manage]]

--- a/docs/cases/cases-manage.asciidoc
+++ b/docs/cases/cases-manage.asciidoc
@@ -60,10 +60,8 @@ For self-managed {kib}:
 . Create a preconfigured email connector.
 +
 --
-NOTE: At this time, email notifications support only preconfigured connectors,
-which are defined in the `kibana.yml` file. For examples, refer to
-{kibana-ref}/email-action-type.html#preconfigured-email-configuration[Preconfigured email connector]
-and {kibana-ref}/email-action-type.html#configuring-email[Configuring email connectors for well-known services].
+NOTE: At this time, email notifications support only {kibana-ref}/pre-configured-connectors.html[preconfigured email connectors],
+which are defined in the `kibana.yml` file.
 --
 . Set the `notifications.connectors.default.email` {kib} setting to the name of
 your email connector.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -14,7 +14,6 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :siem-ui:      {es-sec-ui}
 :ml-dir:       {stack-docs-root}/docs/en/stack/ml
 :beats-dir:    {beats-root}
-:kibana-dir:   {kibana-root}/docs
 
 include::es-overview.asciidoc[]
 


### PR DESCRIPTION
This PR removes a tagged region to err on the side of simplicity as we migrate our content.