### PR TITLE
Adds cross ref to 8.9.1 release notes 

### DIFF
--- a/docs/release-notes/8.9.asciidoc
+++ b/docs/release-notes/8.9.asciidoc
@@ -60,7 +60,7 @@ There are no breaking changes in 8.9.1.
 [discrete]
 [[enhancements-8.9.1]]
 ==== Enhancements
-* Event correlation queries and rules can now detect missing events in EQL sequences.
+* Event correlation queries and rules can now detect {ref}/eql-syntax.html#eql-missing-events[missing events] in EQL sequences.
 
 [discrete]
 [[bug-fixes-8.9.1]]


### PR DESCRIPTION
Adds a reference to the [missing events](https://www.elastic.co/guide/en/elasticsearch/reference/master/eql-syntax.html#eql-missing-events) section of the EQL syntax reference docs.

Preview