### PR TITLE
Fix several typos in "Configure an integration policy for Elastic Defend"

### DIFF
--- a/docs/getting-started/configure-integration-policy.asciidoc
+++ b/docs/getting-started/configure-integration-policy.asciidoc
@@ -50,7 +50,7 @@ to create a new trusted application, go to **Manage** -> **Trusted applications*
 [[malware-protection]]
 == Malware protection
 
-Malware prevention on the {agent} detects and stops malicious attacks by using a <<machine-learning-model, machine learning model>>
+{elastic-defend} malware prevention detects and stops malicious attacks by using a <<machine-learning-model, machine learning model>>
 that looks for static attributes to determine if a file is malicious or benign.
 
 By default, malware protection is enabled on Windows, macOS, and Linux hosts.
@@ -70,16 +70,16 @@ Malware protection also allows you to manage a blocklist to prevent specified ap
 extending the list of processes that {elastic-defend} considers malicious. Use the **Blocklist enabled** toggle
 to enable or disable this feature for all hosts associated with the integration policy. To configure the blocklist, refer to <<blocklist>>.
 
-When *Detect* is enabled for malware protection, {agent} will quarantine any malicious file it finds. Specifically {agent} will remove the file from its current location, encrypt it with the encryption key `ELASTIC`, move it to a different folder, and rename it as an ID string, such as `318e70c2-af9b-4c3a-939d-11410b9a112c`.
+When *Prevent* is enabled for malware protection, {elastic-defend} will quarantine any malicious file it finds. Specifically {elastic-defend} will remove the file from its current location, encrypt it with the encryption key `ELASTIC`, move it to a different folder, and rename it as an GUID string, such as `318e70c2-af9b-4c3a-939d-11410b9a112c`.
 
 The quarantine folder location varies by operating system:
 
 - macOS: `/System/Volumes/Data/.equarantine`
 - Linux: `.equarantine` at the root of the mount point of the file being quarantined
-- Windows - {agent} versions 8.5 and later: `[DriveLetter:]\.quarantine`, unless the files are from the `C:` drive. These files are moved to `C:\Program Files\Elastic\Endpoint\state\.equarantine`.
-- Windows - {agent} versions 8.4 and earlier: `[DriveLetter:]\.quarantine`, for any drive
+- Windows - {elastic-defend} versions 8.5 and later: `[DriveLetter:]\.quarantine`, unless the files are from the `C:` drive. These files are moved to `C:\Program Files\Elastic\Endpoint\state\.equarantine`.
+- Windows - {elastic-defend} versions 8.4 and earlier: `[DriveLetter:]\.quarantine`, for any drive
 
-To restore a quarantined file to its original state and location, <<add-exceptions, add an exception>> to the rule that identified the file as malicious. If the exception would've stopped the rule from identifying the file as malicious, {agent} restores the file.
+To restore a quarantined file to its original state and location, <<add-exceptions, add an exception>> to the rule that identified the file as malicious. If the exception would've stopped the rule from identifying the file as malicious, {elastic-defend} restores the file.
 
 [role="screenshot"]
 image::images/install-endpoint/malware-protection.png[Detail of malware protection section.]
@@ -97,7 +97,7 @@ If you upgrade to a Platinum or Enterprise license from Basic or Gold, ransomwar
 
 Ransomware protection levels are:
 
-* **Detect**: Detects ransomware on the host and generates an alert. The {agent}
+* **Detect**: Detects ransomware on the host and generates an alert. {elastic-defend}
 will **not** block ransomware. You must pay attention to and analyze any ransomware alerts that are generated.
 * **Prevent** (Default): Detects ransomware on the host, blocks it from executing,
 and generates an alert.
@@ -125,7 +125,7 @@ If you upgrade to a Platinum or Enterprise license from Basic or Gold, memory th
 Memory threat protection levels are:
 
 * **Detect**: Detects memory threat activity on the host and generates an alert.
-The {agent} will **not** block the in-memory activity. You must pay attention to and analyze any alerts that are generated.
+{elastic-defend} will **not** block the in-memory activity. You must pay attention to and analyze any alerts that are generated.
 * **Prevent** (Default): Detects memory threat activity on the host, forces the process
 or thread to stop, and generates an alert.
 
@@ -152,7 +152,7 @@ malicious behavior protection will be disabled by default.
 Malicious behavior protection levels are:
 
 * **Detect**: Detects malicious behavior on the host and generates an alert.
-The {agent} will **not** block the malicious behavior. You must pay attention to and analyze any alerts that are generated.
+{elastic-defend} will **not** block the malicious behavior. You must pay attention to and analyze any alerts that are generated.
 * **Prevent** (Default): Detects malicious behavior on the host, forces the process to stop,
 and generates an alert.
 
@@ -188,7 +188,7 @@ image::images/install-endpoint/event-collection.png[Detail of event collection s
 [[register-as-antivirus]]
 == Register {elastic-sec} as antivirus (optional)
 
-With {agent} version 7.10 or later on Windows 7 or later, you can
+With {elastic-defend} version 7.10 or later on Windows 7 or later, you can
 configure {elastic-sec} as your antivirus software by turning on **Register as antivirus**.
 
 NOTE: Windows Server versions are not supported. Antivirus registration requires Windows Security Center, which is not included in Windows Server operating systems.


### PR DESCRIPTION
- [x] Change several Agent references to Defend/Endpoint.  Defend/Endpoint provides these features, not Agent itself.
- [x] Correct a typo related to malware detect/prevent quarantine.