### PR TITLE
[Expandable flyout] Task 1: Term refresh

### DIFF
--- a/docs/assistant/security-assistant.asciidoc
+++ b/docs/assistant/security-assistant.asciidoc
@@ -62,7 +62,7 @@ To open AI Assistant, press *Cmd + ;* (or *Ctrl + ;* on Windows) from anywhere i
 
 You can also chat with AI Assistant from several particular pages in {elastic-sec} where you can easily send context-specific data and prompts to AI Assistant.
 
-* <<view-alert-details, Alert details>> or Event details flyout: Click *Chat* while viewing the details of an alert or event.
+* <<view-alert-details, Expandable flyout>> or Event details flyout: Click *Chat* while viewing the details of an alert or event.
 * <<rules-ui-management, Rules page>>: Select one or more rules, then click the magic wand icon (🪄✨) at the top of the page next to the *Rules* title.
 * <<data-quality-dash, Data Quality dashboard>>: Select the *Incompatible fields* tab, then click *Chat*. (This is only available for fields marked red, indicating they're incompatible).
 * <<timelines-ui, Timeline>>: Select the *Security Assistant* tab.

--- a/docs/cases/cases-manage.asciidoc
+++ b/docs/cases/cases-manage.asciidoc
@@ -252,7 +252,7 @@ Be mindful of the following:
 
 * If the imported case had connectors attached to it, you'll be prompted to re-authenticate the connectors. To do so, click *Go to connectors* on the *Import saved objects* flyout and complete the necessary steps.
 Alternatively, open the main menu, then go to *{stack-manage-app} -> {connectors-ui}* to access connectors.
-* If the imported case had attached alerts, verify that the alerts' source documents exist in the environment. Case features that interact with alerts (such as the Alert details flyout and rule details page) rely on the alerts' source documents to function.
+* If the imported case had attached alerts, verify that the alerts' source documents exist in the environment. Case features that interact with alerts (such as the expandable flyout and rule details page) rely on the alerts' source documents to function.
 
 =========================
 +

--- a/docs/detections/add-exceptions.asciidoc
+++ b/docs/detections/add-exceptions.asciidoc
@@ -6,7 +6,7 @@
 :frontmatter-tags-content-type: [how-to]
 :frontmatter-tags-user-goals: [configure] 
 
-You can add exceptions to a rule from the rule details page, the Alerts table, the alert details flyout, or the Shared Exception Lists page. When you add an exception, you can also close all alerts that meet the exception’s criteria.
+You can add exceptions to a rule from the rule details page, the Alerts table, the expandable flyout, or the Shared Exception Lists page. When you add an exception, you can also close all alerts that meet the exception’s criteria.
 
 [IMPORTANT]
 ==============
@@ -49,10 +49,10 @@ image::images/rule-exception-tab.png[Detail of rule exceptions tab]
 .. Go to *Alerts*.
 .. Scroll down to the Alerts table, go to the alert you want to create an exception for, click the *More Actions* menu (*...*), then select *Add rule exception*.
 
-* To add an exception from the alert details flyout:
+* To add an exception from the expandable flyout:
 .. Go to *Alerts*.
 .. Click the *View details* button from the Alerts table. 
-.. In the alert details flyout, click *Take action -> Add rule exception*. 
+.. In the expandable flyout, click *Take action -> Add rule exception*. 
 
 * To add an exception from the Shared Exception Lists page:
 .. Go to *Manage* -> *Shared Exception Lists*.

--- a/docs/detections/alert-suppression.asciidoc
+++ b/docs/detections/alert-suppression.asciidoc
@@ -13,7 +13,7 @@ Alert suppression allows you to reduce the number of repeated or duplicate detec
 
 Normally, when a rule matches multiple source events, it creates multiple alerts, one for each event. When alert suppression is configured, matching events are grouped by their values in a specified field, and only one alert is created for each group. You can configure alert suppression to create alerts each time the rule runs, or once within a specified time window. You can also specify multiple fields to group events by unique combinations of values.
 
-The {security-app} displays several indicators in the Alerts table and the alert details flyout when a detection alert is created with alert suppression enabled. You can view the original events associated with suppressed alerts by investigating the alert in Timeline.
+The {security-app} displays several indicators in the Alerts table and the expandable flyout when a detection alert is created with alert suppression enabled. You can view the original events associated with suppressed alerts by investigating the alert in Timeline.
 
 NOTE: Alert suppression is not available for Elastic prebuilt rules. However, if you want to suppress alerts for a prebuilt rule, you can duplicate it, then configure alert suppression on the duplicated rule.
 
@@ -55,7 +55,7 @@ image::images/suppressed-alerts-table.png[Suppressed alerts icon and tooltip in 
 [role="screenshot"]
 image::images/suppressed-alerts-table-column.png[Suppressed alerts count field column in Alerts table,75%]
 
-* Alert details flyout — *Insights* section:
+* Expandable flyout — *Insights* section:
 +
 [role="screenshot"]
 image::images/suppressed-alerts-details.png[Suppressed alerts Insights section in alert details flyout,75%]
@@ -69,4 +69,4 @@ With alert suppression, detection alerts aren't created for the grouped source e
 [role="screenshot"]
 image::images/timeline-button.png[Investigate in timeline button, 200]
 
-* Alert details flyout — Select *Take action* -> *Investigate in timeline*.
+* Expandable flyout — Select *Take action* -> *Investigate in timeline*.

--- a/docs/detections/alerts-add-to-cases.asciidoc
+++ b/docs/detections/alerts-add-to-cases.asciidoc
@@ -18,7 +18,7 @@ image::images/add-alert-to-case.gif[width=50%][height=50%][Animation of adding a
 To add alerts to a new case:
 
 . Do one of the following:
-** To add a single alert to a case, select the *More actions* menu (*...*) in the Alerts table or **Take action** in the alert details flyout, then select *Add to a new case*.
+** To add a single alert to a case, select the *More actions* menu (*...*) in the Alerts table or **Take action** in the expandable flyout, then select *Add to a new case*.
 ** To add multiple alerts, select the alerts, then select *Add to a new case* from the *Bulk actions* menu.
 . Give the case a name, assign a severity level, and provide a description. You can use
 https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax[Markdown] syntax in the case description.
@@ -40,7 +40,7 @@ image::images/add-alert-to-new-case.png[width=60%][height=60%][Create case flyou
 To add alerts to an existing case:
 
 . Do one of the following:
-** To add a single alert to a case, select the *More actions* menu (*...*) in the Alerts table or **Take action** in the alert details flyout, then select **Add to existing case**.
+** To add a single alert to a case, select the *More actions* menu (*...*) in the Alerts table or **Take action** in the expandable flyout, then select **Add to existing case**.
 ** To add multiple alerts, select the alerts, then select *Add to an existing case* from the *Bulk actions* menu.
 . From the **Select case** dialog box, select the case to which you want to attach the alert. A confirmation message is displayed with an option to view the updated case. Click the link in the notification or go to the Cases page to view the case's details.
 +

--- a/docs/detections/alerts-ui-manage.asciidoc
+++ b/docs/detections/alerts-ui-manage.asciidoc
@@ -17,7 +17,7 @@ image::detections/images/alert-page.png[Alerts page overview]
 === View and filter detection alerts
 The Alerts page offers various ways for you to organize and triage detection alerts as you investigate suspicious events. You can:
 
-* View an alert's details. Click the *View details* button from the Alerts table to open the alert details flyout. Learn more at <<view-alert-details>>.
+* View an alert's details. Click the *View details* button from the Alerts table to open the expandable flyout. Learn more at <<view-alert-details>>.
 +
 [role="screenshot"]
 image::images/view-alert-details.png[View details button, 200]
@@ -133,7 +133,7 @@ TIP: When using grid view, you can view alert-rendered reason statements and eve
 [float]
 [[alert-actions]]
 === Take actions on an alert
-From the Alerts table or the alert details flyout, you can:
+From the Alerts table or the expandable flyout, you can:
 
 * <<signals-to-cases>>
 * <<detection-alert-status>>
@@ -141,7 +141,7 @@ From the Alerts table or the alert details flyout, you can:
 * <<apply-alert-tags>>
 * <<endpoint-rule-exceptions,Add an endpoint exception from an alert>>
 * <<host-isolation-ov,Isolate an alert's host>>
-* <<response-actions,Perform response actions on an alert's host>> (Alert details flyout only)
+* <<response-actions,Perform response actions on an alert's host>> (Expandable flyout only)
 * <<alerts-run-osquery, Run Osquery against an alert>>
 * <<signals-to-timelines>>
 * <<visual-event-analyzer,Visually analyze an alert's process relationships>>
@@ -197,7 +197,7 @@ Alerts table. Exceptions prevent a rule from generating alerts even when its
 criteria are met.
 
 To add an exception, click the *More actions* menu (*...*) in the Alerts table, then select
-*Add exception*. Alternatively, select *Take action* -> *Add rule exception* in the alert details flyout.
+*Add exception*. Alternatively, select *Take action* -> *Add rule exception* in the expandable flyout.
 
 For information about exceptions and how to use them, refer to
 <<add-exceptions>>.
@@ -206,7 +206,7 @@ For information about exceptions and how to use them, refer to
 [[signals-to-timelines]]
 ==== View alerts in Timeline
 
-* To view a single alert in Timeline, click the *Investigate in timeline* button in the Alerts table. Alternatively, select *Take action* -> *Investigate in timeline* in the alert details flyout.
+* To view a single alert in Timeline, click the *Investigate in timeline* button in the Alerts table. Alternatively, select *Take action* -> *Investigate in timeline* in the expandable flyout.
 +
 [role="screenshot"]
 image::images/timeline-button.png[Investigate in timeline button, 300]

--- a/docs/experimental-features/host-risk-score.asciidoc
+++ b/docs/experimental-features/host-risk-score.asciidoc
@@ -101,7 +101,7 @@ The `host.risk.calculated_level` column in the Alerts table:
 [role="screenshot"]
 image::images/hrs-alerts-table.png[Host risk score in the Alerts table]
 
-The *Overview* tab on the Alert details flyout:
+The *Overview* tab on the expandable flyout:
 
 [role="screenshot"]
 image::images/score-in-flyout.png[Host risk score in Alert details flyout]

--- a/docs/experimental-features/user-risk-score.asciidoc
+++ b/docs/experimental-features/user-risk-score.asciidoc
@@ -94,7 +94,7 @@ The `user.risk.calculated_level` column in the Alerts table:
 [role="screenshot"]
 image::images/urs-alerts-table.png[User risk score in Alerts table]
 
-The *Overview* tab on the Alert details flyout:
+The *Overview* tab on the Expandable flyout:
 
 [role="screenshot"]
 image::images/urs-score-flyout.png[User risk score in Alert details flyout]

--- a/docs/management/admin/host-isolation-ov.asciidoc
+++ b/docs/management/admin/host-isolation-ov.asciidoc
@@ -31,7 +31,7 @@ Isolated hosts, however, can still send data to {es} and {kib}. You can also cre
 [role="screenshot"]
 image::images/isolated-host.png[Endpoint page highlighting a host that's been isolated]
 
-You can isolate a host from a detection alert's details flyout, from the Endpoints page, or (with an Enterprise subscription) from the endpoint response console. Once a host is successfully isolated, an `Isolated` status displays next to the `Agent status` field, which you can view on the alert details flyout or Endpoints list table.
+You can isolate a host from a detection alert's details flyout, from the Endpoints page, or (with an Enterprise subscription) from the endpoint response console. Once a host is successfully isolated, an `Isolated` status displays next to the `Agent status` field, which you can view on the expandable flyout or Endpoints list table.
 
 TIP: If the request fails, verify that the {agent} and your endpoint are both online before trying again.
 
@@ -104,7 +104,7 @@ image::images/host-isolated-notif.png[Host isolated notification message,350]
 . Open a detection alert:
 * From the Alerts table or Timeline: Click *View details* (image:images/view-details-icon.png[View details icon,16,15]).
 * From a case with an attached alert: Click *Show alert details* (*>*).
-. From the alert details flyout, click *Take action -> Release host*.
+. From the expandable flyout, click *Take action -> Release host*.
 . Enter a comment describing why you're releasing the host (optional).
 . Click *Confirm*.
 ====

--- a/docs/management/admin/response-actions.asciidoc
+++ b/docs/management/admin/response-actions.asciidoc
@@ -29,7 +29,7 @@ Launch the response console from any of the following places in {elastic-sec}:
 
 * *Endpoints* page -> *Actions* menu (*...*) -> *Respond*
 * Endpoint details flyout -> *Take action* -> *Respond*
-* Alert details flyout -> *Take action* -> *Respond*
+* Expandable flyout -> *Take action* -> *Respond*
 
 To perform an action on the endpoint, enter a <<response-action-commands,response action command>> in the input area at the bottom of the console, then press *Return*. Output from the action is displayed in the console.
 
@@ -113,7 +113,7 @@ TIP: You can use the <<use-osquery,Osquery manager integration>> to query a host
 
 [NOTE]
 ====
-When {elastic-defend} prevents file activity due to <<malware-protection,malware prevention>>, the file is quarantined on the host and a malware prevention alert is created. To retrieve this file with `get-file`, copy the path from the alert's *Quarantined file path* field (`file.Ext.quarantine_path`), which appears under *Highlighted fields* in the alert details flyout. Then paste the value into the `--path` parameter. 
+When {elastic-defend} prevents file activity due to <<malware-protection,malware prevention>>, the file is quarantined on the host and a malware prevention alert is created. To retrieve this file with `get-file`, copy the path from the alert's *Quarantined file path* field (`file.Ext.quarantine_path`), which appears under *Highlighted fields* in the expandable flyout. Then paste the value into the `--path` parameter. 
 ====
 
 === `execute`

--- a/docs/osquery/alerts-run-osquery.asciidoc
+++ b/docs/osquery/alerts-run-osquery.asciidoc
@@ -13,7 +13,7 @@ Run live queries on hosts associated with alerts to learn more about your infras
 To run Osquery from an alert:
 
 . Do one of the following from the Alerts table:
-** Click the *View details* button to open the Alert details flyout, then click *Take action -> Run Osquery*.
+** Click the *View details* button to open the expandable flyout, then click *Take action -> Run Osquery*.
 ** Select the *More actions* menu (*...*), then select *Run Osquery*.
 . Choose to run a single query or a query pack.
 . Select one or more {agent}s or groups to query. Start typing in the search field to get suggestions for {agent}s by name, ID, platform, and policy.

--- a/docs/osquery/osquery-response-action.asciidoc
+++ b/docs/osquery/osquery-response-action.asciidoc
@@ -64,7 +64,7 @@ IMPORTANT: If you edited a saved query or query pack that an Osquery Response Ac
 [[find-osquery-response-action-results]]
 === Find query results
 
-When a rule generates an alert, Osquery automatically collects data on the host. Query results are displayed within the *Response Results* tab in the Alert details flyout. The number next to the *Response Results* tab represents the number of queries attached to the rule, in addition to endpoint response actions run by the rule.
+When a rule generates an alert, Osquery automatically collects data on the host. Query results are displayed within the *Response Results* tab in the expandable flyout. The number next to the *Response Results* tab represents the number of queries attached to the rule, in addition to endpoint response actions run by the rule.
 
 NOTE: Refer to <<view-osquery-results>> for more information about query results.
 


### PR DESCRIPTION
Fixes part of https://github.com/elastic/security-docs/issues/2687 by replacing all text instances of "alert details flyout" with "expandable flyout". 

NOTE: Changes to the "View detection alert details" page are occurring in a separate PR (https://github.com/elastic/security-docs/pull/3816).

Previews:
- [Manage detection alerts](https://security-docs_3815.docs-preview.app.elstc.co/guide/en/security/master/alerts-ui-manage.html)
- [Suppress detection alerts](https://security-docs_3815.docs-preview.app.elstc.co/guide/en/security/master/alert-suppression.html) 
- [Add and manage exceptions](https://security-docs_3815.docs-preview.app.elstc.co/guide/en/security/master/add-exceptions.html)
- [Endpoint response actions](https://security-docs_3815.docs-preview.app.elstc.co/guide/en/security/master/response-actions.html)
- [AI Assistant](https://security-docs_3815.docs-preview.app.elstc.co/guide/en/security/master/security-assistant.html)
- [Open and manage cases](https://security-docs_3815.docs-preview.app.elstc.co/guide/en/security/master/cases-open-manage.html)
- [Add detection alerts to cases](https://security-docs_3815.docs-preview.app.elstc.co/guide/en/security/master/signals-to-cases.html)
- [Run Osquery from alerts](https://security-docs_3815.docs-preview.app.elstc.co/guide/en/security/master/alerts-run-osquery.html)
- [Add Osquery Response Actions](https://security-docs_3815.docs-preview.app.elstc.co/guide/en/security/master/osquery-response-action.html)
- [Host isolation](https://security-docs_3815.docs-preview.app.elstc.co/guide/en/security/master/host-isolation-ov.html)
- [Host risk score](https://security-docs_3815.docs-preview.app.elstc.co/guide/en/security/master/host-risk-score.html)
- [User risk score](https://security-docs_3815.docs-preview.app.elstc.co/guide/en/security/master/user-risk-score.html)