### PR TITLE
[API docs] Fixes URLs in the update exception container docs and create exception item docs

### DIFF
--- a/docs/detections/api/exceptions/api-create-exception-item.asciidoc
+++ b/docs/detections/api/exceptions/api-create-exception-item.asciidoc
@@ -139,7 +139,7 @@ container:
 
 [source,console]
 --------------------------------------------------
-POST api/lists/exception_lists/items
+POST api/exception_lists/items
 {
   "description": "Excludes the weekly maintenance job",
   "entries": [
@@ -169,7 +169,7 @@ Adds hosts on which the `maintenance` process is allowed to run to the
 
 [source,console]
 --------------------------------------------------
-POST api/lists/exception_lists/items
+POST api/exception_lists/items
 {
   "comments": [
     {"comment": "Allows maintenance process to run on the specified machines"}
@@ -216,7 +216,7 @@ value on Windows OS:
 
 [source,console]
 --------------------------------------------------
-POST api/lists/exception_lists/items
+POST api/exception_lists/items
 {
   "_tags": [
     "endpoint", <1>
@@ -255,7 +255,7 @@ as an exception item to the `trusted-IPs` exception container:
 
 [source,console]
 --------------------------------------------------
-POST api/lists/exception_lists/items
+POST api/exception_lists/items
 {
   "description": "Uses the external-ip-container list to exclude trusted external IPs.",
   "entries": [
@@ -293,7 +293,7 @@ Adds an exception for nested Endpoint fields:
 
 [source,console]
 --------------------------------------------------
-POST api/lists/exception_lists/items
+POST api/exception_lists/items
 {
   "description": "Excludes all processes signed by Trusted Signer, Inc.",
   "entries": [

--- a/docs/detections/api/exceptions/api-update-exception-container.asciidoc
+++ b/docs/detections/api/exceptions/api-update-exception-container.asciidoc
@@ -5,7 +5,7 @@ Updates an existing exception container.
 
 ==== Request URL
 
-`PUT <kibana host>:<port>/api/lists`
+`PUT <kibana host>:<port>/api/exception_lists`
 
 ==== Request body
 


### PR DESCRIPTION
Fixes the first item in https://github.com/elastic/security-docs/issues/3160 and adds the changes being made in https://github.com/elastic/security-docs/pull/3756 and in https://github.com/elastic/security-docs/pull/3419.

- [Update exception container](https://security-docs_3819.docs-preview.app.elstc.co/guide/en/security/master/exceptions-api-update-container.html): Updates the endpoint's request URL from `PUT <kibana host>:<port>/api/lists` to `PUT <kibana host>:<port>/api/exception_lists`
- [Create exception item](https://security-docs_3819.docs-preview.app.elstc.co/guide/en/security/master/exceptions-api-create-exception-item.html): Fixes the URL used in the examples. Changes `POST api/lists/exception_lists/items` to `POST api/exception_lists/items`.
