### PR TITLE
Fixes breaking changes links in Upgrade guide

### DIFF
--- a/docs/upgrade/upgrade-security.asciidoc
+++ b/docs/upgrade/upgrade-security.asciidoc
@@ -75,12 +75,12 @@ Review the {kibana-ref}/resolve-migrations-failures.html[common causes of {kib} 
 
 . Review the breaking changes for each product you use and make the necessary changes so your code is compatible with {version}.
 
-** {stack-ref}/apm-breaking-changes.html[APM {version} breaking changes]
-** {stack-ref}/beats-breaking-changes.html[Beats {version} breaking changes]
-** {stack-ref}/elasticsearch-breaking-changes.html[{es} {version} breaking changes]
-** {stack-ref}/security-breaking-changes.html[{elastic-sec} {version} breaking changes]
-** {stack-ref}/kibana-breaking-changes.html[{kib} {version} breaking changes]
-** {stack-ref}/logstash-breaking-changes.html[{ls} {version} breaking changes]
+** {apm-guide-ref}/apm-breaking.html[APM {version} breaking changes]
+** {beats-ref}/breaking-changes.html[Beats {version} breaking changes]
+** {ref}/breaking-changes.html[{es} {version} breaking changes]
+** {security-guide}/release-notes.html[{elastic-sec} {version} breaking changes]
+** {kibana-ref}/release-notes.html[{kib} {version} breaking changes]
+** {logstash-ref}/breaking-changes.html[{ls} {version} breaking changes]
 +
 . If you use any {es} plugins, ensure each plugin has a version compatible with {es} version {version}.
 
@@ -109,12 +109,12 @@ This section provides the necessary steps you need to take before upgrading to 8
 
 First, review the breaking changes for each product you use and make the necessary changes so your code is compatible with {version}.
 
-** {stack-ref}/apm-breaking-changes.html[APM {version} breaking changes]
-** {stack-ref}/beats-breaking-changes.html[Beats {version} breaking changes]
-** {stack-ref}/elasticsearch-breaking-changes.html[{es} {version} breaking changes]
-** {stack-ref}/security-breaking-changes.html[{elastic-sec} {version} breaking changes]
-** {stack-ref}/kibana-breaking-changes.html[{kib} {version} breaking changes]
-** {stack-ref}/logstash-breaking-changes.html[{ls} {version} breaking changes]
+** {apm-guide-ref}/apm-breaking.html[APM {version} breaking changes]
+** {beats-ref}/breaking-changes.html[Beats {version} breaking changes]
+** {ref}/breaking-changes.html[{es} {version} breaking changes]
+** {security-guide}/release-notes.html[{elastic-sec} {version} breaking changes]
+** {kibana-ref}/release-notes.html[{kib} {version} breaking changes]
+** {logstash-ref}/breaking-changes.html[{ls} {version} breaking changes]
 
 [float]
 [[reenable-rules-upgrade]]


### PR DESCRIPTION
- Resolves #3924 

Preview: [Upgrade Elastic Security to 8.10.0](https://security-docs_3959.docs-preview.app.elstc.co/guide/en/security/master/upgrade-intro.html)