### PR TITLE
Update MITRE ATT&CK® version mentioned in the docs

### DIFF
--- a/docs/detections/rules-coverage.asciidoc
+++ b/docs/detections/rules-coverage.asciidoc
@@ -12,7 +12,7 @@ Mirroring the MITRE ATT&CK® framework, columns represent major tactics, and cel
 
 [NOTE]
 ====
-This page only includes the detection rules you currently have installed, and only rules that are mapped to MITRE ATT&CK® tactics. Additionally, rules must be mapped to the MITRE ATT&CK® version used by {elastic-sec}: `v12.1`. Elastic prebuilt rules that aren't installed and custom rules that are either unmapped or mapped to a deprecated tactic or technique will not be included.
+This page only includes the detection rules you currently have installed, and only rules that are mapped to MITRE ATT&CK® tactics. Additionally, rules must be mapped to the MITRE ATT&CK® version used by {elastic-sec}: `v13.1`. Elastic prebuilt rules that aren't installed and custom rules that are either unmapped or mapped to a deprecated tactic or technique will not be included.
 
 You can map custom rules to tactics in **Advanced settings** when creating or editing a rule.
 ====


### PR DESCRIPTION
Addresses part of https://github.com/elastic/security-docs/issues/4013 and backports the changes to the 8.10 and 8.11 feature docs. 

Preview - [MITRE ATT&CK® coverage](https://security-docs_4014.docs-preview.app.elstc.co/guide/en/security/master/rules-coverage.html) (see note at the top of the page)