### PR TITLE
adds note about security update to 8.10.4 RNs

### DIFF
--- a/docs/release-notes/8.10.asciidoc
+++ b/docs/release-notes/8.10.asciidoc
@@ -6,6 +6,18 @@
 === 8.10.4
 
 [discrete]
+[[security-update-8.10.4]]
+==== Security updates
+
+* If {endpoint} (v7.9.0 - v8.10.3) is configured to use a non-default option in which the logging level is explicitly set to `debug`, and {agent} is simultaneously configured to collect and send those logs to {es}, then {agent} API keys can be viewed in {es} in plaintext.
++
+The issue is resolved in {stack} 8.10.4.
++
+For more information, see our related
+https://discuss.elastic.co/t/endpoint-v8-10-4-security-update/345203[security
+announcement].
+
+[discrete]
 [[bug-fixes-8.10.4]]
 ==== Bug fixes
 * Fixes a bug in Timeline that prevented the **Show top _x_** action from showing results ({pull}168339[#168339]).

--- a/docs/release-notes/8.10.asciidoc
+++ b/docs/release-notes/8.10.asciidoc
@@ -9,7 +9,7 @@
 [[security-update-8.10.4]]
 ==== Security updates
 
-* If {endpoint} (v7.9.0 - v8.10.3) is configured to use a non-default option in which the logging level is explicitly set to `debug`, and {agent} is simultaneously configured to collect and send those logs to {es}, then {agent} API keys can be viewed in {es} in plaintext.
+* If {elastic-endpoint} (v7.9.0 - v8.10.3) is configured to use a non-default option in which the logging level is explicitly set to `debug`, and {agent} is simultaneously configured to collect and send those logs to {es}, then {agent} API keys can be viewed in {es} in plaintext.
 +
 The issue is resolved in {stack} 8.10.4.
 +

--- a/docs/release-notes/8.10.asciidoc
+++ b/docs/release-notes/8.10.asciidoc
@@ -13,7 +13,7 @@
 +
 The issue is resolved in {stack} 8.10.4.
 +
-For more information, see our related
+For more information, refer to our related
 https://discuss.elastic.co/t/endpoint-v8-10-4-security-update/345203[security
 announcement].
 


### PR DESCRIPTION
Resolves #4055 

Preview: [8.10.4 RNs](https://security-docs_4056.docs-preview.app.elstc.co/guide/en/security/master/release-notes-header-8.10.1.html)