### PR TITLE
[Docs][Rules] Remove custom highlighted fields params from Rule Creation API Docs in 8.10 

### DIFF
--- a/docs/detections/api/rules/rules-api-create.asciidoc
+++ b/docs/detections/api/rules/rules-api-create.asciidoc
@@ -348,10 +348,6 @@ Required when `actions` are used to send notifications.
 
 |version |Integer |The rule's version number. Defaults to `1`.
 
-|investigation_fields |Object a| Specify highlighted fields for personalized alert investigation flows:
-
-* `field_names`: String, required
-
 |==============================================
 
 [[opt-fields-query-eql]]


### PR DESCRIPTION
Fixes https://github.com/elastic/security-docs/issues/4082.

[Preview](https://security-docs_4085.docs-preview.app.elstc.co/guide/en/security/8.10/rules-api-create.html#opt-fields-all) - Removed the `investigation_fields` parameter from the Create rule API docs.