### PR TITLE
[BUG] Update `field_names` type description

### DIFF
--- a/docs/detections/api/rules/rules-api-create.asciidoc
+++ b/docs/detections/api/rules/rules-api-create.asciidoc
@@ -350,7 +350,7 @@ Required when `actions` are used to send notifications.
 
 |investigation_fields |Object a| Specify highlighted fields for personalized alert investigation flows:
 
-* `field_names`: String, required
+* `field_names`: String[] , required
 
 |==============================================
 


### PR DESCRIPTION
Fixes https://github.com/elastic/security-docs/issues/4086.

Preview - Updates the `field_names` type from `string` to `string[]`.