### PR TITLE
Extend the EOL date for bulk action endpoints

### DIFF
--- a/docs/detections/api/rules/rules-api-bulk-actions.asciidoc
+++ b/docs/detections/api/rules/rules-api-bulk-actions.asciidoc
@@ -10,7 +10,7 @@ You can bulk create, update, and delete rules.
 [[bulk-actions-rules-api-create]]
 ==== Bulk create
 
-IMPORTANT: This API has been deprecated since version 8.2, and is scheduled for end of life in Q4 2023. Please use the <<bulk-actions-rules-api-action, bulk action API>> instead.
+IMPORTANT: This API has been deprecated since version 8.2, and is scheduled for end of life in 2024. Please use the <<bulk-actions-rules-api-action, bulk action API>> instead.
 
 WARNING: This API supports {kibana-ref}/api.html#token-api-authentication[Token-based authentication] only.
 
@@ -95,7 +95,7 @@ generated for all rules that did not include a `rule_id` field.
 [[bulk-actions-rules-api-delete]]
 ==== Bulk delete
 
-IMPORTANT: This API has been deprecated since version 8.2, and is scheduled for end of life in Q4 2023. Please use the <<bulk-actions-rules-api-action, bulk action API>> instead.
+IMPORTANT: This API has been deprecated since version 8.2, and is scheduled for end of life in 2024. Please use the <<bulk-actions-rules-api-action, bulk action API>> instead.
 
 Deletes multiple rules.
 
@@ -143,7 +143,7 @@ A JSON array containing the deleted rules.
 [[bulk-actions-rules-api-update]]
 ==== Bulk update
 
-IMPORTANT: This API has been deprecated since version 8.2, and is scheduled for end of life in Q4 2023. Please use the <<bulk-actions-rules-api-action, bulk action API>> instead.
+IMPORTANT: This API has been deprecated since version 8.2, and is scheduled for end of life in 2024. Please use the <<bulk-actions-rules-api-action, bulk action API>> instead.
 
 WARNING: This API supports {kibana-ref}/api.html#token-api-authentication[Token-based authentication] only.
 


### PR DESCRIPTION
Fixes https://github.com/elastic/security-docs/issues/4147

Updates EOL date for the following endpoints:
- Bulk create
- Bulk delete
- Bulk update