### PR TITLE
Adds missing beta tag

### DIFF
--- a/docs/cloud-native-security/vuln-management-findings.asciidoc
+++ b/docs/cloud-native-security/vuln-management-findings.asciidoc
@@ -1,6 +1,8 @@
 [[vuln-management-findings]]
 = Findings
 
+beta::[]
+
 The vulnerabilities findings page displays the vulnerabilities detected by the <<vuln-management-overview, CNVM integration>>. CNVM findings include metadata such as the CVE identifier, CVSS score, severity, affected package, and fix version if available, as well as information about impacted systems.
 
 To help you prioritize remediation efforts, you can filter and sort your findings based on these fields.


### PR DESCRIPTION
Fixes #4165 by adding a beta tag to the CNVM Findings page in 8.9. The screenshot already showed beta but the beta::[] tag was missing. 

Preview: CNVM Findings page