### PR TITLE
Replaces Network Beaconing docs

### DIFF
--- a/docs/detections/machine-learning/machine-learning.asciidoc
+++ b/docs/detections/machine-learning/machine-learning.asciidoc
@@ -86,10 +86,11 @@ time frame, previously analyzed data is not processed again.
 
 You can also install {ml} jobs using https://docs.elastic.co/integrations[Elastic integrations]. Here are the Advanced Analytics integrations available for Security:
 
-* https://docs.elastic.co/integrations/ded[Data Exfiltration Detection]
-* https://docs.elastic.co/integrations/dga[Domain Generation Algorithm Detection]
-* https://docs.elastic.co/integrations/lmd[Lateral Movement Detection]
-* https://docs.elastic.co/integrations/problemchild[Living off the Land Attack Detection]
+* {integrations-docs}/ded[Data Exfiltration Detection]
+* {integrations-docs}/dga[Domain Generation Algorithm Detection]
+* {integrations-docs}/lmd[Lateral Movement Detection]
+* {integrations-docs}/problemchild[Living off the Land Attack Detection]
+* {integrations-docs}/beaconing[Network Beaconing Identification]
 
 To learn more about {ml} jobs enabled by these integrations, refer to the https://www.elastic.co/guide/en/security/current/prebuilt-ml-jobs.html[Prebuilt jobs page].
 

--- a/docs/experimental-features/experimental-features-intro.asciidoc
+++ b/docs/experimental-features/experimental-features-intro.asciidoc
@@ -6,4 +6,4 @@ The features in this section are experimental and may be changed or removed comp
 
 include::host-risk-score.asciidoc[]
 include::user-risk-score.asciidoc[]
-include::beaconing-detection.asciidoc[]
+


### PR DESCRIPTION
Resolves #4169.

Removes [Network Beaconing](https://www.elastic.co/guide/en/security/current/network-beaconing-framework.html) from the Technical Preview section. Adds a link to [Network Beaconing Identification](https://docs.elastic.co/integrations/beaconing) under [Anomaly detection with machine learning](https://www.elastic.co/guide/en/security/current/machine-learning.html#ml-integrations).
Also updates integrations docs links to use attribute.

Preview: [Anomaly detection with machine learning](https://security-docs_4192.docs-preview.app.elstc.co/guide/en/security/master/machine-learning.html#ml-integrations)