### PR TITLE
Add beta tag for AI Assistant knowledge base

### DIFF
--- a/docs/release-notes/8.11.asciidoc
+++ b/docs/release-notes/8.11.asciidoc
@@ -30,7 +30,7 @@
 `windows.advanced.events.api_verbose` ({pull}167549[#167549]).
 * Adds the `Same family` category and tab to the Data Quality dashboard. Fields with mappings in the same family have the same search behavior as the type specified by ECS, but may have different space usage or performance characteristics ({pull}167480[#167480]).
 * Updates the exceptions flyout's `match_any` operator to accept duplicate values that differ in case ({pull}167208[#167208]).
-* Enables the Elastic AI Assistant to answer questions about Elasticsearch Query Language (ES|QL) by allowing it to query, via ELSER, an ES|QL knowledge base. Refer to <<security-assistant, Elastic AI Assistant>> to enable the knowledge base ({pull}167097[#167097]).
+* beta:[] Enables the Elastic AI Assistant to answer questions about Elasticsearch Query Language (ES|QL) by allowing it to query, via ELSER, an ES|QL knowledge base. Refer to <<security-assistant, Elastic AI Assistant>> to enable the knowledge base ({pull}167097[#167097]).
 * Enables ES|QL in Timeline (technical preview) ({pull}166764[#166764]).
 * Adds the new ES|QL rule type (technical preview) ({pull}165450[#165450]).
 * Updates the Endpoint policy UI (**Manage -> Policies**) to include a `Protection updates` tab, a new column called `Deployed version`, and a banner that highlights outdated policies ({pull}165256[#165256], {pull}162719[#162719]).

--- a/docs/whats-new.asciidoc
+++ b/docs/whats-new.asciidoc
@@ -38,7 +38,7 @@ You can use Elastic's new Amazon Bedrock connector to integrate with Anthropic C
 [float]
 === ES|QL knowledge base
 
-With the new knowledge base enabled, {security-guide}/security-assistant.html[Elastic AI Assistant] can answer detailed questions about the Elastic Search Query Language (ES|QL), including help with generating specific queries and syntax questions.
+beta:[] With the new knowledge base enabled, {security-guide}/security-assistant.html[Elastic AI Assistant] can answer detailed questions about the Elastic Search Query Language (ES|QL), including help with generating specific queries and syntax questions.
 
 [float]
 == Detection rules and alerts enhancements


### PR DESCRIPTION
Fixes #4210 by adding beta tag to release notes & What's New highlights.

Previews:
- [What's new | Elastic AI Assistant enhancements](https://security-docs_4211.docs-preview.app.elstc.co/guide/en/security/master/whats-new.html#_elastic_ai_assistant_enhancements)
- [8.11 release notes](https://security-docs_4211.docs-preview.app.elstc.co/guide/en/security/master/release-notes-header-8.11.0.html)