### PR TITLE
[Security Solution] Add known issue for date selection in Protection Updates

### DIFF
--- a/docs/release-notes/8.11.asciidoc
+++ b/docs/release-notes/8.11.asciidoc
@@ -11,6 +11,7 @@
 * MITRE ATT&CK® technique cells show duplicate rules ({issue}167929[#167929]).
 * MITRE ATT&CK® tactic cells show an incorrect rule count ({issue}167930[#167930]).
 * An incorrect MITRE ATT&CK® sub-technique is applied after you save a rule ({issue}170347[#170347]).
+* When using the Protection Updates feature, if you freeze the updates to the current day, it is possible that the set of protections has not been released for that day yet.  As a result, the Agent could fail to download the artifacts and be set to an Unhealthy state.  To workaround this issue, pick a date previous to the current one ({issue}170847[#170847]).
 
 [discrete]
 [[breaking-changes-8.11.0]]

--- a/docs/release-notes/8.11.asciidoc
+++ b/docs/release-notes/8.11.asciidoc
@@ -11,7 +11,7 @@
 * MITRE ATT&CK® technique cells show duplicate rules ({issue}167929[#167929]).
 * MITRE ATT&CK® tactic cells show an incorrect rule count ({issue}167930[#167930]).
 * An incorrect MITRE ATT&CK® sub-technique is applied after you save a rule ({issue}170347[#170347]).
-* When using the Protection Updates feature, if you freeze the updates to the current day, it is possible that the set of protections has not been released for that day yet.  As a result, the Agent could fail to download the artifacts and be set to an Unhealthy state.  To workaround this issue, pick a date previous to the current one ({issue}170847[#170847]).
+* When using {elastic-defend}'s protection updates feature, if you turn off automatic updates and select the current day as your deployed artifacts version, it's possible that the set of protections has not been released for that day yet. As a result, {agent} could fail to download the artifacts and be set to an Unhealthy state. To avoid this issue, pick a date previous to the current one ({issue}170847[#170847]).
 
 [discrete]
 [[breaking-changes-8.11.0]]


### PR DESCRIPTION
We discovered an issue in the Protection Updates feature released in `8.11.0` that we will fix for `8.11.1`.  We'd like to add another entry to known issues for `8.11.0` before the fix goes out in the next patch.

The issue is that if the user picks the current date, it's possible that we haven't released a protection update yet for that date, so the Agent will go to an Unhealthy state.  The workaround is to pick a previous date like the day before.  The upcoming fix will simply disallow users from selecting the current date from the UI to reduce the user confusion

Related bug ticket: https://github.com/elastic/kibana/issues/170847