### PR TITLE
[BUG] 8.11.0 release notes include links to private repository

### DIFF
--- a/docs/release-notes/8.11.asciidoc
+++ b/docs/release-notes/8.11.asciidoc
@@ -51,10 +51,10 @@
 * Enables ES|QL in Timeline (technical preview) ({pull}166764[#166764]).
 * Adds the new ES|QL rule type (technical preview) ({pull}165450[#165450]).
 * Updates the Endpoint policy UI (**Manage -> Policies**) to include a `Protection updates` tab, a new column called `Deployed version`, and a banner that highlights outdated policies ({pull}165256[#165256], {pull}162719[#162719]).
-* Introduces full support for {elastic-endpoint} on macOS Sonoma (https://github.com/elastic/endpoint-dev/issues/13058[#13058]).
-* Updates {elastic-defend} to support AlmaLinux 9 and Rocky Linux 9 (https://github.com/elastic/endpoint-dev/pull/13613[#13613]).
-* Adds a new optional parameter to {elastic-endpoint}'s `top` command. The `--limit` parameter specifies how many times to refresh the command's output before a graceful exit (https://github.com/elastic/endpoint-dev/pull/13608[#13608]).
-* Adds Agent tamper protection for {elastic-defend}, which prevents unauthorized attempts to uninstall {agent} and {elastic-endpoint} from a host (https://github.com/elastic/endpoint-dev/pull/12997[#12997]).
+* Introduces full support for {elastic-endpoint} on macOS Sonoma.
+* Updates {elastic-defend} to support AlmaLinux 9 and Rocky Linux 9.
+* Adds a new optional parameter to {elastic-endpoint}'s `top` command. The `--limit` parameter specifies how many times to refresh the command's output before a graceful exit.
+* Adds Agent tamper protection for {elastic-defend}, which prevents unauthorized attempts to uninstall {agent} and {elastic-endpoint} from a host.
 
 [discrete]
 [[enhancements-8.11.0]]


### PR DESCRIPTION
Fixes https://github.com/elastic/security-docs/issues/4247

[Preview](https://security-docs_4248.docs-preview.app.elstc.co/guide/en/security/master/release-notes-header-8.11.0.html#features-8.11.0) - Links and issue numbers removed for the last four features