### PR TITLE
Update Prebuilt Rule Links for Malicious Site in 7.16

### DIFF
--- a/docs/detections/prebuilt-rules/downloadable-packages/0-14-2/prebuilt-rule-0-14-2-creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-14-2/prebuilt-rule-0-14-2-creation-of-a-hidden-local-user-account.asciidoc
@@ -23,7 +23,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*: 
 
-* https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*: 

--- a/docs/detections/prebuilt-rules/downloadable-packages/0-14-2/prebuilt-rule-0-14-2-creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-14-2/prebuilt-rule-0-14-2-creation-of-a-hidden-local-user-account.asciidoc
@@ -23,7 +23,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*: 
 
-* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* https://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*: 

--- a/docs/detections/prebuilt-rules/downloadable-packages/0-14-2/prebuilt-rule-0-14-2-remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-14-2/prebuilt-rule-0-14-2-remote-file-copy-via-teamviewer.asciidoc
@@ -23,7 +23,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*: 
 
-* https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/0-14-2/prebuilt-rule-0-14-2-remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-14-2/prebuilt-rule-0-14-2-remote-file-copy-via-teamviewer.asciidoc
@@ -23,7 +23,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*: 
 
-* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* https://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/0-16-2/prebuilt-rule-0-16-2-account-configured-with-never-expiring-password.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-16-2/prebuilt-rule-0-16-2-account-configured-with-never-expiring-password.asciidoc
@@ -23,7 +23,7 @@ Detects the creation and modification of an account with the "Don't Expire Passw
 *References*: 
 
 * https://www.cert.ssi.gouv.fr/uploads/guide-ad.html#dont_expire
-* http://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
+* https://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/0-16-2/prebuilt-rule-0-16-2-account-configured-with-never-expiring-password.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-16-2/prebuilt-rule-0-16-2-account-configured-with-never-expiring-password.asciidoc
@@ -23,7 +23,7 @@ Detects the creation and modification of an account with the "Don't Expire Passw
 *References*: 
 
 * https://www.cert.ssi.gouv.fr/uploads/guide-ad.html#dont_expire
-* https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
+* http://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/0-16-2/prebuilt-rule-0-16-2-creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-16-2/prebuilt-rule-0-16-2-creation-of-a-hidden-local-user-account.asciidoc
@@ -23,7 +23,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*: 
 
-* https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*: 

--- a/docs/detections/prebuilt-rules/downloadable-packages/0-16-2/prebuilt-rule-0-16-2-creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-16-2/prebuilt-rule-0-16-2-creation-of-a-hidden-local-user-account.asciidoc
@@ -23,7 +23,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*: 
 
-* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* https://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*: 

--- a/docs/detections/prebuilt-rules/downloadable-packages/0-16-2/prebuilt-rule-0-16-2-remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-16-2/prebuilt-rule-0-16-2-remote-file-copy-via-teamviewer.asciidoc
@@ -23,7 +23,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*: 
 
-* https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/0-16-2/prebuilt-rule-0-16-2-remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-16-2/prebuilt-rule-0-16-2-remote-file-copy-via-teamviewer.asciidoc
@@ -23,7 +23,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*: 
 
-* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* https://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/0-16-2/prebuilt-rule-0-16-2-suspicious-managed-code-hosting-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-16-2/prebuilt-rule-0-16-2-suspicious-managed-code-hosting-process.asciidoc
@@ -23,7 +23,7 @@ Identifies a suspicious managed code hosting process which could indicate code i
 
 *References*: 
 
-* http://web.archive.org/web/20230329154538/https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
+* https://web.archive.org/web/20230329154538/https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/0-16-2/prebuilt-rule-0-16-2-suspicious-managed-code-hosting-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-16-2/prebuilt-rule-0-16-2-suspicious-managed-code-hosting-process.asciidoc
@@ -23,7 +23,7 @@ Identifies a suspicious managed code hosting process which could indicate code i
 
 *References*: 
 
-* https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
+* http://web.archive.org/web/20230329154538/https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/0-16-2/prebuilt-rule-0-16-2-suspicious-werfault-child-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-16-2/prebuilt-rule-0-16-2-suspicious-werfault-child-process.asciidoc
@@ -25,7 +25,7 @@ A suspicious WerFault child process was detected, which may indicate an attempt 
 
 * https://www.hexacorn.com/blog/2019/09/19/silentprocessexit-quick-look-under-the-hood/
 * https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Persistence/persistence_SilentProcessExit_ImageHijack_sysmon_13_1.evtx
-* http://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
+* https://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/0-16-2/prebuilt-rule-0-16-2-suspicious-werfault-child-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-16-2/prebuilt-rule-0-16-2-suspicious-werfault-child-process.asciidoc
@@ -25,7 +25,7 @@ A suspicious WerFault child process was detected, which may indicate an attempt 
 
 * https://www.hexacorn.com/blog/2019/09/19/silentprocessexit-quick-look-under-the-hood/
 * https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Persistence/persistence_SilentProcessExit_ImageHijack_sysmon_13_1.evtx
-* https://blog.menasec.net/2021/01/
+* http://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/7-16-3/prebuilt-rule-7-16-3-account-configured-with-never-expiring-password.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/7-16-3/prebuilt-rule-7-16-3-account-configured-with-never-expiring-password.asciidoc
@@ -23,7 +23,7 @@ Detects the creation and modification of an account with the "Don't Expire Passw
 *References*: 
 
 * https://www.cert.ssi.gouv.fr/uploads/guide-ad.html#dont_expire
-* http://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
+* https://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/7-16-3/prebuilt-rule-7-16-3-account-configured-with-never-expiring-password.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/7-16-3/prebuilt-rule-7-16-3-account-configured-with-never-expiring-password.asciidoc
@@ -23,7 +23,7 @@ Detects the creation and modification of an account with the "Don't Expire Passw
 *References*: 
 
 * https://www.cert.ssi.gouv.fr/uploads/guide-ad.html#dont_expire
-* https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
+* http://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/7-16-3/prebuilt-rule-7-16-3-creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/7-16-3/prebuilt-rule-7-16-3-creation-of-a-hidden-local-user-account.asciidoc
@@ -23,7 +23,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*: 
 
-* https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*: 

--- a/docs/detections/prebuilt-rules/downloadable-packages/7-16-3/prebuilt-rule-7-16-3-creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/7-16-3/prebuilt-rule-7-16-3-creation-of-a-hidden-local-user-account.asciidoc
@@ -23,7 +23,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*: 
 
-* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* https://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*: 

--- a/docs/detections/prebuilt-rules/downloadable-packages/7-16-3/prebuilt-rule-7-16-3-remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/7-16-3/prebuilt-rule-7-16-3-remote-file-copy-via-teamviewer.asciidoc
@@ -23,7 +23,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*: 
 
-* https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/7-16-3/prebuilt-rule-7-16-3-remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/7-16-3/prebuilt-rule-7-16-3-remote-file-copy-via-teamviewer.asciidoc
@@ -23,7 +23,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*: 
 
-* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* https://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/7-16-4/prebuilt-rule-7-16-4-creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/7-16-4/prebuilt-rule-7-16-4-creation-of-a-hidden-local-user-account.asciidoc
@@ -23,7 +23,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*: 
 
-* https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*: 

--- a/docs/detections/prebuilt-rules/downloadable-packages/7-16-4/prebuilt-rule-7-16-4-creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/7-16-4/prebuilt-rule-7-16-4-creation-of-a-hidden-local-user-account.asciidoc
@@ -23,7 +23,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*: 
 
-* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* https://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*: 

--- a/docs/detections/prebuilt-rules/downloadable-packages/7-16-4/prebuilt-rule-7-16-4-remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/7-16-4/prebuilt-rule-7-16-4-remote-file-copy-via-teamviewer.asciidoc
@@ -23,7 +23,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*: 
 
-* https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/7-16-4/prebuilt-rule-7-16-4-remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/7-16-4/prebuilt-rule-7-16-4-remote-file-copy-via-teamviewer.asciidoc
@@ -23,7 +23,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*: 
 
-* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* https://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/7-16-4/prebuilt-rule-7-16-4-suspicious-werfault-child-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/7-16-4/prebuilt-rule-7-16-4-suspicious-werfault-child-process.asciidoc
@@ -25,7 +25,7 @@ A suspicious WerFault child process was detected, which may indicate an attempt 
 
 * https://www.hexacorn.com/blog/2019/09/19/silentprocessexit-quick-look-under-the-hood/
 * https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Persistence/persistence_SilentProcessExit_ImageHijack_sysmon_13_1.evtx
-* http://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
+* https://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/7-16-4/prebuilt-rule-7-16-4-suspicious-werfault-child-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/7-16-4/prebuilt-rule-7-16-4-suspicious-werfault-child-process.asciidoc
@@ -25,7 +25,7 @@ A suspicious WerFault child process was detected, which may indicate an attempt 
 
 * https://www.hexacorn.com/blog/2019/09/19/silentprocessexit-quick-look-under-the-hood/
 * https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Persistence/persistence_SilentProcessExit_ImageHijack_sysmon_13_1.evtx
-* https://blog.menasec.net/2021/01/
+* http://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/rule-details/creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/creation-of-a-hidden-local-user-account.asciidoc
@@ -23,7 +23,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*:
 
-* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* https://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*:

--- a/docs/detections/prebuilt-rules/rule-details/creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/creation-of-a-hidden-local-user-account.asciidoc
@@ -23,7 +23,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*:
 
-* https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*:

--- a/docs/detections/prebuilt-rules/rule-details/remote-execution-via-file-shares.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/remote-execution-via-file-shares.asciidoc
@@ -23,7 +23,7 @@ Identifies the execution of a file that was created by the virtual system proces
 
 *References*:
 
-* http://web.archive.org/web/20230329172636/https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
+* https://web.archive.org/web/20230329172636/https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/rule-details/remote-execution-via-file-shares.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/remote-execution-via-file-shares.asciidoc
@@ -23,7 +23,7 @@ Identifies the execution of a file that was created by the virtual system proces
 
 *References*:
 
-* https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
+* http://web.archive.org/web/20230329172636/https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/rule-details/remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/remote-file-copy-via-teamviewer.asciidoc
@@ -23,7 +23,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*:
 
-* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* https://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/rule-details/remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/remote-file-copy-via-teamviewer.asciidoc
@@ -23,7 +23,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*:
 
-* https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/rule-details/suspicious-managed-code-hosting-process.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/suspicious-managed-code-hosting-process.asciidoc
@@ -23,7 +23,7 @@ Identifies a suspicious managed code hosting process which could indicate code i
 
 *References*:
 
-* https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
+* http://web.archive.org/web/20230329154538/https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/rule-details/suspicious-managed-code-hosting-process.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/suspicious-managed-code-hosting-process.asciidoc
@@ -23,7 +23,7 @@ Identifies a suspicious managed code hosting process which could indicate code i
 
 *References*:
 
-* http://web.archive.org/web/20230329154538/https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
+* https://web.archive.org/web/20230329154538/https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/rule-details/suspicious-werfault-child-process.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/suspicious-werfault-child-process.asciidoc
@@ -25,7 +25,7 @@ A suspicious WerFault child process was detected, which may indicate an attempt 
 
 * https://www.hexacorn.com/blog/2019/09/19/silentprocessexit-quick-look-under-the-hood/
 * https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Persistence/persistence_SilentProcessExit_ImageHijack_sysmon_13_1.evtx
-* https://blog.menasec.net/2021/01/
+* http://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/rule-details/suspicious-werfault-child-process.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/suspicious-werfault-child-process.asciidoc
@@ -25,7 +25,7 @@ A suspicious WerFault child process was detected, which may indicate an attempt 
 
 * https://www.hexacorn.com/blog/2019/09/19/silentprocessexit-quick-look-under-the-hood/
 * https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Persistence/persistence_SilentProcessExit_ImageHijack_sysmon_13_1.evtx
-* http://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
+* https://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
 
 *Tags*:
 


### PR DESCRIPTION
## Summary
Fixes links to malicious site.

Related:
* https://github.com/elastic/security-docs/pull/4239
* https://github.com/elastic/detection-rules/pull/3271