### PR TITLE
Update Prebuilt Rule Links for Malicious Site in 8.5

### DIFF
--- a/docs/detections/prebuilt-rules/downloadable-packages/0-14-2/prebuilt-rule-0-14-2-creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-14-2/prebuilt-rule-0-14-2-creation-of-a-hidden-local-user-account.asciidoc
@@ -23,7 +23,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*: 
 
-* https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*: 

--- a/docs/detections/prebuilt-rules/downloadable-packages/0-14-2/prebuilt-rule-0-14-2-creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-14-2/prebuilt-rule-0-14-2-creation-of-a-hidden-local-user-account.asciidoc
@@ -23,7 +23,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*: 
 
-* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* https://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*: 

--- a/docs/detections/prebuilt-rules/downloadable-packages/0-14-2/prebuilt-rule-0-14-2-remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-14-2/prebuilt-rule-0-14-2-remote-file-copy-via-teamviewer.asciidoc
@@ -23,7 +23,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*: 
 
-* https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/0-14-2/prebuilt-rule-0-14-2-remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/0-14-2/prebuilt-rule-0-14-2-remote-file-copy-via-teamviewer.asciidoc
@@ -23,7 +23,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*: 
 
-* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* https://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/1-0-2/prebuilt-rule-1-0-2-account-configured-with-never-expiring-password.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/1-0-2/prebuilt-rule-1-0-2-account-configured-with-never-expiring-password.asciidoc
@@ -23,7 +23,7 @@ Detects the creation and modification of an account with the "Don't Expire Passw
 *References*: 
 
 * https://www.cert.ssi.gouv.fr/uploads/guide-ad.html#dont_expire
-* http://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
+* https://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/1-0-2/prebuilt-rule-1-0-2-account-configured-with-never-expiring-password.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/1-0-2/prebuilt-rule-1-0-2-account-configured-with-never-expiring-password.asciidoc
@@ -23,7 +23,7 @@ Detects the creation and modification of an account with the "Don't Expire Passw
 *References*: 
 
 * https://www.cert.ssi.gouv.fr/uploads/guide-ad.html#dont_expire
-* https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
+* http://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/1-0-2/prebuilt-rule-1-0-2-creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/1-0-2/prebuilt-rule-1-0-2-creation-of-a-hidden-local-user-account.asciidoc
@@ -23,7 +23,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*: 
 
-* https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*: 

--- a/docs/detections/prebuilt-rules/downloadable-packages/1-0-2/prebuilt-rule-1-0-2-creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/1-0-2/prebuilt-rule-1-0-2-creation-of-a-hidden-local-user-account.asciidoc
@@ -23,7 +23,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*: 
 
-* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* https://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*: 

--- a/docs/detections/prebuilt-rules/downloadable-packages/1-0-2/prebuilt-rule-1-0-2-remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/1-0-2/prebuilt-rule-1-0-2-remote-file-copy-via-teamviewer.asciidoc
@@ -23,7 +23,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*: 
 
-* https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/1-0-2/prebuilt-rule-1-0-2-remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/1-0-2/prebuilt-rule-1-0-2-remote-file-copy-via-teamviewer.asciidoc
@@ -23,7 +23,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*: 
 
-* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* https://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/1-0-2/prebuilt-rule-1-0-2-suspicious-managed-code-hosting-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/1-0-2/prebuilt-rule-1-0-2-suspicious-managed-code-hosting-process.asciidoc
@@ -23,7 +23,7 @@ Identifies a suspicious managed code hosting process which could indicate code i
 
 *References*: 
 
-* http://web.archive.org/web/20230329154538/https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
+* https://web.archive.org/web/20230329154538/https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/1-0-2/prebuilt-rule-1-0-2-suspicious-managed-code-hosting-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/1-0-2/prebuilt-rule-1-0-2-suspicious-managed-code-hosting-process.asciidoc
@@ -23,7 +23,7 @@ Identifies a suspicious managed code hosting process which could indicate code i
 
 *References*: 
 
-* https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
+* http://web.archive.org/web/20230329154538/https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/1-0-2/prebuilt-rule-1-0-2-suspicious-werfault-child-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/1-0-2/prebuilt-rule-1-0-2-suspicious-werfault-child-process.asciidoc
@@ -25,7 +25,7 @@ A suspicious WerFault child process was detected, which may indicate an attempt 
 
 * https://www.hexacorn.com/blog/2019/09/19/silentprocessexit-quick-look-under-the-hood/
 * https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Persistence/persistence_SilentProcessExit_ImageHijack_sysmon_13_1.evtx
-* http://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
+* https://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/1-0-2/prebuilt-rule-1-0-2-suspicious-werfault-child-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/1-0-2/prebuilt-rule-1-0-2-suspicious-werfault-child-process.asciidoc
@@ -25,7 +25,7 @@ A suspicious WerFault child process was detected, which may indicate an attempt 
 
 * https://www.hexacorn.com/blog/2019/09/19/silentprocessexit-quick-look-under-the-hood/
 * https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Persistence/persistence_SilentProcessExit_ImageHijack_sysmon_13_1.evtx
-* https://blog.menasec.net/2021/01/
+* http://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-1-1/prebuilt-rule-8-1-1-account-configured-with-never-expiring-password.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-1-1/prebuilt-rule-8-1-1-account-configured-with-never-expiring-password.asciidoc
@@ -23,7 +23,7 @@ Detects the creation and modification of an account with the "Don't Expire Passw
 *References*: 
 
 * https://www.cert.ssi.gouv.fr/uploads/guide-ad.html#dont_expire
-* http://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
+* https://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-1-1/prebuilt-rule-8-1-1-account-configured-with-never-expiring-password.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-1-1/prebuilt-rule-8-1-1-account-configured-with-never-expiring-password.asciidoc
@@ -23,7 +23,7 @@ Detects the creation and modification of an account with the "Don't Expire Passw
 *References*: 
 
 * https://www.cert.ssi.gouv.fr/uploads/guide-ad.html#dont_expire
-* https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
+* http://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-1-1/prebuilt-rule-8-1-1-creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-1-1/prebuilt-rule-8-1-1-creation-of-a-hidden-local-user-account.asciidoc
@@ -23,7 +23,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*: 
 
-* https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*: 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-1-1/prebuilt-rule-8-1-1-creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-1-1/prebuilt-rule-8-1-1-creation-of-a-hidden-local-user-account.asciidoc
@@ -23,7 +23,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*: 
 
-* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* https://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*: 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-1-1/prebuilt-rule-8-1-1-remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-1-1/prebuilt-rule-8-1-1-remote-file-copy-via-teamviewer.asciidoc
@@ -23,7 +23,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*: 
 
-* https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-1-1/prebuilt-rule-8-1-1-remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-1-1/prebuilt-rule-8-1-1-remote-file-copy-via-teamviewer.asciidoc
@@ -23,7 +23,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*: 
 
-* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* https://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-2-1/prebuilt-rule-8-2-1-creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-2-1/prebuilt-rule-8-2-1-creation-of-a-hidden-local-user-account.asciidoc
@@ -23,7 +23,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*: 
 
-* https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*: 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-2-1/prebuilt-rule-8-2-1-creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-2-1/prebuilt-rule-8-2-1-creation-of-a-hidden-local-user-account.asciidoc
@@ -23,7 +23,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*: 
 
-* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* https://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*: 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-2-1/prebuilt-rule-8-2-1-remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-2-1/prebuilt-rule-8-2-1-remote-file-copy-via-teamviewer.asciidoc
@@ -23,7 +23,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*: 
 
-* https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-2-1/prebuilt-rule-8-2-1-remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-2-1/prebuilt-rule-8-2-1-remote-file-copy-via-teamviewer.asciidoc
@@ -23,7 +23,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*: 
 
-* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* https://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-2-1/prebuilt-rule-8-2-1-suspicious-werfault-child-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-2-1/prebuilt-rule-8-2-1-suspicious-werfault-child-process.asciidoc
@@ -25,7 +25,7 @@ A suspicious WerFault child process was detected, which may indicate an attempt 
 
 * https://www.hexacorn.com/blog/2019/09/19/silentprocessexit-quick-look-under-the-hood/
 * https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Persistence/persistence_SilentProcessExit_ImageHijack_sysmon_13_1.evtx
-* http://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
+* https://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-2-1/prebuilt-rule-8-2-1-suspicious-werfault-child-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-2-1/prebuilt-rule-8-2-1-suspicious-werfault-child-process.asciidoc
@@ -25,7 +25,7 @@ A suspicious WerFault child process was detected, which may indicate an attempt 
 
 * https://www.hexacorn.com/blog/2019/09/19/silentprocessexit-quick-look-under-the-hood/
 * https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Persistence/persistence_SilentProcessExit_ImageHijack_sysmon_13_1.evtx
-* https://blog.menasec.net/2021/01/
+* http://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-1/prebuilt-rule-8-3-1-suspicious-managed-code-hosting-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-1/prebuilt-rule-8-3-1-suspicious-managed-code-hosting-process.asciidoc
@@ -23,7 +23,7 @@ Identifies a suspicious managed code hosting process which could indicate code i
 
 *References*: 
 
-* http://web.archive.org/web/20230329154538/https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
+* https://web.archive.org/web/20230329154538/https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-1/prebuilt-rule-8-3-1-suspicious-managed-code-hosting-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-1/prebuilt-rule-8-3-1-suspicious-managed-code-hosting-process.asciidoc
@@ -23,7 +23,7 @@ Identifies a suspicious managed code hosting process which could indicate code i
 
 *References*: 
 
-* https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
+* http://web.archive.org/web/20230329154538/https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-2/prebuilt-rule-8-3-2-account-configured-with-never-expiring-password.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-2/prebuilt-rule-8-3-2-account-configured-with-never-expiring-password.asciidoc
@@ -23,7 +23,7 @@ Detects the creation and modification of an account with the "Don't Expire Passw
 *References*: 
 
 * https://www.cert.ssi.gouv.fr/uploads/guide-ad.html#dont_expire
-* http://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
+* https://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-2/prebuilt-rule-8-3-2-account-configured-with-never-expiring-password.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-2/prebuilt-rule-8-3-2-account-configured-with-never-expiring-password.asciidoc
@@ -23,7 +23,7 @@ Detects the creation and modification of an account with the "Don't Expire Passw
 *References*: 
 
 * https://www.cert.ssi.gouv.fr/uploads/guide-ad.html#dont_expire
-* https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
+* http://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-2/prebuilt-rule-8-3-2-creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-2/prebuilt-rule-8-3-2-creation-of-a-hidden-local-user-account.asciidoc
@@ -23,7 +23,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*: 
 
-* https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*: 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-2/prebuilt-rule-8-3-2-creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-2/prebuilt-rule-8-3-2-creation-of-a-hidden-local-user-account.asciidoc
@@ -23,7 +23,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*: 
 
-* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* https://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*: 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-2/prebuilt-rule-8-3-2-remote-execution-via-file-shares.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-2/prebuilt-rule-8-3-2-remote-execution-via-file-shares.asciidoc
@@ -23,7 +23,7 @@ Identifies the execution of a file that was created by the virtual system proces
 
 *References*: 
 
-* http://web.archive.org/web/20230329172636/https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
+* https://web.archive.org/web/20230329172636/https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-2/prebuilt-rule-8-3-2-remote-execution-via-file-shares.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-2/prebuilt-rule-8-3-2-remote-execution-via-file-shares.asciidoc
@@ -23,7 +23,7 @@ Identifies the execution of a file that was created by the virtual system proces
 
 *References*: 
 
-* https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
+* http://web.archive.org/web/20230329172636/https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-2/prebuilt-rule-8-3-2-remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-2/prebuilt-rule-8-3-2-remote-file-copy-via-teamviewer.asciidoc
@@ -23,7 +23,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*: 
 
-* https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-2/prebuilt-rule-8-3-2-remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-2/prebuilt-rule-8-3-2-remote-file-copy-via-teamviewer.asciidoc
@@ -23,7 +23,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*: 
 
-* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* https://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-2/prebuilt-rule-8-3-2-suspicious-werfault-child-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-2/prebuilt-rule-8-3-2-suspicious-werfault-child-process.asciidoc
@@ -25,7 +25,7 @@ A suspicious WerFault child process was detected, which may indicate an attempt 
 
 * https://www.hexacorn.com/blog/2019/09/19/silentprocessexit-quick-look-under-the-hood/
 * https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Persistence/persistence_SilentProcessExit_ImageHijack_sysmon_13_1.evtx
-* http://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
+* https://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-2/prebuilt-rule-8-3-2-suspicious-werfault-child-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-2/prebuilt-rule-8-3-2-suspicious-werfault-child-process.asciidoc
@@ -25,7 +25,7 @@ A suspicious WerFault child process was detected, which may indicate an attempt 
 
 * https://www.hexacorn.com/blog/2019/09/19/silentprocessexit-quick-look-under-the-hood/
 * https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Persistence/persistence_SilentProcessExit_ImageHijack_sysmon_13_1.evtx
-* https://blog.menasec.net/2021/01/
+* http://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-3/prebuilt-rule-8-3-3-account-configured-with-never-expiring-password.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-3/prebuilt-rule-8-3-3-account-configured-with-never-expiring-password.asciidoc
@@ -24,7 +24,7 @@ Detects the creation and modification of an account with the "Don't Expire Passw
 *References*: 
 
 * https://www.cert.ssi.gouv.fr/uploads/guide-ad.html#dont_expire
-* http://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
+* https://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-3/prebuilt-rule-8-3-3-account-configured-with-never-expiring-password.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-3/prebuilt-rule-8-3-3-account-configured-with-never-expiring-password.asciidoc
@@ -24,7 +24,7 @@ Detects the creation and modification of an account with the "Don't Expire Passw
 *References*: 
 
 * https://www.cert.ssi.gouv.fr/uploads/guide-ad.html#dont_expire
-* https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
+* http://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-3/prebuilt-rule-8-3-3-creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-3/prebuilt-rule-8-3-3-creation-of-a-hidden-local-user-account.asciidoc
@@ -23,7 +23,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*: 
 
-* https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*: 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-3/prebuilt-rule-8-3-3-creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-3/prebuilt-rule-8-3-3-creation-of-a-hidden-local-user-account.asciidoc
@@ -23,7 +23,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*: 
 
-* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* https://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*: 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-3/prebuilt-rule-8-3-3-remote-execution-via-file-shares.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-3/prebuilt-rule-8-3-3-remote-execution-via-file-shares.asciidoc
@@ -23,7 +23,7 @@ Identifies the execution of a file that was created by the virtual system proces
 
 *References*:
 
-* http://web.archive.org/web/20230329172636/https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
+* https://web.archive.org/web/20230329172636/https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-3/prebuilt-rule-8-3-3-remote-execution-via-file-shares.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-3/prebuilt-rule-8-3-3-remote-execution-via-file-shares.asciidoc
@@ -23,7 +23,7 @@ Identifies the execution of a file that was created by the virtual system proces
 
 *References*:
 
-* https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
+* http://web.archive.org/web/20230329172636/https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-3/prebuilt-rule-8-3-3-remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-3/prebuilt-rule-8-3-3-remote-file-copy-via-teamviewer.asciidoc
@@ -24,7 +24,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*:
 
-* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* https://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-3/prebuilt-rule-8-3-3-remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-3/prebuilt-rule-8-3-3-remote-file-copy-via-teamviewer.asciidoc
@@ -24,7 +24,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*:
 
-* https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-3/prebuilt-rule-8-3-3-suspicious-managed-code-hosting-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-3/prebuilt-rule-8-3-3-suspicious-managed-code-hosting-process.asciidoc
@@ -23,7 +23,7 @@ Identifies a suspicious managed code hosting process which could indicate code i
 
 *References*: 
 
-* http://web.archive.org/web/20230329154538/https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
+* https://web.archive.org/web/20230329154538/https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-3/prebuilt-rule-8-3-3-suspicious-managed-code-hosting-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-3/prebuilt-rule-8-3-3-suspicious-managed-code-hosting-process.asciidoc
@@ -23,7 +23,7 @@ Identifies a suspicious managed code hosting process which could indicate code i
 
 *References*: 
 
-* https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
+* http://web.archive.org/web/20230329154538/https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-3/prebuilt-rule-8-3-3-suspicious-werfault-child-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-3/prebuilt-rule-8-3-3-suspicious-werfault-child-process.asciidoc
@@ -26,7 +26,7 @@ A suspicious WerFault child process was detected, which may indicate an attempt 
 
 * https://www.hexacorn.com/blog/2019/09/19/silentprocessexit-quick-look-under-the-hood/
 * https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Persistence/persistence_SilentProcessExit_ImageHijack_sysmon_13_1.evtx
-* https://blog.menasec.net/2021/01/
+* http://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-3/prebuilt-rule-8-3-3-suspicious-werfault-child-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-3/prebuilt-rule-8-3-3-suspicious-werfault-child-process.asciidoc
@@ -26,7 +26,7 @@ A suspicious WerFault child process was detected, which may indicate an attempt 
 
 * https://www.hexacorn.com/blog/2019/09/19/silentprocessexit-quick-look-under-the-hood/
 * https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Persistence/persistence_SilentProcessExit_ImageHijack_sysmon_13_1.evtx
-* http://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
+* https://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-4/prebuilt-rule-8-3-4-suspicious-werfault-child-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-4/prebuilt-rule-8-3-4-suspicious-werfault-child-process.asciidoc
@@ -27,7 +27,7 @@ A suspicious WerFault child process was detected, which may indicate an attempt 
 * https://www.hexacorn.com/blog/2019/09/19/silentprocessexit-quick-look-under-the-hood/
 * https://www.hexacorn.com/blog/2019/09/20/werfault-command-line-switches-v0-1/
 * https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Persistence/persistence_SilentProcessExit_ImageHijack_sysmon_13_1.evtx
-* http://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
+* https://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-3-4/prebuilt-rule-8-3-4-suspicious-werfault-child-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-3-4/prebuilt-rule-8-3-4-suspicious-werfault-child-process.asciidoc
@@ -27,7 +27,7 @@ A suspicious WerFault child process was detected, which may indicate an attempt 
 * https://www.hexacorn.com/blog/2019/09/19/silentprocessexit-quick-look-under-the-hood/
 * https://www.hexacorn.com/blog/2019/09/20/werfault-command-line-switches-v0-1/
 * https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Persistence/persistence_SilentProcessExit_ImageHijack_sysmon_13_1.evtx
-* https://blog.menasec.net/2021/01/
+* http://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-4-1/prebuilt-rule-8-4-1-account-configured-with-never-expiring-password.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-4-1/prebuilt-rule-8-4-1-account-configured-with-never-expiring-password.asciidoc
@@ -23,7 +23,7 @@ Detects the creation and modification of an account with the "Don't Expire Passw
 *References*: 
 
 * https://www.cert.ssi.gouv.fr/uploads/guide-ad.html#dont_expire
-* http://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
+* https://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-4-1/prebuilt-rule-8-4-1-account-configured-with-never-expiring-password.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-4-1/prebuilt-rule-8-4-1-account-configured-with-never-expiring-password.asciidoc
@@ -23,7 +23,7 @@ Detects the creation and modification of an account with the "Don't Expire Passw
 *References*: 
 
 * https://www.cert.ssi.gouv.fr/uploads/guide-ad.html#dont_expire
-* https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
+* http://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-4-1/prebuilt-rule-8-4-1-creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-4-1/prebuilt-rule-8-4-1-creation-of-a-hidden-local-user-account.asciidoc
@@ -23,7 +23,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*: 
 
-* https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*: 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-4-1/prebuilt-rule-8-4-1-creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-4-1/prebuilt-rule-8-4-1-creation-of-a-hidden-local-user-account.asciidoc
@@ -23,7 +23,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*: 
 
-* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* https://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*: 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-4-1/prebuilt-rule-8-4-1-remote-execution-via-file-shares.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-4-1/prebuilt-rule-8-4-1-remote-execution-via-file-shares.asciidoc
@@ -23,7 +23,7 @@ Identifies the execution of a file that was created by the virtual system proces
 
 *References*:
 
-* http://web.archive.org/web/20230329172636/https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
+* https://web.archive.org/web/20230329172636/https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-4-1/prebuilt-rule-8-4-1-remote-execution-via-file-shares.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-4-1/prebuilt-rule-8-4-1-remote-execution-via-file-shares.asciidoc
@@ -23,7 +23,7 @@ Identifies the execution of a file that was created by the virtual system proces
 
 *References*:
 
-* https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
+* http://web.archive.org/web/20230329172636/https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-4-1/prebuilt-rule-8-4-1-remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-4-1/prebuilt-rule-8-4-1-remote-file-copy-via-teamviewer.asciidoc
@@ -24,7 +24,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*:
 
-* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* https://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-4-1/prebuilt-rule-8-4-1-remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-4-1/prebuilt-rule-8-4-1-remote-file-copy-via-teamviewer.asciidoc
@@ -24,7 +24,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*:
 
-* https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-4-1/prebuilt-rule-8-4-1-suspicious-werfault-child-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-4-1/prebuilt-rule-8-4-1-suspicious-werfault-child-process.asciidoc
@@ -26,7 +26,7 @@ A suspicious WerFault child process was detected, which may indicate an attempt 
 
 * https://www.hexacorn.com/blog/2019/09/19/silentprocessexit-quick-look-under-the-hood/
 * https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Persistence/persistence_SilentProcessExit_ImageHijack_sysmon_13_1.evtx
-* https://blog.menasec.net/2021/01/
+* http://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-4-1/prebuilt-rule-8-4-1-suspicious-werfault-child-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-4-1/prebuilt-rule-8-4-1-suspicious-werfault-child-process.asciidoc
@@ -26,7 +26,7 @@ A suspicious WerFault child process was detected, which may indicate an attempt 
 
 * https://www.hexacorn.com/blog/2019/09/19/silentprocessexit-quick-look-under-the-hood/
 * https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Persistence/persistence_SilentProcessExit_ImageHijack_sysmon_13_1.evtx
-* http://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
+* https://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-4-2/prebuilt-rule-8-4-2-account-configured-with-never-expiring-password.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-4-2/prebuilt-rule-8-4-2-account-configured-with-never-expiring-password.asciidoc
@@ -24,7 +24,7 @@ Detects the creation and modification of an account with the "Don't Expire Passw
 *References*: 
 
 * https://www.cert.ssi.gouv.fr/uploads/guide-ad.html#dont_expire
-* http://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
+* https://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-4-2/prebuilt-rule-8-4-2-account-configured-with-never-expiring-password.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-4-2/prebuilt-rule-8-4-2-account-configured-with-never-expiring-password.asciidoc
@@ -24,7 +24,7 @@ Detects the creation and modification of an account with the "Don't Expire Passw
 *References*: 
 
 * https://www.cert.ssi.gouv.fr/uploads/guide-ad.html#dont_expire
-* https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
+* http://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-4-2/prebuilt-rule-8-4-2-creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-4-2/prebuilt-rule-8-4-2-creation-of-a-hidden-local-user-account.asciidoc
@@ -23,7 +23,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*: 
 
-* https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*: 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-4-2/prebuilt-rule-8-4-2-creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-4-2/prebuilt-rule-8-4-2-creation-of-a-hidden-local-user-account.asciidoc
@@ -23,7 +23,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*: 
 
-* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* https://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*: 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-4-2/prebuilt-rule-8-4-2-remote-execution-via-file-shares.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-4-2/prebuilt-rule-8-4-2-remote-execution-via-file-shares.asciidoc
@@ -23,7 +23,7 @@ Identifies the execution of a file that was created by the virtual system proces
 
 *References*:
 
-* http://web.archive.org/web/20230329172636/https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
+* https://web.archive.org/web/20230329172636/https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-4-2/prebuilt-rule-8-4-2-remote-execution-via-file-shares.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-4-2/prebuilt-rule-8-4-2-remote-execution-via-file-shares.asciidoc
@@ -23,7 +23,7 @@ Identifies the execution of a file that was created by the virtual system proces
 
 *References*:
 
-* https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
+* http://web.archive.org/web/20230329172636/https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-4-2/prebuilt-rule-8-4-2-remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-4-2/prebuilt-rule-8-4-2-remote-file-copy-via-teamviewer.asciidoc
@@ -24,7 +24,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*:
 
-* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* https://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-4-2/prebuilt-rule-8-4-2-remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-4-2/prebuilt-rule-8-4-2-remote-file-copy-via-teamviewer.asciidoc
@@ -24,7 +24,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*:
 
-* https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-4-2/prebuilt-rule-8-4-2-suspicious-managed-code-hosting-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-4-2/prebuilt-rule-8-4-2-suspicious-managed-code-hosting-process.asciidoc
@@ -23,7 +23,7 @@ Identifies a suspicious managed code hosting process which could indicate code i
 
 *References*: 
 
-* http://web.archive.org/web/20230329154538/https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
+* https://web.archive.org/web/20230329154538/https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-4-2/prebuilt-rule-8-4-2-suspicious-managed-code-hosting-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-4-2/prebuilt-rule-8-4-2-suspicious-managed-code-hosting-process.asciidoc
@@ -23,7 +23,7 @@ Identifies a suspicious managed code hosting process which could indicate code i
 
 *References*: 
 
-* https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
+* http://web.archive.org/web/20230329154538/https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-4-2/prebuilt-rule-8-4-2-suspicious-werfault-child-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-4-2/prebuilt-rule-8-4-2-suspicious-werfault-child-process.asciidoc
@@ -27,7 +27,7 @@ A suspicious WerFault child process was detected, which may indicate an attempt 
 * https://www.hexacorn.com/blog/2019/09/19/silentprocessexit-quick-look-under-the-hood/
 * https://www.hexacorn.com/blog/2019/09/20/werfault-command-line-switches-v0-1/
 * https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Persistence/persistence_SilentProcessExit_ImageHijack_sysmon_13_1.evtx
-* http://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
+* https://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-4-2/prebuilt-rule-8-4-2-suspicious-werfault-child-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-4-2/prebuilt-rule-8-4-2-suspicious-werfault-child-process.asciidoc
@@ -27,7 +27,7 @@ A suspicious WerFault child process was detected, which may indicate an attempt 
 * https://www.hexacorn.com/blog/2019/09/19/silentprocessexit-quick-look-under-the-hood/
 * https://www.hexacorn.com/blog/2019/09/20/werfault-command-line-switches-v0-1/
 * https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Persistence/persistence_SilentProcessExit_ImageHijack_sysmon_13_1.evtx
-* https://blog.menasec.net/2021/01/
+* http://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-4-3/prebuilt-rule-8-4-3-account-configured-with-never-expiring-password.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-4-3/prebuilt-rule-8-4-3-account-configured-with-never-expiring-password.asciidoc
@@ -24,7 +24,7 @@ Detects the creation and modification of an account with the "Don't Expire Passw
 *References*: 
 
 * https://www.cert.ssi.gouv.fr/uploads/guide-ad.html#dont_expire
-* http://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
+* https://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-4-3/prebuilt-rule-8-4-3-account-configured-with-never-expiring-password.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-4-3/prebuilt-rule-8-4-3-account-configured-with-never-expiring-password.asciidoc
@@ -24,7 +24,7 @@ Detects the creation and modification of an account with the "Don't Expire Passw
 *References*: 
 
 * https://www.cert.ssi.gouv.fr/uploads/guide-ad.html#dont_expire
-* https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
+* http://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-5-1/prebuilt-rule-8-5-1-account-configured-with-never-expiring-password.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-5-1/prebuilt-rule-8-5-1-account-configured-with-never-expiring-password.asciidoc
@@ -24,7 +24,7 @@ Detects the creation and modification of an account with the "Don't Expire Passw
 *References*: 
 
 * https://www.cert.ssi.gouv.fr/uploads/guide-ad.html#dont_expire
-* http://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
+* https://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-5-1/prebuilt-rule-8-5-1-account-configured-with-never-expiring-password.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-5-1/prebuilt-rule-8-5-1-account-configured-with-never-expiring-password.asciidoc
@@ -24,7 +24,7 @@ Detects the creation and modification of an account with the "Don't Expire Passw
 *References*: 
 
 * https://www.cert.ssi.gouv.fr/uploads/guide-ad.html#dont_expire
-* https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
+* http://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-5-2/prebuilt-rule-8-5-2-account-configured-with-never-expiring-password.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-5-2/prebuilt-rule-8-5-2-account-configured-with-never-expiring-password.asciidoc
@@ -24,7 +24,7 @@ Detects the creation and modification of an account with the "Don't Expire Passw
 *References*: 
 
 * https://www.cert.ssi.gouv.fr/uploads/guide-ad.html#dont_expire
-* http://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
+* https://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-5-2/prebuilt-rule-8-5-2-account-configured-with-never-expiring-password.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-5-2/prebuilt-rule-8-5-2-account-configured-with-never-expiring-password.asciidoc
@@ -24,7 +24,7 @@ Detects the creation and modification of an account with the "Don't Expire Passw
 *References*: 
 
 * https://www.cert.ssi.gouv.fr/uploads/guide-ad.html#dont_expire
-* https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
+* http://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-5-2/prebuilt-rule-8-5-2-creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-5-2/prebuilt-rule-8-5-2-creation-of-a-hidden-local-user-account.asciidoc
@@ -24,7 +24,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*: 
 
-* https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*: 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-5-2/prebuilt-rule-8-5-2-creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-5-2/prebuilt-rule-8-5-2-creation-of-a-hidden-local-user-account.asciidoc
@@ -24,7 +24,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*: 
 
-* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* https://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*: 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-5-2/prebuilt-rule-8-5-2-remote-execution-via-file-shares.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-5-2/prebuilt-rule-8-5-2-remote-execution-via-file-shares.asciidoc
@@ -24,7 +24,7 @@ Identifies the execution of a file that was created by the virtual system proces
 
 *References*:
 
-* http://web.archive.org/web/20230329172636/https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
+* https://web.archive.org/web/20230329172636/https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-5-2/prebuilt-rule-8-5-2-remote-execution-via-file-shares.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-5-2/prebuilt-rule-8-5-2-remote-execution-via-file-shares.asciidoc
@@ -24,7 +24,7 @@ Identifies the execution of a file that was created by the virtual system proces
 
 *References*:
 
-* https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
+* http://web.archive.org/web/20230329172636/https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-5-2/prebuilt-rule-8-5-2-remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-5-2/prebuilt-rule-8-5-2-remote-file-copy-via-teamviewer.asciidoc
@@ -24,7 +24,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*:
 
-* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* https://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-5-2/prebuilt-rule-8-5-2-remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-5-2/prebuilt-rule-8-5-2-remote-file-copy-via-teamviewer.asciidoc
@@ -24,7 +24,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*:
 
-* https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-5-2/prebuilt-rule-8-5-2-suspicious-managed-code-hosting-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-5-2/prebuilt-rule-8-5-2-suspicious-managed-code-hosting-process.asciidoc
@@ -23,7 +23,7 @@ Identifies a suspicious managed code hosting process which could indicate code i
 
 *References*: 
 
-* http://web.archive.org/web/20230329154538/https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
+* https://web.archive.org/web/20230329154538/https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-5-2/prebuilt-rule-8-5-2-suspicious-managed-code-hosting-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-5-2/prebuilt-rule-8-5-2-suspicious-managed-code-hosting-process.asciidoc
@@ -23,7 +23,7 @@ Identifies a suspicious managed code hosting process which could indicate code i
 
 *References*: 
 
-* https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
+* http://web.archive.org/web/20230329154538/https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-5-2/prebuilt-rule-8-5-2-suspicious-werfault-child-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-5-2/prebuilt-rule-8-5-2-suspicious-werfault-child-process.asciidoc
@@ -27,7 +27,7 @@ A suspicious WerFault child process was detected, which may indicate an attempt 
 * https://www.hexacorn.com/blog/2019/09/19/silentprocessexit-quick-look-under-the-hood/
 * https://www.hexacorn.com/blog/2019/09/20/werfault-command-line-switches-v0-1/
 * https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Persistence/persistence_SilentProcessExit_ImageHijack_sysmon_13_1.evtx
-* http://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
+* https://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-5-2/prebuilt-rule-8-5-2-suspicious-werfault-child-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-5-2/prebuilt-rule-8-5-2-suspicious-werfault-child-process.asciidoc
@@ -27,7 +27,7 @@ A suspicious WerFault child process was detected, which may indicate an attempt 
 * https://www.hexacorn.com/blog/2019/09/19/silentprocessexit-quick-look-under-the-hood/
 * https://www.hexacorn.com/blog/2019/09/20/werfault-command-line-switches-v0-1/
 * https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Persistence/persistence_SilentProcessExit_ImageHijack_sysmon_13_1.evtx
-* https://blog.menasec.net/2021/01/
+* http://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-5-4/prebuilt-rule-8-5-4-account-configured-with-never-expiring-password.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-5-4/prebuilt-rule-8-5-4-account-configured-with-never-expiring-password.asciidoc
@@ -24,7 +24,7 @@ Detects the creation and modification of an account with the "Don't Expire Passw
 *References*: 
 
 * https://www.cert.ssi.gouv.fr/uploads/guide-ad.html#dont_expire
-* http://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
+* https://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-5-4/prebuilt-rule-8-5-4-account-configured-with-never-expiring-password.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-5-4/prebuilt-rule-8-5-4-account-configured-with-never-expiring-password.asciidoc
@@ -24,7 +24,7 @@ Detects the creation and modification of an account with the "Don't Expire Passw
 *References*: 
 
 * https://www.cert.ssi.gouv.fr/uploads/guide-ad.html#dont_expire
-* https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
+* http://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-5-7/prebuilt-rule-8-5-7-account-configured-with-never-expiring-password.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-5-7/prebuilt-rule-8-5-7-account-configured-with-never-expiring-password.asciidoc
@@ -24,7 +24,7 @@ Detects the creation and modification of an account with the "Don't Expire Passw
 *References*: 
 
 * https://www.cert.ssi.gouv.fr/uploads/guide-ad.html#dont_expire
-* http://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
+* https://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-5-7/prebuilt-rule-8-5-7-account-configured-with-never-expiring-password.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-5-7/prebuilt-rule-8-5-7-account-configured-with-never-expiring-password.asciidoc
@@ -24,7 +24,7 @@ Detects the creation and modification of an account with the "Don't Expire Passw
 *References*: 
 
 * https://www.cert.ssi.gouv.fr/uploads/guide-ad.html#dont_expire
-* https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
+* http://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-5-7/prebuilt-rule-8-5-7-creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-5-7/prebuilt-rule-8-5-7-creation-of-a-hidden-local-user-account.asciidoc
@@ -24,7 +24,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*: 
 
-* https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*: 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-5-7/prebuilt-rule-8-5-7-creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-5-7/prebuilt-rule-8-5-7-creation-of-a-hidden-local-user-account.asciidoc
@@ -24,7 +24,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*: 
 
-* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* https://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*: 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-5-7/prebuilt-rule-8-5-7-remote-execution-via-file-shares.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-5-7/prebuilt-rule-8-5-7-remote-execution-via-file-shares.asciidoc
@@ -24,7 +24,7 @@ Identifies the execution of a file that was created by the virtual system proces
 
 *References*:
 
-* http://web.archive.org/web/20230329172636/https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
+* https://web.archive.org/web/20230329172636/https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-5-7/prebuilt-rule-8-5-7-remote-execution-via-file-shares.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-5-7/prebuilt-rule-8-5-7-remote-execution-via-file-shares.asciidoc
@@ -24,7 +24,7 @@ Identifies the execution of a file that was created by the virtual system proces
 
 *References*:
 
-* https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
+* http://web.archive.org/web/20230329172636/https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-5-7/prebuilt-rule-8-5-7-remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-5-7/prebuilt-rule-8-5-7-remote-file-copy-via-teamviewer.asciidoc
@@ -24,7 +24,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*:
 
-* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* https://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-5-7/prebuilt-rule-8-5-7-remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-5-7/prebuilt-rule-8-5-7-remote-file-copy-via-teamviewer.asciidoc
@@ -24,7 +24,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*:
 
-* https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-5-7/prebuilt-rule-8-5-7-suspicious-managed-code-hosting-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-5-7/prebuilt-rule-8-5-7-suspicious-managed-code-hosting-process.asciidoc
@@ -23,7 +23,7 @@ Identifies a suspicious managed code hosting process which could indicate code i
 
 *References*: 
 
-* http://web.archive.org/web/20230329154538/https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
+* https://web.archive.org/web/20230329154538/https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-5-7/prebuilt-rule-8-5-7-suspicious-managed-code-hosting-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-5-7/prebuilt-rule-8-5-7-suspicious-managed-code-hosting-process.asciidoc
@@ -23,7 +23,7 @@ Identifies a suspicious managed code hosting process which could indicate code i
 
 *References*: 
 
-* https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
+* http://web.archive.org/web/20230329154538/https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-5-7/prebuilt-rule-8-5-7-suspicious-werfault-child-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-5-7/prebuilt-rule-8-5-7-suspicious-werfault-child-process.asciidoc
@@ -27,7 +27,7 @@ A suspicious WerFault child process was detected, which may indicate an attempt 
 * https://www.hexacorn.com/blog/2019/09/19/silentprocessexit-quick-look-under-the-hood/
 * https://www.hexacorn.com/blog/2019/09/20/werfault-command-line-switches-v0-1/
 * https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Persistence/persistence_SilentProcessExit_ImageHijack_sysmon_13_1.evtx
-* http://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
+* https://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-5-7/prebuilt-rule-8-5-7-suspicious-werfault-child-process.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-5-7/prebuilt-rule-8-5-7-suspicious-werfault-child-process.asciidoc
@@ -27,7 +27,7 @@ A suspicious WerFault child process was detected, which may indicate an attempt 
 * https://www.hexacorn.com/blog/2019/09/19/silentprocessexit-quick-look-under-the-hood/
 * https://www.hexacorn.com/blog/2019/09/20/werfault-command-line-switches-v0-1/
 * https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Persistence/persistence_SilentProcessExit_ImageHijack_sysmon_13_1.evtx
-* https://blog.menasec.net/2021/01/
+* http://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
 
 *Tags*: 
 

--- a/docs/detections/prebuilt-rules/rule-details/account-configured-with-never-expiring-password.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/account-configured-with-never-expiring-password.asciidoc
@@ -23,7 +23,7 @@ Detects the creation and modification of an account with the "Don't Expire Passw
 *References*:
 
 * https://www.cert.ssi.gouv.fr/uploads/guide-ad.html#dont_expire
-* http://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
+* https://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/rule-details/account-configured-with-never-expiring-password.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/account-configured-with-never-expiring-password.asciidoc
@@ -23,7 +23,7 @@ Detects the creation and modification of an account with the "Don't Expire Passw
 *References*:
 
 * https://www.cert.ssi.gouv.fr/uploads/guide-ad.html#dont_expire
-* https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
+* http://web.archive.org/web/20230329171952/https://blog.menasec.net/2019/02/threat-hunting-26-persistent-password.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/rule-details/creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/creation-of-a-hidden-local-user-account.asciidoc
@@ -23,7 +23,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*:
 
-* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* https://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*:

--- a/docs/detections/prebuilt-rules/rule-details/creation-of-a-hidden-local-user-account.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/creation-of-a-hidden-local-user-account.asciidoc
@@ -23,7 +23,7 @@ Identifies the creation of a hidden local user account by appending the dollar s
 
 *References*:
 
-* https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
+* http://web.archive.org/web/20230329153858/https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html
 * https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign
 
 *Tags*:

--- a/docs/detections/prebuilt-rules/rule-details/remote-execution-via-file-shares.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/remote-execution-via-file-shares.asciidoc
@@ -23,7 +23,7 @@ Identifies the execution of a file that was created by the virtual system proces
 
 *References*:
 
-* http://web.archive.org/web/20230329172636/https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
+* https://web.archive.org/web/20230329172636/https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/rule-details/remote-execution-via-file-shares.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/remote-execution-via-file-shares.asciidoc
@@ -23,7 +23,7 @@ Identifies the execution of a file that was created by the virtual system proces
 
 *References*:
 
-* https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
+* http://web.archive.org/web/20230329172636/https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/rule-details/remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/remote-file-copy-via-teamviewer.asciidoc
@@ -23,7 +23,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*:
 
-* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* https://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/rule-details/remote-file-copy-via-teamviewer.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/remote-file-copy-via-teamviewer.asciidoc
@@ -23,7 +23,7 @@ Identifies an executable or script file remotely downloaded via a TeamViewer tra
 
 *References*:
 
-* https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
+* http://web.archive.org/web/20230329160957/https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/rule-details/suspicious-managed-code-hosting-process.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/suspicious-managed-code-hosting-process.asciidoc
@@ -23,7 +23,7 @@ Identifies a suspicious managed code hosting process which could indicate code i
 
 *References*:
 
-* https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
+* http://web.archive.org/web/20230329154538/https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/rule-details/suspicious-managed-code-hosting-process.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/suspicious-managed-code-hosting-process.asciidoc
@@ -23,7 +23,7 @@ Identifies a suspicious managed code hosting process which could indicate code i
 
 *References*:
 
-* http://web.archive.org/web/20230329154538/https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
+* https://web.archive.org/web/20230329154538/https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/rule-details/suspicious-werfault-child-process.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/suspicious-werfault-child-process.asciidoc
@@ -25,7 +25,7 @@ A suspicious WerFault child process was detected, which may indicate an attempt 
 
 * https://www.hexacorn.com/blog/2019/09/19/silentprocessexit-quick-look-under-the-hood/
 * https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Persistence/persistence_SilentProcessExit_ImageHijack_sysmon_13_1.evtx
-* https://blog.menasec.net/2021/01/
+* http://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
 
 *Tags*:
 

--- a/docs/detections/prebuilt-rules/rule-details/suspicious-werfault-child-process.asciidoc
+++ b/docs/detections/prebuilt-rules/rule-details/suspicious-werfault-child-process.asciidoc
@@ -25,7 +25,7 @@ A suspicious WerFault child process was detected, which may indicate an attempt 
 
 * https://www.hexacorn.com/blog/2019/09/19/silentprocessexit-quick-look-under-the-hood/
 * https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Persistence/persistence_SilentProcessExit_ImageHijack_sysmon_13_1.evtx
-* http://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
+* https://web.archive.org/web/20230530011556/https://blog.menasec.net/2021/01/
 
 *Tags*:
 


### PR DESCRIPTION
## Summary
Fixes links to malicious site.

Related:
* https://github.com/elastic/security-docs/pull/4239
* https://github.com/elastic/detection-rules/pull/3271