### PR TITLE
Create stub page for bi-directional integration response actions (SentinelOne) 

### DIFF
--- a/docs/management/admin/response-actions-config.asciidoc
+++ b/docs/management/admin/response-actions-config.asciidoc
@@ -1,0 +1,13 @@
+[[response-actions-config]]
+= Response actions configuration
+
+:frontmatter-description: Configure third-party systems to perform response actions on protected hosts.
+:frontmatter-tags-products: [security]
+:frontmatter-tags-content-type: [how-to]
+:frontmatter-tags-user-goals: [manage]
+
+[sidebar]
+--
+[.text-center]
+**This is a placeholder for future documentation.**
+--

--- a/docs/management/manage-intro.asciidoc
+++ b/docs/management/manage-intro.asciidoc
@@ -8,6 +8,7 @@ include::{security-docs-root}/docs/management/admin/admin-pg-ov.asciidoc[levelof
 include::{security-docs-root}/docs/management/admin/response-actions.asciidoc[leveloffset=+2]
 include::{security-docs-root}/docs/management/admin/response-actions-history.asciidoc[leveloffset=+2]
 include::{security-docs-root}/docs/management/admin/host-isolation-ov.asciidoc[leveloffset=+2]
+include::{security-docs-root}/docs/management/admin/response-actions-config.asciidoc[leveloffset=+2]
 include::{security-docs-root}/docs/management/admin/policy-list.asciidoc[leveloffset=+1]
 include::{security-docs-root}/docs/management/admin/trusted-apps.asciidoc[leveloffset=+1]
 include::{security-docs-root}/docs/management/admin/event-filters.asciidoc[leveloffset=+1]


### PR DESCRIPTION
Contributes to #4312 by creating a stub page for the configuration docs.

Preview: https://security-docs_4317.docs-preview.app.elstc.co/guide/en/security/master/response-actions-config.html