### PR TITLE
[7.13] Adds Export exception list API docs (#4316)

### DIFF
--- a/docs/detections/api/exceptions-api-index.asciidoc
+++ b/docs/detections/api/exceptions-api-index.asciidoc
@@ -12,6 +12,8 @@ include::exceptions/api-get-exception-containers.asciidoc[]
 
 include::exceptions/api-get-exception-items.asciidoc[]
 
+include::exceptions/api-export-exception-list.asciidoc[]
+
 include::exceptions/api-update-exception-container.asciidoc[]
 
 include::exceptions/api-update-exception-item.asciidoc[]

--- a/docs/detections/api/exceptions/api-export-exception-list.asciidoc
+++ b/docs/detections/api/exceptions/api-export-exception-list.asciidoc
@@ -1,0 +1,46 @@
+[[exceptions-api-export-exception-list]]
+=== Export exception list
+
+Exports an exception list and its associated items to an `.ndjson` file.
+
+==== Request URL
+
+`POST <kibana host>:<port>/api/exception_lists/_export`
+
+===== URL query parameters
+
+[width="100%",options="header"]
+|==============================================
+|Name |Type |Description |Required
+
+|`id` |String |ID of the exception list. |Yes.
+|`list_id` |String |List ID of the exception list. |Yes.
+|`namespace_type` |String a|Determines whether the exported exception list is associated with a single {kib} space or available in all spaces, using one of the following:
+
+* `single`: Associated with the {kib} space in which it is created.
+* `agnostic`: Available in all {kib} spaces.
+
+|No, defaults to `single`.
+|==============================================
+
+===== Example request
+
+Exports the exception list with an `id` value of `b590e8f0-43fa-11eb-ad0b-97969c856022` and a `list_id` value of `4fcd2765-0ba8-4048-8a65-27afcab72b12`, associated with a single {kib} space.
+  
+[source,console]
+--------------------------------------------------
+POST api/exception_lists/_export?id=b590e8f0-43fa-11eb-ad0b-97969c856022&list_id=4fcd2765-0ba8-4048-8a65-27afcab72b12&namespace_type=single
+--------------------------------------------------
+
+==== Response code
+
+`200`::
+    Indicates a successful call.
+
+==== Sample `.ndjson` file
+[source,json]
+-------------------------------------------------
+{"_version":"WzgxLDFd","created_at":"2020-12-22T02:09:23.199Z","created_by":"elastic","description":"test","id":"b590e8f0-43fa-11eb-ad0b-97969c856022","immutable":false,"list_id":"4fcd2765-0ba8-4048-8a65-27afcab72b12","name":"Test Exception List","namespace_type":"single","os_types":[],"tags":[],"tie_breaker_id":"0437982d-4f48-4bcd-ab78-3a9b0696bae9","type":"detection","updated_at":"2020-12-22T02:09:23.257Z","updated_by":"elastic","version":1}
+{"_version":"Wzg5LDFd","comments":[],"created_at":"2020-12-22T02:09:48.419Z","created_by":"elastic","description":"test - exception list item","entries":[{"field":"host.name","type":"match","operator":"included","value":"siem-kibana"}],"id":"c4992d30-43fa-11eb-ad0b-97969c856022","item_id":"0f9edfd7-a5b0-4974-b5de-f949b7b89465","list_id":"4fcd2765-0ba8-4048-8a65-27afcab72b12","name":"Test - exception list item","namespace_type":"single","os_types":[],"tags":[],"tie_breaker_id":"56564ed3-c85d-4399-b6ea-cd12617530bd","type":"simple","updated_at":"2020-12-22T02:09:48.486Z","updated_by":"elastic"}
+{"exception_list_items_details":{"exported_count":1}}
+-------------------------------------------------


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.13`:
 - [Adds Export exception list API docs (#4316)](https://github.com/elastic/security-docs/pull/4316)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)