### PR TITLE
Adds `include_expired_exceptions` to Export exception list API

### DIFF
--- a/docs/detections/api/exceptions/api-export-exception-list.asciidoc
+++ b/docs/detections/api/exceptions/api-export-exception-list.asciidoc
@@ -21,6 +21,7 @@ Exports an exception list and its associated items to an `.ndjson` file.
 * `agnostic`: Available in all {kib} spaces.
 
 |No, defaults to `single`.
+|`include_expired_exceptions` |Boolean |Determines whether to include expired exceptions in the exported list. |No, defaults to `true`.
 |==============================================
 
 ===== Example request


### PR DESCRIPTION
Resolves #3061 by adding the `include_expired_exceptions` to versions `8.7` and newer.

Preview: [Export exception list](https://security-docs_4360.docs-preview.app.elstc.co/guide/en/security/master/exceptions-api-export-exception-list.html)