### PR TITLE
Remove enableGroupedNav advanced setting

### DIFF
--- a/docs/getting-started/advanced-setting.asciidoc
+++ b/docs/getting-started/advanced-setting.asciidoc
@@ -101,13 +101,6 @@ determines the threshold above which anomaly scores appear in {elastic-sec}:
 * `securitySolution:defaultAnomalyScore`
 
 [discrete]
-== Enable grouped navigation
-
-The `securitySolution:enableGroupedNav` setting enables the grouped navigation menu for {elastic-sec}, which groups related pages and highlights commonly visited areas for a streamlined experience.
-
-By default, the {security-app} uses the legacy navigation menu; turn on `securitySolution:enableGroupedNav` to use the grouped navigation menu.
-
-[discrete]
 == Modify news feed settings
 
 You can change these settings, which affect the news feed displayed on the


### PR DESCRIPTION
Contributes to https://github.com/elastic/staging-serverless-security-docs/pull/213 by updating classic docs to remove the advanced setting `enableGroupedNav`. This setting was actually removed from the product in 8.9 and we never updated the docs, so we need to backport to that version.

Preview: [Advanced settings](https://security-docs_4362.docs-preview.app.elstc.co/guide/en/security/master/advanced-settings.html)

### Related serverless PR
* If you're reviewing this PR, you should probably also review https://github.com/elastic/staging-serverless-security-docs/pull/213 to see the serverless docs changes