### PR TITLE
Add Buildkite preview links to PRs

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -15,5 +15,5 @@
             with:
               github-token: ${{ secrets.GITHUB_TOKEN }}
               repo: ${{ github.event.repository.name }}
-              preview-path: 'guide/en/elasticsearch/client/python-api/index.html'
+              preview-path: 'guide/en/security/master/index.html'
               pr: ${{ github.event.pull_request.number }}

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,0 +1,19 @@
+    name: docs-preview
+    
+    on:
+      pull_request_target:
+        types: [opened]
+    
+    permissions:
+      pull-requests: write
+    
+    jobs:
+      doc-preview-pr:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: elastic/docs/.github/actions/docs-preview@master
+            with:
+              github-token: ${{ secrets.GITHUB_TOKEN }}
+              repo: ${{ github.event.repository.name }}
+              preview-path: 'guide/en/elasticsearch/client/python-api/index.html'
+              pr: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Contributes to https://github.com/elastic/security-docs/issues/4313 by adding a new GitHub action that provides links to both Buildkite and Jenkins build previews.