### PR TITLE
Fixes requirement statement on Behavioral detection use cases page

### DIFF
--- a/docs/advanced-entity-analytics/behavioral-detection-use-cases.asciidoc
+++ b/docs/advanced-entity-analytics/behavioral-detection-use-cases.asciidoc
@@ -14,7 +14,7 @@ Behavioral detection integrations provide a convenient way to enable behavioral 
 .Requirements
 [sidebar]
 --
-* Elastic integrations require a https://www.elastic.co/pricing[Platinum subscription] or higher.
+* Behavioral detection integrations require a https://www.elastic.co/pricing[Platinum subscription] or higher.
 * To learn more about the requirements for using {ml} jobs, refer to <<ml-requirements, Machine learning job and rule requirements>>.
 --
 


### PR DESCRIPTION
Fixes the requirement statement on the [Behavioral detection use cases](https://www.elastic.co/guide/en/security/8.11/behavioral-detection-use-cases.html) page, since not all Elastic integrations require a Platinum subscription.

Preview: [Behavioral detection use cases](https://security-docs_bk_4470.docs-preview.app.elstc.co/guide/en/security/master/behavioral-detection-use-cases.html)