### PR TITLE
Exclude cold and frozen tiers advanced setting

### DIFF
--- a/docs/detections/visual-event-analyzer.asciidoc
+++ b/docs/detections/visual-event-analyzer.asciidoc
@@ -4,6 +4,8 @@
 
 {elastic-sec} allows any event detected by {elastic-endpoint} to be analyzed using a process-based visual analyzer, which shows a graphical timeline of processes that led up to the alert and the events that occurred immediately after. Examining events in the visual event analyzer is useful to determine the origin of potentially malicious activity and other areas in your environment that may be compromised. It also enables security analysts to drill down into all related hosts, processes, and other events to aid in their investigations.
 
+TIP: If you're experiencing performance degradation, you can <<exclude-cold-frozen-tiers, exclude cold and frozen tier data>> from analyzer queries.
+
 [float]
 [[find-events-analyze]]
 === Find events to analyze

--- a/docs/getting-started/advanced-setting.asciidoc
+++ b/docs/getting-started/advanced-setting.asciidoc
@@ -115,7 +115,13 @@ retrieved.
 [[enable-expandable-flyout]]
 == Display the expandable flyout
 
-The `securitySolution:enableExpandableFlyout` setting enables the expandable alert details flyout on the Alerts page. This setting is turned on by default. Turn it off to apply the simplified alert details flyout design that was used in {elastic-sec} 8.9 and earlier. 
+The `securitySolution:enableExpandableFlyout` setting enables the expandable alert details flyout on the Alerts page. This setting is turned on by default. Turn it off to apply the simplified alert details flyout design that was used in {elastic-sec} 8.9 and earlier.
+
+[discrete]
+[[exclude-cold-frozen-tiers]]
+== Exclude cold and frozen tier data from analyzer queries
+
+Including data from cold and frozen {ref}/data-tiers.html[data tiers] in <<visual-event-analyzer, visual event analyzer>> queries may result in performance degradation. The `securitySolution:excludeColdAndFrozenTiersInAnalyzer` setting allows you to exclude this data from analyzer queries. This setting is turned off by default.
 
 [discrete]
 == Change the default search interval and data refresh time


### PR DESCRIPTION
Contributes to #4387.

Corresponding serverless PR: https://github.com/elastic/staging-serverless-security-docs/pull/250

Previews:
* [Exclude cold and frozen tier data from analyzer queries](https://security-docs_bk_4484.docs-preview.app.elstc.co/guide/en/security/master/advanced-settings.html#exclude-cold-frozen-tiers)
* [Visual event analyzer](https://security-docs_bk_4484.docs-preview.app.elstc.co/guide/en/security/master/visual-event-analyzer.html)
 