### PR TITLE
Update get-file-api.asciidoc to fix a typo

### DIFF
--- a/docs/management/api/get-file-api.asciidoc
+++ b/docs/management/api/get-file-api.asciidoc
@@ -7,7 +7,7 @@ You must have the `File Operations` {kib} privilege in the Security feature as p
 
 ==== Request URL
 
-`POST <kibana host>:<port>/api/endpoint/action/get-file`
+`POST <kibana host>:<port>/api/endpoint/action/get_file`
 
 ==== Request body
 
@@ -31,7 +31,7 @@ Retrieve a file `/usr/my-file.txt` on a host with an `endpoint_id` value of `ed5
 
 [source,sh]
 --------------------------------------------------
-POST /api/endpoint/action/get-file
+POST /api/endpoint/action/get_file
 {
   "endpoint_ids": ["ed518850-681a-4d60-bb98-e22640cae2a8"],
   "parameters": {


### PR DESCRIPTION
According to the code (https://github.com/elastic/kibana/blob/6bec71021ac92a84da05a3646fe0992579c52832/x-pack/plugins/security_solution/common/endpoint/constants.ts#L94), it appears that the API endpoint should be `get_file`, not `get-file`. This PR corrects the typo found in https://www.elastic.co/guide/en/security/8.11/get-file-api.html