### PR TITLE
Adds RAG for alerts info to the AI Assistant page

### DIFF
--- a/docs/assistant/security-assistant.asciidoc
+++ b/docs/assistant/security-assistant.asciidoc
@@ -166,6 +166,7 @@ When you include a particular event as context, you can use a similar interface 
 +
 The *Show anonymized* toggle controls whether you see the obfuscated or plaintext versions of the fields you sent to AI Assistant. It doesn't control what gets obfuscated — that's determined by the anonymization settings. It also doesn't affect how event fields appear _before_ being sent to AI Assistant. Instead, it controls how fields that were already sent and obfuscated appear to you.
 
+[[ai-assistant-knowledge-base]]
 * **Knowledge base:** Use retrieval-augmented generation to provide additional context to AI Assistant. 
 +
 beta::[]

--- a/docs/assistant/security-assistant.asciidoc
+++ b/docs/assistant/security-assistant.asciidoc
@@ -166,18 +166,27 @@ When you include a particular event as context, you can use a similar interface 
 +
 The *Show anonymized* toggle controls whether you see the obfuscated or plaintext versions of the fields you sent to AI Assistant. It doesn't control what gets obfuscated — that's determined by the anonymization settings. It also doesn't affect how event fields appear _before_ being sent to AI Assistant. Instead, it controls how fields that were already sent and obfuscated appear to you.
 
-* **Knowledge base:** Use retrieval-augmented generation to provide specialized knowledge of the Elastic Search Query Language ({esql}) to AI Assistant. For example, with the knowledge base active, you can ask AI Assistant to help you write an {esql} query for a particular use case, or ask it to answer general questions about {esql} syntax and usage. Without the knowledge base enabled, AI Assistant will not be able to answer questions about {esql}.
+* **Knowledge base:** Use retrieval-augmented generation to provide additional context to AI Assistant. 
 +
 beta::[]
 +
-To enable the knowledge base:
+**Enable AI Assistant to answer questions about the Elastic Search Query Language ({esql}):**
 +
 . Enable the Elastic Learned Sparse EncodeR (ELSER). This model provides additional context to the third-party LLM. To learn more, refer to {ml-docs}/ml-nlp-elser.html#download-deploy-elser[Configure ELSER].
 . Initialize the knowledge base by clicking *Initialize*.
 . Turn on the *Knowledge Base* option.
 . Click *Save*. The knowledge base is now active.
 +
-When the knowledge base is active, a quick prompt for {esql} queries becomes available. It provides a good starting point for your {esql} conversations and questions.
+When this setting is enabled, AI Assistant can answer questions about {esql}. For example, it can help you write an {esql} query for a particular use case, or answer general questions about {esql} syntax and usage. 
+A quick prompt for {esql} queries becomes available, which provides a good starting point for your {esql} conversations and questions. When this setting is disabled, AI Assistant can not answer questions about {esql}.
++
+**Enable AI Assistant to answer questions about alerts in your environment:**
++ 
+. Turn on the **Alerts** setting.
+. Use the slider to select how many alerts to send to AI Assistant. 
++ 
+When this setting is enabled, AI Assistant will receive multiple alerts as context for each of your prompts. It will receive alerts from the last 24 hours that have a status of `open` or `acknowledged`, ordered first by risk score, then by recency, and excluding building block alerts. 
+
 
 [discrete]
 [[ai-assistant-queries]]


### PR DESCRIPTION
Fixes #4456. Updates the AI Assistant page with information about the RAG for alerts feature that allows you to send multiple alerts as part of each prompt, so that AI Assistant can answer questions about recent alerts in your environment rather than just individual alerts.

Related updates to the "Triage alerts with AI Assistant" page can be previewed here: [#4359 ](https://github.com/elastic/security-docs/pull/4359)

Preview: AI Assistant