### PR TITLE
Fixes get file API typo

### DIFF
--- a/docs/management/api/get-file-api.asciidoc
+++ b/docs/management/api/get-file-api.asciidoc
@@ -7,7 +7,7 @@ You must have the `File Operations` {kib} privilege in the Security feature as p
 
 ==== Request URL
 
-`POST <kibana host>:<port>/api/endpoint/action/get-file`
+`POST <kibana host>:<port>/api/endpoint/action/get_file`
 
 ==== Request body
 
@@ -31,7 +31,7 @@ Retrieve a file `/usr/my-file.txt` on a host with an `endpoint_id` value of `ed5
 
 [source,sh]
 --------------------------------------------------
-POST /api/endpoint/action/get-file
+POST /api/endpoint/action/get_file
 {
   "endpoint_ids": ["ed518850-681a-4d60-bb98-e22640cae2a8"],
   "parameters": {


### PR DESCRIPTION
Per https://github.com/elastic/security-docs/pull/4500, fixes the 'Get a file from a host' endpoint to `get_file`.
 
Preview: [Get a file from a host](https://security-docs_bk_4526.docs-preview.app.elstc.co/guide/en/security/master/get-file-api.html)

cc @nathandh22 