### PR TITLE
[Request][REDO] Add warning against using ES|QL on production environmentsFirst draft

### DIFF
--- a/docs/assistant/security-assistant.asciidoc
+++ b/docs/assistant/security-assistant.asciidoc
@@ -178,7 +178,7 @@ The *Show anonymized* toggle controls whether you see the obfuscated or plaintex
 [discrete]
 [[ai-assistant-knowledge-base]]
 === Knowledge base
-beta::[]
+beta::["Do not use {esql} on production environments. This functionality is in beta and is subject to change. The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features."]
 
 The **Knowledge base** tab of the AI Assistant settings menu allows you to enable retrieval-augmented generation so that AI Assistant can answer questions about the Elastic Search Query Language ({esql}), or about alerts in your environment.
 

--- a/docs/detections/about-rules.asciidoc
+++ b/docs/detections/about-rules.asciidoc
@@ -44,7 +44,7 @@ TIP: You can also use value lists as the indicator match index. See <<indicator-
 
 * <<create-esql-rule, *ES|QL*>>: Searches the defined indices and creates an alert when results match an {ref}/esql.html[Elasticsearch Query Language (ES|QL)] query.
 +
-preview::[]
+preview::["Do not use {esql} on production environments. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features."]
 
 [role="screenshot"]
 image::images/all-rules.png[Shows the Rules page]

--- a/docs/detections/api/rules/rules-api-create.asciidoc
+++ b/docs/detections/api/rules/rules-api-create.asciidoc
@@ -39,7 +39,7 @@ mappings should be {ecs-ref}[ECS-compliant].
 * *New terms*: Generates an alert for each new term detected in source documents within a specified time range.
 * *{esql}*: Uses {ref}/esql.html[Elasticsearch Query Language ({esql})] to find events and aggregate search results.
 +
-preview::[]
+preview::["Do not use {esql} on production environments. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features."]
 * *{ml-cap} rules*: Creates an alert when a {ml} job discovers an anomaly above
 the defined threshold (see <<machine-learning>>).
 

--- a/docs/detections/rules-ui-create.asciidoc
+++ b/docs/detections/rules-ui-create.asciidoc
@@ -274,7 +274,7 @@ For example, if a rule has an interval of 5 minutes, no additional look-back tim
 [[create-esql-rule]]
 === Create an {esql} rule
 
-preview::[]
+preview::["Do not use {esql} on production environments. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features."]
 
 Use {ref}/esql.html[{esql}] to query your source events and aggregate event data. Query results are returned in a table with rows and columns. Each row becomes an alert.
 

--- a/docs/events/timeline-ui-overview.asciidoc
+++ b/docs/events/timeline-ui-overview.asciidoc
@@ -196,7 +196,7 @@ From the *Correlation* tab, you can also do the following:
 [[esql-in-timeline]]
 == Use {esql} to investigate events 
 
-preview::[]
+preview::["Do not use {esql} on production environments. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features."]
 
 The {ref}/esql.html[Elasticsearch Query Language ({esql})] provides a powerful way to filter, transform, and analyze event data stored in {es}. {esql} queries use "pipes" to manipulate and transform data in a step-by-step fashion. This approach allows you to compose a series of operations, where the output of one operation becomes the input for the next, enabling complex data transformations and analysis.
 


### PR DESCRIPTION
Fixes https://github.com/elastic/security-docs/issues/4538

Previews: Updates the tech preview note to match the wording used in https://github.com/elastic/elasticsearch/pull/103797

- [Use ES|QL to investigate events](https://security-docs_bk_4554.docs-preview.app.elstc.co/guide/en/security/master/timelines-ui.html#esql-in-timeline)
- [Configure AI Assistant | Knowledge base](https://security-docs_bk_4554.docs-preview.app.elstc.co/guide/en/security/master/security-assistant.html#ai-assistant-knowledge-base)
- [About detection rules](https://security-docs_bk_4554.docs-preview.app.elstc.co/guide/en/security/master/about-rules.html)
- [Create an ES|QL rule](https://security-docs_bk_4554.docs-preview.app.elstc.co/guide/en/security/master/rules-ui-create.html#create-esql-rule)
- [Create rule](https://security-docs_bk_4554.docs-preview.app.elstc.co/guide/en/security/master/rules-api-create.html)