### PR TITLE
Removes list of default index patterns

### DIFF
--- a/docs/getting-started/advanced-setting.asciidoc
+++ b/docs/getting-started/advanced-setting.asciidoc
@@ -42,16 +42,8 @@ image::images/solution-advanced-settings.png[]
 == Update default Elastic Security indices
 
 The `securitySolution:defaultIndex` field defines which {es} indices the
-{security-app} uses to collect data. By default, these index patterns are used to
-match {es} indices:
-
-* `apm-*-transaction*`
-* `auditbeat-*`
-* `endgame-*`
-* `filebeat-*`
-* `logs-*`
-* `packetbeat-*`
-* `winlogbeat-*`
+{security-app} uses to collect data. By default, index patterns are used to
+match sets of {es} indices.
 
 NOTE: Index patterns use wildcards to specify a set of indices. For example, the
 `filebeat-*` index pattern means all indices starting with `filebeat-` are
@@ -64,7 +56,7 @@ data shipped via {beats} and the {agent} is automatically added to the
 
 You can add or remove any indices and index patterns as required. For background information on {es} indices, refer to {ref}/documents-indices.html[Data in: documents and indices].
 
-NOTE: If you leave the `logs-*` index selected, by default, all Elastic cloud logs are excluded from all queries in the {security-app}. This is to avoid adding data from cloud monitoring to the app.
+NOTE: If you leave the `logs-*` index pattern selected, by default, all Elastic cloud logs are excluded from all queries in the {security-app}. This is to avoid adding data from cloud monitoring to the app.
 
 IMPORTANT: {elastic-sec} requires {ecs-ref}[ECS-compliant data]. If you use third-party data
 collectors to ship data to {es}, the data must be mapped to ECS.

--- a/docs/getting-started/advanced-setting.asciidoc
+++ b/docs/getting-started/advanced-setting.asciidoc
@@ -56,8 +56,6 @@ data shipped via {beats} and the {agent} is automatically added to the
 
 You can add or remove any indices and index patterns as required. For background information on {es} indices, refer to {ref}/documents-indices.html[Data in: documents and indices].
 
-NOTE: If you leave the `logs-*` index pattern selected, by default, all Elastic cloud logs are excluded from all queries in the {security-app}. This is to avoid adding data from cloud monitoring to the app.
-
 IMPORTANT: {elastic-sec} requires {ecs-ref}[ECS-compliant data]. If you use third-party data
 collectors to ship data to {es}, the data must be mapped to ECS.
 <<siem-field-reference>> lists ECS fields used in {elastic-sec}.

--- a/docs/getting-started/advanced-setting.asciidoc
+++ b/docs/getting-started/advanced-setting.asciidoc
@@ -56,7 +56,7 @@ data shipped via {beats} and the {agent} is automatically added to the
 
 You can add or remove any indices and index patterns as required. For background information on {es} indices, refer to {ref}/documents-indices.html[Data in: documents and indices].
 
-NOTE: If you leave the `-*elastic-cloud-logs-*` index pattern selected, by default, all Elastic cloud logs are excluded from all queries in the {security-app}. This is to avoid adding data from cloud monitoring to the app.
+NOTE: If you leave the `-*elastic-cloud-logs-*` index pattern selected, all Elastic cloud logs are excluded from all queries in the {security-app} by default. This is to avoid adding data from cloud monitoring to the app.
 
 IMPORTANT: {elastic-sec} requires {ecs-ref}[ECS-compliant data]. If you use third-party data
 collectors to ship data to {es}, the data must be mapped to ECS.

--- a/docs/getting-started/advanced-setting.asciidoc
+++ b/docs/getting-started/advanced-setting.asciidoc
@@ -56,6 +56,8 @@ data shipped via {beats} and the {agent} is automatically added to the
 
 You can add or remove any indices and index patterns as required. For background information on {es} indices, refer to {ref}/documents-indices.html[Data in: documents and indices].
 
+NOTE: If you leave the `-*elastic-cloud-logs-*` index pattern selected, by default, all Elastic cloud logs are excluded from all queries in the {security-app}. This is to avoid adding data from cloud monitoring to the app.
+
 IMPORTANT: {elastic-sec} requires {ecs-ref}[ECS-compliant data]. If you use third-party data
 collectors to ship data to {es}, the data must be mapped to ECS.
 <<siem-field-reference>> lists ECS fields used in {elastic-sec}.


### PR DESCRIPTION
Contributes to #4541 by removing the list of default Elastic Security index patterns.

Preview: [Update default Elastic Security indices](https://security-docs_bk_4558.docs-preview.app.elstc.co/guide/en/security/master/advanced-settings.html#update-sec-indices)

Serverless PR: https://github.com/elastic/staging-serverless-security-docs/pull/257
