### PR TITLE
[8.8] Backport query rule alert suppression to API docs (#4496)

### DIFF
--- a/docs/detections/api/rules/rules-api-create.asciidoc
+++ b/docs/detections/api/rules/rules-api-create.asciidoc
@@ -465,6 +465,29 @@ must be an {es} date data type.
 
 |==============================================
 
+[[opt-fields-alert-suppression-create]]
+===== Optional alert suppression fields for query rules
+
+preview::[]
+
+[width="100%",options="header"]
+|==============================================
+|Name |Type |Description
+
+|alert_suppression |Object a|Defines alert suppression configuration. Available fields:
+
+* `group_by` (string[], required): An array of 1-3 field names to use for suppressing alerts.
+
+* `duration` (<<alert-suppression-duration-schema, duration object>>, optional): The time period in which alerts will be suppressed, beginning when the rule first meets its criteria and creates the alert. If not specified, alerts will be suppressed on rule execution only.
+
+* `missing_fields_strategy` (string, optional): Defines how to handle events with missing suppression fields. Possible values:
+
+    - `doNotSuppress`: Create a separate alert for each matching event.
+
+    - `suppress`: Create one alert for each group of events with missing fields.
+
+|==============================================
+
 [[actions-object-schema]]
 ===== `actions` schema
 
@@ -646,6 +669,20 @@ All fields are required:
 
 NOTE: Only threats described using the MITRE ATT&CK^TM^ framework are displayed
 in the UI (*Manage* -> *Rules* -> *_Rule name_*).
+
+[[alert-suppression-duration-schema]]
+===== `alert_suppression.duration` schema
+
+All fields are required:
+
+[width="100%",options="header"]
+|==============================================
+|Name |Type |Description
+
+|unit |string | Time unit. Possible values are: `s`(seconds), `m`(minutes), or `h`(hours).
+|value |number | Positive number.
+
+|==============================================
 
 ===== Example requests
 
@@ -920,6 +957,51 @@ POST api/detection_engine/rules
 }
 --------------------------------------------------
 // KIBANA
+
+*Example 7*
+
+Query rule that searches for processes started by MS Office and suppresses alerts by the `process.parent.name` field within a 5-hour time period:
+
+[source,console]
+--------------------------------------------------
+POST api/detection_engine/rules
+{
+  "rule_id": "process_started_by_ms_office_program",
+  "risk_score": 50,
+  "description": "Process started by MS Office program - possible payload",
+  "interval": "1h",
+  "name": "MS Office child process",
+  "severity": "low",
+  "tags": [
+   "child process",
+   "ms office"
+   ],
+  "type": "query",
+  "from": "now-70m",
+  "query": "process.parent.name:EXCEL.EXE or process.parent.name:MSPUB.EXE or process.parent.name:OUTLOOK.EXE or process.parent.name:POWERPNT.EXE or process.parent.name:VISIO.EXE or process.parent.name:WINWORD.EXE",
+  "language": "kuery",
+  "filters": [
+     {
+      "query": {
+         "match": {
+            "event.action": {
+               "query": "Process Create (rule: ProcessCreate)",
+               "type": "phrase"
+            }
+         }
+      }
+     }
+  ],
+  "enabled": false,
+  "alert_suppression": {
+    "duration": { "unit": "h", "value": 5 },
+    "group_by": [
+        "process.parent.name"
+    ],
+    "missing_fields_strategy": "suppress"
+  }
+}
+--------------------------------------------------
 
 ==== Response code
 

--- a/docs/detections/api/rules/rules-api-update.asciidoc
+++ b/docs/detections/api/rules/rules-api-update.asciidoc
@@ -489,6 +489,31 @@ technique:
 NOTE: Only threats described using the MITRE ATT&CK^TM^ framework are displayed
 in the UI (*Manage* -> *Rules* -> *_Rule name_*).
 
+
+[[opt-fields-alert-suppression-update]]
+===== Optional alert suppression fields for query rules
+
+preview::[]
+
+[width="100%",options="header"]
+|==============================================
+|Name |Type |Description
+
+|alert_suppression |Object a|Defines alert suppression configuration. Available fields:
+
+* `group_by` (string[], required): An array of 1-3 field names to use for suppressing alerts.
+
+* `duration` (<<alert-suppression-duration-schema, duration object>>, optional): The time period in which alerts will be suppressed, beginning when the rule first meets its criteria and creates the alert. If not specified, alerts will be suppressed on rule execution only.
+
+* `missing_fields_strategy` (string, optional): Defines how to handle events with missing suppression fields. Possible values:
+
+    - `doNotSuppress`: Create a separate alert for each matching event.
+
+    - `suppress`: Create one alert for each group of events with missing fields.
+
+|==============================================
+
+
 ===== Example request
 
 Updates the `threat` object:


### PR DESCRIPTION
Backports the following commits to 8.8:
 - Backport query rule alert suppression to API docs (#4496)