### PR TITLE
Fixes data type inconsitency in Apply alert tags API

### DIFF
--- a/docs/detections/api/rules/signals-api-overview.asciidoc
+++ b/docs/detections/api/rules/signals-api-overview.asciidoc
@@ -268,7 +268,7 @@ A JSON object with the `tags` and `ids` fields:
 |==============================================
 |Name |Type |Description |Required
 
-|`tags` |String[] a|Array of alert tags. Alert tags are the words and phrases that help categorize alerts. 
+|`tags` |Object a|Object containing alert tags. Alert tags are the words and phrases that help categorize alerts. 
 
 Properties of the `tags` object:
 


### PR DESCRIPTION
Fixes #4567 by updating the `tags` parameter's data type in the description to object.

Preview: [Signals endpoint](https://security-docs_bk_4581.docs-preview.app.elstc.co/guide/en/security/master/signals-api-overview.html#_apply_alert_tags)