### PR TITLE
[ESS][BUG][8.14.11]Fixes minor typos in the 8.11.4 release notes

### DIFF
--- a/docs/release-notes/8.11.asciidoc
+++ b/docs/release-notes/8.11.asciidoc
@@ -8,7 +8,7 @@
 [discrete]
 [[bug-fixes-8.11.4]]
 ==== Bug fixes
-* Stops the {esql} tab from rendering until you click on it in Timeline({pull}173484[#173484]).
+* Stops the **{esql}** tab from rendering until you click on it in Timeline({pull}173484[#173484]).
 * Adds a feature flag (`timelineEsqlTabDisabled`) to hide the **{esql}** tab in Timeline ({pull}174029[#174029]).
 * Removes the default query from the **{esql}** tab in Timeline ({pull}174393[#174393]).
 * Fixes a bug that caused the **Add to Case** action to fail if you didn't add a comment before isolating and releasing a host ({pull}172912[#172912]).

--- a/docs/release-notes/8.11.asciidoc
+++ b/docs/release-notes/8.11.asciidoc
@@ -8,7 +8,7 @@
 [discrete]
 [[bug-fixes-8.11.4]]
 ==== Bug fixes
-* Stops the **{esql}** tab from rendering until you click on it in Timeline({pull}173484[#173484]).
+* Stops the **{esql}** tab from rendering until you click on it in Timeline ({pull}173484[#173484]).
 * Adds a feature flag (`timelineEsqlTabDisabled`) to hide the **{esql}** tab in Timeline ({pull}174029[#174029]).
 * Removes the default query from the **{esql}** tab in Timeline ({pull}174393[#174393]).
 * Fixes a bug that caused the **Add to Case** action to fail if you didn't add a comment before isolating and releasing a host ({pull}172912[#172912]).


### PR DESCRIPTION
[Preview](https://security-docs_bk_4597.docs-preview.app.elstc.co/guide/en/security/master/release-notes-header-8.11.0.html#release-notes-8.11.4) - Fixes minor typos in the first bullet 