### PR TITLE
[BUG] Remove outdated note in ML docs

### DIFF
--- a/docs/advanced-entity-analytics/machine-learning.asciidoc
+++ b/docs/advanced-entity-analytics/machine-learning.asciidoc
@@ -22,10 +22,6 @@ If you have the `machine_learning_admin` role, you can use the *ML job settings*
 [role="screenshot"]
 image::images/ml-ui.png[ML job settings UI on the Alerts page]
 
-TIP: To add a custom job to the *ML job settings* interface, add `Security` to
-the job's `Groups` field (*{kib}* -> *{ml-cap}* -> *Create/Edit job* -> *Job
-details*).
-
 [float]
 [[manage-ml-rules]]
 === Manage {ml} detection rules


### PR DESCRIPTION
Resolves https://github.com/elastic/security-docs/issues/3997 by removing the outdated tip about custom ML jobs, in classic docs. No twin PR needed; serverless docs have already been updated.

Backport to 8.10.