### PR TITLE
[BUG] Endpoint Trusted Applications docs need to mention that process events will always be generated (Classic docs)

### DIFF
--- a/docs/management/admin/endpoint-artifacts.asciidoc
+++ b/docs/management/admin/endpoint-artifacts.asciidoc
@@ -16,7 +16,7 @@ a| *_Prevents {elastic-endpoint} from monitoring a process._* Use to avoid confl
 
 * Creates intentional blind spots in your security environment — use sparingly!
 * Doesn't monitor the application for threats, nor does it generate alerts, even if it behaves like malware, ransomware, etc.
-* Doesn't generate events for the application except process events for visualizations.
+* Doesn't generate events for the application except process events for visualizations and other internal use by the {stack}.
 * Might improve performance, since {elastic-endpoint} monitors fewer processes.
 * Might still generate malicious behavior alerts, if the application's process events indicate malicious behavior. To suppress alerts, create <<endpoint-rule-exceptions,Endpoint alert exceptions>>.
 

--- a/docs/management/admin/trusted-apps.asciidoc
+++ b/docs/management/admin/trusted-apps.asciidoc
@@ -14,6 +14,8 @@ Trusted applications create blindspots for {elastic-defend}, because the applica
 
 Trusted applications might still generate alerts in some cases, such as if the application's process events indicate malicious behavior. To reduce false positive alerts, add an <<endpoint-rule-exceptions,Endpoint alert exception>>, which prevents {elastic-defend} from generating alerts. To compare trusted applications with other endpoint artifacts, refer to <<endpoint-artifacts>>.
 
+Additionally, trusted applications still generate some `create` and `terminate` process events for visualizations and other internal use by the {stack}. To prevent process events from being written to {es}, use an <<event-filters,event filter>> to filter out the specific events that you don't want stored in {es}.
+
 By default, a trusted application is recognized globally across all hosts running {elastic-defend}. If you have a https://www.elastic.co/pricing[Platinum or Enterprise subscription], you can also assign a trusted application to a specific {elastic-defend} integration policy, enabling the application to be trusted by only the hosts assigned to that policy.
 
 To add a trusted application:

--- a/docs/management/admin/trusted-apps.asciidoc
+++ b/docs/management/admin/trusted-apps.asciidoc
@@ -14,7 +14,7 @@ Trusted applications create blindspots for {elastic-defend}, because the applica
 
 Trusted applications might still generate alerts in some cases, such as if the application's process events indicate malicious behavior. To reduce false positive alerts, add an <<endpoint-rule-exceptions,Endpoint alert exception>>, which prevents {elastic-defend} from generating alerts. To compare trusted applications with other endpoint artifacts, refer to <<endpoint-artifacts>>.
 
-Additionally, trusted applications still generate some `create` and `terminate` process events for visualizations and other internal use by the {stack}. To prevent process events from being written to {es}, use an <<event-filters,event filter>> to filter out the specific events that you don't want stored in {es}.
+Additionally, trusted applications still generate some process events for visualizations and other internal use by the {stack}. To prevent process events from being written to {es}, use an <<event-filters,event filter>> to filter out the specific events that you don't want stored in {es}.
 
 By default, a trusted application is recognized globally across all hosts running {elastic-defend}. If you have a https://www.elastic.co/pricing[Platinum or Enterprise subscription], you can also assign a trusted application to a specific {elastic-defend} integration policy, enabling the application to be trusted by only the hosts assigned to that policy.
 

--- a/docs/management/admin/trusted-apps.asciidoc
+++ b/docs/management/admin/trusted-apps.asciidoc
@@ -14,7 +14,7 @@ Trusted applications create blindspots for {elastic-defend}, because the applica
 
 Trusted applications might still generate alerts in some cases, such as if the application's process events indicate malicious behavior. To reduce false positive alerts, add an <<endpoint-rule-exceptions,Endpoint alert exception>>, which prevents {elastic-defend} from generating alerts. To compare trusted applications with other endpoint artifacts, refer to <<endpoint-artifacts>>.
 
-Additionally, trusted applications still generate some process events for visualizations and other internal use by the {stack}. To prevent process events from being written to {es}, use an <<event-filters,event filter>> to filter out the specific events that you don't want stored in {es}.
+Additionally, trusted applications still generate process events for visualizations and other internal use by the {stack}. To prevent process events from being written to {es}, use an <<event-filters,event filter>> to filter out the specific events that you don't want stored in {es}, but be aware that features that depend on these process events may not function correctly.
 
 By default, a trusted application is recognized globally across all hosts running {elastic-defend}. If you have a https://www.elastic.co/pricing[Platinum or Enterprise subscription], you can also assign a trusted application to a specific {elastic-defend} integration policy, enabling the application to be trusted by only the hosts assigned to that policy.
 


### PR DESCRIPTION
Contributes to https://github.com/elastic/security-docs/issues/3489 by updating the classic docs with additional explanation of how process events are still created for trusted applications.

Previews:
- [Trusted applications](https://security-docs_bk_4640.docs-preview.app.elstc.co/guide/en/security/master/trusted-apps-ov.html) — New paragraph explains process events.
- [Optimize Elastic Defend](https://security-docs_bk_4640.docs-preview.app.elstc.co/guide/en/security/master/endpoint-artifacts.html) — Expands trusted apps bullet for additional context.

### Twin PR for serverless docs
- https://github.com/elastic/staging-serverless-security-docs/pull/272