### PR TITLE
[BUG][ESS] Outdated information mentioned in the step 5 for Osquery

### DIFF
--- a/docs/osquery/alerts-run-osquery.asciidoc
+++ b/docs/osquery/alerts-run-osquery.asciidoc
@@ -35,7 +35,7 @@ TIP: Refer to {kibana-ref}/osquery.html#osquery-prebuilt-packs-queries[prebuilt 
 [role="screenshot"]
 image::images/setup-query.png[width=80%][height=80%][Shows how to set up a single query]
 
-. Click **Submit**. Query results display within the flyout.
+. Click **Submit**. Query results will display within the flyout.
 +
 NOTE: Refer to <<view-osquery-results>> for more information about query results.
 . Click *Save for later* to save the query for future use (optional).

--- a/docs/osquery/alerts-run-osquery.asciidoc
+++ b/docs/osquery/alerts-run-osquery.asciidoc
@@ -35,7 +35,7 @@ TIP: Refer to {kibana-ref}/osquery.html#osquery-prebuilt-packs-queries[prebuilt 
 [role="screenshot"]
 image::images/setup-query.png[width=80%][height=80%][Shows how to set up a single query]
 
-. Click **Submit**. Queries will time out after 5 minutes if there are no responses. Otherwise, query results display within the flyout.
+. Click **Submit**. Query results display within the flyout.
 +
 NOTE: Refer to <<view-osquery-results>> for more information about query results.
 . Click *Save for later* to save the query for future use (optional).


### PR DESCRIPTION
Contributes to https://github.com/elastic/security-docs/issues/4626

[Preview](https://security-docs_bk_4658.docs-preview.app.elstc.co/guide/en/security/master/alerts-run-osquery.html) - Updated step 5

Twin Serverless PR: https://github.com/elastic/staging-serverless-security-docs/pull/274