### PR TITLE
Documents that nested fields aren't supported for Theshold rules "Group by" operations

### DIFF
--- a/docs/detections/rules-ui-create.asciidoc
+++ b/docs/detections/rules-ui-create.asciidoc
@@ -108,6 +108,9 @@ alerts.
 NOTE: You can use {kib} saved queries (image:images/saved-query-menu.png[Saved query menu,18,18]) and queries from saved Timelines (*Import query from saved Timeline*) as rule conditions.
 
 .. Use the *Group by* and *Threshold* fields to determine which source event field is used as a threshold and the threshold's value.
++
+NOTE: Nested fields are not supported for use with *Group by*.
++
 .. Use the *Count* field to limit alerts by cardinality of a certain field.
 +
 For example, if *Group by* is `source.ip, destination.ip` and its *Threshold* is `10`, an alert is generated for every pair of source and destination IP addresses that appear in at least 10 of the rule's search results.


### PR DESCRIPTION
Resolves #4119 by adding a note that says you can't use nested fields for "group by" to the doc about how to make a threshold rule.

Please let me know if you think we should add any other details. One thing we could consider adding a link to this page: https://www.elastic.co/guide/en/elasticsearch/reference/8.12/nested.html

Preview: Create a threshold rule