### PR TITLE
Removes references to RAG from AI Assistant docs

### DIFF
--- a/docs/assistant/security-assistant.asciidoc
+++ b/docs/assistant/security-assistant.asciidoc
@@ -153,7 +153,7 @@ NOTE: To delete a custom prompt, open the *Name* drop-down menu, hover over the 
 
 * **Anonymization:** Select fields to include as plaintext, to obfuscate, and to not send when you provide events to AI Assistant as context. <<ai-assistant-anonymization, Learn more>>.
 
-* **Knowledge base:** Use retrieval-augmented generation (RAG) to provide additional context to AI Assistant so it can answer questions about {esql} and alerts in your environment. <<ai-assistant-knowledge-base, Learn more>>.
+* **Knowledge base:** Provide additional context to AI Assistant so it can answer questions about {esql} and alerts in your environment. <<ai-assistant-knowledge-base, Learn more>>.
 
 [discrete]
 [[ai-assistant-anonymization]]
@@ -179,7 +179,7 @@ The *Show anonymized* toggle controls whether you see the obfuscated or plaintex
 === Knowledge base
 beta::["Do not use {esql} on production environments. This functionality is in beta and is subject to change. The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features."]
 
-The **Knowledge base** tab of the AI Assistant settings menu allows you to enable retrieval-augmented generation so that AI Assistant can answer questions about the Elastic Search Query Language ({esql}), or about alerts in your environment.
+The **Knowledge base** tab of the AI Assistant settings menu allows you to enable AI Assistant to answer questions about the Elastic Search Query Language ({esql}), and about alerts in your environment.
 
 [discrete]
 [[rag-for-esql]]


### PR DESCRIPTION
Fixes #4735 
Minor change to remove references to an implementation detail that users don't need to know about

Preview: [AI Assistant](https://security-docs_bk_4736.docs-preview.app.elstc.co/guide/en/security/master/security-assistant.html)