### PR TITLE
Update link to SentinelOne connector docs in classic

### DIFF
--- a/docs/management/admin/response-actions-config.asciidoc
+++ b/docs/management/admin/response-actions-config.asciidoc
@@ -58,8 +58,7 @@ Refer to the {integrations-docs}/sentinel_one[SentinelOne integration docs] or S
 .. Select *Add {agent} to your hosts* and continue with the <<enroll-agent,{agent} installation steps>> to install {agent} on a resource in your network (such as a server or VM). {agent} will act as a bridge collecting data from SentinelOne and sending it to {elastic-sec}.
 ====
 
-. **Create a SentinelOne connector.** Elastic's {kibana-ref}/action-types.html[SentinelOne connector] enables {elastic-sec} to perform actions on SentinelOne-protected hosts.
-// TODO: Update link above to sentinelone-action-type.html once that page is published.
+. **Create a SentinelOne connector.** Elastic's {kibana-ref}/sentinelone-action-type.html[SentinelOne connector] enables {elastic-sec} to perform actions on SentinelOne-protected hosts.
 +
 .Expand for details
 [%collapsible]


### PR DESCRIPTION
Contributes to https://github.com/elastic/security-docs/issues/4312 by updating the link in classic docs to the SentinelOne connector docs.