### PR TITLE
[BUG] Add supported operating system to the tamper protection page [classic]

### DIFF
--- a/docs/getting-started/agent-tamper-protection.asciidoc
+++ b/docs/getting-started/agent-tamper-protection.asciidoc
@@ -13,6 +13,8 @@ When enabled, {agent} and {elastic-endpoint} can only be uninstalled on the host
 * Hosts must be enrolled in the {elastic-defend} integration.
 
 * {agent}s must be version 8.11.0 or later.
+
+* This feature is supported for all operating systems.
 --
 
 [role="screenshot"]


### PR DESCRIPTION
Contributes to https://github.com/elastic/security-docs/issues/4741 by adding an OS support statement to the classic docs.

Preview:
- [Prevent Agent uninstallation](https://security-docs_bk_4751.docs-preview.app.elstc.co/guide/en/security/master/agent-tamper-protection.html)

Twin PR for serverless docs:
- https://github.com/elastic/staging-serverless-security-docs/pull/286