### PR TITLE
[BUG][8.6-8.12]Fix note that describes how exceptions work with EQL rules 

### DIFF
--- a/docs/detections/add-exceptions.asciidoc
+++ b/docs/detections/add-exceptions.asciidoc
@@ -12,7 +12,7 @@ You can add exceptions to a rule from the rule details page, the Alerts table, t
 ==============
 * To ensure an exception is successfully applied, ensure that the fields you've defined for its query are correctly and consistently mapped in their respective indices. Refer to {ecs-ref}[ECS] to learn more about supported mappings.
 
-* Be careful when adding exceptions to <<create-eql-rule,event correlation>> rules. Exceptions are evaluated against every event in the sequence, and when the exception matches _all_ event(s) in the sequence, alerts _are not_ generated. If the exception only matches _some_ of the events in the sequence, alerts _are_ generated.
+* Be careful when adding exceptions to <<create-eql-rule,event correlation>> rules. Exceptions are evaluated against every event in the sequence, and if an exception matches any events that are necessary to complete the sequence, alerts are not created.
 +
 To exclude values from a
 specific event in the sequence, update the rule's EQL statement. For example:


### PR DESCRIPTION
Contributes to https://github.com/elastic/security-docs/issues/4757

[Preview](https://security-docs_bk_4758.docs-preview.app.elstc.co/guide/en/security/master/add-exceptions.html): Updated note at the top of the page

Serverless twin PR: https://github.com/elastic/staging-serverless-security-docs/pull/288