### PR TITLE
Update docs-preview link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,5 @@ When you open a pull request, preview links are automatically added as a comment
 You also might want to add targeted links to help reviewers find specific pages related to your PR. Preview URLs include the following pattern (replace `<YOUR_PR_NUMBER_HERE>` with the PR number):
 
 ```
-https://security-docs_<YOUR_PR_NUMBER_HERE>.docs-preview.app.elstc.co/guide/en/security/master/
+https://security-docs_bk_<YOUR_PR_NUMBER_HERE>.docs-preview.app.elstc.co/guide/en/security/master/
 ```


### PR DESCRIPTION
Following the migration from Jenkins to Buildkite, docs previews are now available at <repo>_bk_<PR>.

More context in https://github.com/elastic/docs/pull/2898