### PR TITLE
Adds demo video to the AI Assistant docs

### DIFF
--- a/docs/assistant/ai-alert-triage.asciidoc
+++ b/docs/assistant/ai-alert-triage.asciidoc
@@ -6,7 +6,14 @@ When you view an alert in {elastic-sec}, details such as related documents, host
 
 To enable AI Assistant to answer questions about alerts, you need to provide alert data as context for your prompts. You can either provide multiple alerts using the <<ai-assistant-knowledge-base, knowledge base>> feature, or provide individual alerts directly.
 
-For a demo of AI Assistant's alert triage capabilities, refer to the follow video.
+[[ai-assistant-triage-alerts-knowledge-base]]
+[discrete]
+== Use AI Assistant to triage multiple alerts
+Enable the <<configure-ai-assistant, knowledge base>> **Alerts** setting to send AI Assistant data for up to 100 alerts as context for each of your prompts. With this setting enabled, you can ask AI Assistant questions such as "How many alerts are present in my environment?", "What are my most urgent alerts?", "Which alerts should I triage first?", "Do any of the alerts in my environment indicate data exfiltration from a Windows machine?", and more. 
+
+For more information, refer to <<ai-assistant-knowledge-base, knowledge base>>.
+
+For a demo of AI Assistant's alert triage capabilities, refer to the following video.
 =======
 ++++
 <script type="text/javascript" async src="https://play.vidyard.com/embed/v4.js"></script>
@@ -21,13 +28,6 @@ For a demo of AI Assistant's alert triage capabilities, refer to the follow vide
 </br>
 ++++
 =======
-
-[[ai-assistant-triage-alerts-knowledge-base]]
-[discrete]
-== Use AI Assistant to triage multiple alerts
-Enable the <<configure-ai-assistant, knowledge base>> **Alerts** setting to send AI Assistant data for up to 100 alerts as context for each of your prompts. With this setting enabled, you can ask AI Assistant questions such as "How many alerts are present in my environment?", "What are my most urgent alerts?", "Which alerts should I triage first?", "Do any of the alerts in my environment indicate data exfiltration from a Windows machine?", and more. 
-
-For more information, refer to <<ai-assistant-knowledge-base, knowledge base>>.
 
 [[ai-assistant-triage-alerts-instructions]]
 [discrete]

--- a/docs/assistant/ai-alert-triage.asciidoc
+++ b/docs/assistant/ai-alert-triage.asciidoc
@@ -6,6 +6,8 @@ When you view an alert in {elastic-sec}, details such as related documents, host
 
 To enable AI Assistant to answer questions about alerts, you need to provide alert data as context for your prompts. You can either provide multiple alerts using the <<ai-assistant-knowledge-base, knowledge base>> feature, or provide individual alerts directly.
 
+TIP: This https://www.elastic.co/blog/whats-new-elastic-security-8-12-0#get-intuitive,-real-time-alert-insights-with-natural-language-interactions-from-the-elastic-ai-assistant-for-security[demo video] shows how AI Assistant can help with various parts of the alert triage process.
+
 [[ai-assistant-triage-alerts-knowledge-base]]
 [discrete]
 == Use AI Assistant to triage multiple alerts

--- a/docs/assistant/ai-alert-triage.asciidoc
+++ b/docs/assistant/ai-alert-triage.asciidoc
@@ -6,7 +6,21 @@ When you view an alert in {elastic-sec}, details such as related documents, host
 
 To enable AI Assistant to answer questions about alerts, you need to provide alert data as context for your prompts. You can either provide multiple alerts using the <<ai-assistant-knowledge-base, knowledge base>> feature, or provide individual alerts directly.
 
-TIP: This https://www.elastic.co/blog/whats-new-elastic-security-8-12-0#get-intuitive,-real-time-alert-insights-with-natural-language-interactions-from-the-elastic-ai-assistant-for-security[demo video] shows how AI Assistant can help with various parts of the alert triage process.
+For a demo of AI Assistant's alert triage capabilities, refer to the follow video.
+=======
+++++
+<script type="text/javascript" async src="https://play.vidyard.com/embed/v4.js"></script>
+<img
+  style="width: 100%; margin: auto; display: block;"
+  class="vidyard-player-embed"
+  src="https://play.vidyard.com/v2dQtzmm6SoTFYc7dJzq7m.jpg"
+  data-uuid="v2dQtzmm6SoTFYc7dJzq7m"
+  data-v="4"
+  data-type="inline"
+/>
+</br>
+++++
+=======
 
 [[ai-assistant-triage-alerts-knowledge-base]]
 [discrete]

--- a/docs/assistant/security-assistant.asciidoc
+++ b/docs/assistant/security-assistant.asciidoc
@@ -135,8 +135,6 @@ Quick prompt availability varies based on context — for example, the **Alert s
 TIP: Be sure to specify which language you'd like AI Assistant to use when writing a query. For example: "Can you generate an Event Query Language query to find four failed logins followed by a successful login?"
 ** *Clear chat* (image:images/icon-clear-red.png[Red X icon,16,16]): Delete the conversation history and start a new chat.
 
-TIP: This https://www.elastic.co/blog/whats-new-elastic-security-8-12-0#get-intuitive,-real-time-alert-insights-with-natural-language-interactions-from-the-elastic-ai-assistant-for-security[demo video] shows how AI Assistant can help with various parts of the alert triage process.
-
 [discrete]
 [[configure-ai-assistant]]
 == Configure AI Assistant

--- a/docs/assistant/security-assistant.asciidoc
+++ b/docs/assistant/security-assistant.asciidoc
@@ -135,6 +135,8 @@ Quick prompt availability varies based on context — for example, the **Alert s
 TIP: Be sure to specify which language you'd like AI Assistant to use when writing a query. For example: "Can you generate an Event Query Language query to find four failed logins followed by a successful login?"
 ** *Clear chat* (image:images/icon-clear-red.png[Red X icon,16,16]): Delete the conversation history and start a new chat.
 
+TIP: This https://www.elastic.co/blog/whats-new-elastic-security-8-12-0#get-intuitive,-real-time-alert-insights-with-natural-language-interactions-from-the-elastic-ai-assistant-for-security[demo video] shows how AI Assistant can help with various parts of the alert triage process.
+
 [discrete]
 [[configure-ai-assistant]]
 == Configure AI Assistant


### PR DESCRIPTION
Fixes #4791. Adds a link to James Spiteri's demo video that shows several uses of AI Assistant.

Preview:[ Triage Alerts with AI Assistant](https://security-docs_bk_4792.docs-preview.app.elstc.co/guide/en/security/master/assistant-triage.html)