### PR TITLE
Removes model-specific (OpenAI) language from AI Assistant intro

### DIFF
--- a/docs/assistant/security-assistant.asciidoc
+++ b/docs/assistant/security-assistant.asciidoc
@@ -40,7 +40,7 @@ For example, refer to OpenAI's documentation on https://platform.openai.com/docs
 [[data-information]]
 == Your data and AI Assistant
 
-Elastic does not store or examine prompts or results used by AI Assistant, or use this data for model training. This includes anything you send the model, such as alert or event data, detection rule configurations, queries, and prompts. However, any data you provide to AI Assistant will be processed by the third-party provider you chose when setting up the OpenAI connector as part of the assistant setup.
+Elastic does not store or examine prompts or results used by AI Assistant, or use this data for model training. This includes anything you send the model, such as alert or event data, detection rule configurations, queries, and prompts. However, any data you provide to AI Assistant will be processed by the third-party large language model (LLM) provider you connected to as part of AI Assistant setup.
 
 Elastic does not control third-party tools, and assumes no responsibility or liability for their content, operation, or use, nor for any loss or damage that may arise from your using such tools. Please exercise caution when using AI tools with personal, sensitive, or confidential information. Any data you submit may be used by the provider for AI training or other purposes. There is no guarantee that the provider will keep any information you provide secure or confidential. You should familiarize yourself with the privacy practices and terms of use of any generative AI tools prior to use.
 


### PR DESCRIPTION
Fixes #4799 

Minor language update to refer to LLMs instead of just OpenAI in one place.

Preview: [AI Assistant](https://security-docs_bk_4800.docs-preview.app.elstc.co/guide/en/security/master/security-assistant.html)
