### PR TITLE
[Redo][7.17-8.5] Highlight that rule exceptions are case-sensitive

### DIFF
--- a/docs/detections/detections-ui-exceptions.asciidoc
+++ b/docs/detections/detections-ui-exceptions.asciidoc
@@ -121,6 +121,8 @@ The *Add Rule Exception* flyout opens (the example below was opened from the Ale
 image::images/add-exception-ui.png[]
 . Use the following settings to add conditions that define when the exception prevents alerts. In the example above, the exception prevents the rule from generating alerts when the
 `svchost.exe` process runs on agent hostname `siem-kibana`.
++
+IMPORTANT: Rule exceptions are case-sensitive, which means that any character that's entered as an uppercase or lowercase letter will be treated as such. In the event you _don't_ want a field evaluated as case-sensitive, some ECS fields have a `.caseless` version that you can use.
 
   .. *Field*: Select a field to identify the event being filtered.
 
@@ -203,6 +205,8 @@ The *Add Endpoint Exception* flyout opens, from either the rule details page or 
 [role="screenshot"]
 image::images/endpoint-add-exp.png[]
 . If required, modify the conditions.
++
+IMPORTANT: Rule exceptions are case-sensitive, which means that any character that's entered as an uppercase or lowercase letter will be treated as such. In the event you _don't_ want a field evaluated as case-sensitive, some ECS fields have a `.caseless` version that you can use.
 +
 NOTE: Refer to <<ex-nested-conditions>> for more information on when nested conditions are required.
 


### PR DESCRIPTION
Applies changes from https://github.com/elastic/security-docs/pull/3860 to the 7.17-8.5 docs.

Previews:

- [Add exceptions to a rule](https://security-docs_bk_4806.docs-preview.app.elstc.co/guide/en/security/8.5/detections-ui-exceptions.html#detection-rule-exceptions)
- [Add Elastic endpoint exceptions](https://security-docs_bk_4806.docs-preview.app.elstc.co/guide/en/security/8.5/detections-ui-exceptions.html#endpoint-rule-exceptions)