### PR TITLE
Clarify GovCloud/commercial cloud support for CSPM 

### DIFF
--- a/docs/cloud-native-security/cspm-get-started-aws.asciidoc
+++ b/docs/cloud-native-security/cspm-get-started-aws.asciidoc
@@ -11,6 +11,7 @@ This page explains how to get started monitoring the security posture of your cl
 [sidebar]
 --
 * The CSPM integration is available to all {ecloud} users. On-premise deployments require an https://www.elastic.co/pricing[Enterprise subscription].
+* CSPM is supported on commercial clouds only. Government-specific clouds are not supported (https://github.com/elastic/enhancements[request support]).
 * To view posture data, you need `read` privileges for the following {es} indices:
 ** `logs-cloud_security_posture.findings_latest-*`
 ** `logs-cloud_security_posture.scores-*`

--- a/docs/cloud-native-security/cspm-get-started-aws.asciidoc
+++ b/docs/cloud-native-security/cspm-get-started-aws.asciidoc
@@ -11,7 +11,7 @@ This page explains how to get started monitoring the security posture of your cl
 [sidebar]
 --
 * The CSPM integration is available to all {ecloud} users. On-premise deployments require an https://www.elastic.co/pricing[Enterprise subscription].
-* CSPM is supported on commercial clouds only. Government-specific clouds are not supported (https://github.com/elastic/enhancements[request support]).
+* CSPM is supported on commercial cloud only. Government cloud is not supported (https://github.com/elastic/enhancements[request support]).
 * To view posture data, you need `read` privileges for the following {es} indices:
 ** `logs-cloud_security_posture.findings_latest-*`
 ** `logs-cloud_security_posture.scores-*`

--- a/docs/cloud-native-security/cspm-get-started-azure.asciidoc
+++ b/docs/cloud-native-security/cspm-get-started-azure.asciidoc
@@ -11,6 +11,7 @@ This page explains how to get started monitoring the security posture of your cl
 [sidebar]
 --
 * The CSPM integration is available to all {ecloud} users. On-premise deployments require an https://www.elastic.co/pricing[Enterprise subscription].
+* CSPM is supported on commercial clouds only. Government-specific clouds are not supported (https://github.com/elastic/enhancements[request support]).
 * To view posture data, you need `read` privileges for the following {es} indices:
 ** `logs-cloud_security_posture.findings_latest-*`
 ** `logs-cloud_security_posture.scores-*`

--- a/docs/cloud-native-security/cspm-get-started-azure.asciidoc
+++ b/docs/cloud-native-security/cspm-get-started-azure.asciidoc
@@ -11,7 +11,7 @@ This page explains how to get started monitoring the security posture of your cl
 [sidebar]
 --
 * The CSPM integration is available to all {ecloud} users. On-premise deployments require an https://www.elastic.co/pricing[Enterprise subscription].
-* CSPM is supported on commercial clouds only. Government-specific clouds are not supported (https://github.com/elastic/enhancements[request support]).
+* CSPM is supported on commercial cloud only. Government cloud is not supported (https://github.com/elastic/enhancements[request support]).
 * To view posture data, you need `read` privileges for the following {es} indices:
 ** `logs-cloud_security_posture.findings_latest-*`
 ** `logs-cloud_security_posture.scores-*`

--- a/docs/cloud-native-security/cspm-get-started-gcp.asciidoc
+++ b/docs/cloud-native-security/cspm-get-started-gcp.asciidoc
@@ -11,6 +11,7 @@ This page explains how to get started monitoring the security posture of your GC
 [sidebar]
 --
 * The CSPM integration is available to all {ecloud} users. On-premise deployments require an https://www.elastic.co/pricing[Enterprise subscription].
+* CSPM is supported on commercial clouds only. Government-specific clouds are not supported (https://github.com/elastic/enhancements[request support]).
 * To view posture data, you need `read` privileges for the following {es} indices:
 ** `logs-cloud_security_posture.findings_latest-*`
 ** `logs-cloud_security_posture.scores-*`

--- a/docs/cloud-native-security/cspm-get-started-gcp.asciidoc
+++ b/docs/cloud-native-security/cspm-get-started-gcp.asciidoc
@@ -11,7 +11,7 @@ This page explains how to get started monitoring the security posture of your GC
 [sidebar]
 --
 * The CSPM integration is available to all {ecloud} users. On-premise deployments require an https://www.elastic.co/pricing[Enterprise subscription].
-* CSPM is supported on commercial clouds only. Government-specific clouds are not supported (https://github.com/elastic/enhancements[request support]).
+* CSPM is supported on commercial cloud only. Government cloud is not supported (https://github.com/elastic/enhancements[request support]).
 * To view posture data, you need `read` privileges for the following {es} indices:
 ** `logs-cloud_security_posture.findings_latest-*`
 ** `logs-cloud_security_posture.scores-*`

--- a/docs/cloud-native-security/cspm.asciidoc
+++ b/docs/cloud-native-security/cspm.asciidoc
@@ -8,8 +8,9 @@ This feature currently supports Amazon Web Services (AWS), Google Cloud Platform
 .Requirements
 [sidebar]
 --
-* The CSPM integration is available to all {ecloud} users. On-premise deployments require an https://www.elastic.co/pricing[Enterprise subscription].
+* CSPM is available to all {ecloud} users. On-premise deployments require an https://www.elastic.co/pricing[Enterprise subscription].
 * {stack} version 8.10 or greater.
+* CSPM is supported on commercial clouds only. Government-specific clouds are not supported (https://github.com/elastic/enhancements[request support]).
 --
 
 [discrete]

--- a/docs/cloud-native-security/cspm.asciidoc
+++ b/docs/cloud-native-security/cspm.asciidoc
@@ -10,7 +10,7 @@ This feature currently supports Amazon Web Services (AWS), Google Cloud Platform
 --
 * CSPM is available to all {ecloud} users. On-premise deployments require an https://www.elastic.co/pricing[Enterprise subscription].
 * {stack} version 8.10 or greater.
-* CSPM is supported on commercial clouds only. Government-specific clouds are not supported (https://github.com/elastic/enhancements[request support]).
+* CSPM is supported on commercial cloud only. Government cloud is not supported (https://github.com/elastic/enhancements[request support]).
 --
 
 [discrete]


### PR DESCRIPTION
Fixes #4809 - clarifies CSPM's support for commercial vs government cloud products.

Previews: 
[CSPM for Azure](https://security-docs_bk_4812.docs-preview.app.elstc.co/guide/en/security/master/cspm-get-started-azure.html)
[CSPM for AWS](https://security-docs_bk_4812.docs-preview.app.elstc.co/guide/en/security/master/cspm-get-started.html)
[CSPM for GCP](https://security-docs_bk_4812.docs-preview.app.elstc.co/guide/en/security/master/cspm-get-started-gcp.html)
[CSPM](https://security-docs_bk_4812.docs-preview.app.elstc.co/guide/en/security/master/cspm.html) 