### PR TITLE
[Redo][8.1] Highlight that rule exceptions are case-sensitive

### DIFF
--- a/docs/detections/detections-ui-exceptions.asciidoc
+++ b/docs/detections/detections-ui-exceptions.asciidoc
@@ -123,7 +123,6 @@ the exception prevents the rule from generating alerts when the
 +
 [IMPORTANT]
 ============
-
 * Rule exceptions are case-sensitive, which means that any character that's entered as an uppercase or lowercase letter will be treated as such. In the event you _don't_ want a field evaluated as case-sensitive, some ECS fields have a `.caseless` version that you can use.
 * You can use nested conditions. However, this is only required for
 <<nested-field-list, these fields>>. For all other fields, nested conditions

--- a/docs/detections/detections-ui-exceptions.asciidoc
+++ b/docs/detections/detections-ui-exceptions.asciidoc
@@ -123,10 +123,11 @@ the exception prevents the rule from generating alerts when the
 +
 [IMPORTANT]
 ============
+
+* Rule exceptions are case-sensitive, which means that any character that's entered as an uppercase or lowercase letter will be treated as such. In the event you _don't_ want a field evaluated as case-sensitive, some ECS fields have a `.caseless` version that you can use.
 * You can use nested conditions. However, this is only required for
 <<nested-field-list, these fields>>. For all other fields, nested conditions
 should not be used.
-
 * Wildcards are not supported in rule exceptions or value lists. Values must be literal values.
 ============
 +
@@ -195,6 +196,8 @@ The *Add Endpoint Exception* flyout opens, from either the rule details page or 
 [role="screenshot"]
 image::images/endpoint-add-exp.png[]
 . If required, modify the conditions.
++
+IMPORTANT: Rule exceptions are case-sensitive, which means that any character that's entered as an uppercase or lowercase letter will be treated as such. In the event you _don't_ want a field evaluated as case-sensitive, some ECS fields have a `.caseless` version that you can use.
 +
 NOTE: See <<ex-nested-conditions>> for more information on when nested conditions are required.
 


### PR DESCRIPTION
This is a manual backport of https://github.com/elastic/security-docs/pull/4805.