### PR TITLE
Update role definitions for manual CSPM installation

### DIFF
--- a/docs/cloud-native-security/cspm-get-started-aws.asciidoc
+++ b/docs/cloud-native-security/cspm-get-started-aws.asciidoc
@@ -139,8 +139,6 @@ When using manual authentication to onboard at the organization level, you need 
 ```
 ====
 
-** The AWS-managed `SecurityAudit` policy.
-
 IMPORTANT: You must replace `<Management account ID>` in the trust policy with your AWS account ID.
 
 * Next, for each account you want to scan in the organization, create an IAM role named `cloudbeat-securityaudit` with the following policies:

--- a/docs/cloud-native-security/cspm-get-started-aws.asciidoc
+++ b/docs/cloud-native-security/cspm-get-started-aws.asciidoc
@@ -82,6 +82,17 @@ When using manual authentication to onboard at the organization level, you need 
     "Statement": [
         {
             "Action": [
+                "iam:GetRole",
+                "iam:ListAccountAliases",
+                "iam:ListGroup",
+                "iam:ListRoles",
+                "iam:ListUsers",
+            ],
+            "Resource": "*",
+            "Effect": "Allow"
+        },
+        {
+            "Action": [
                 "organizations:List*",
                 "organizations:Describe*"
             ],

--- a/docs/cloud-native-security/cspm-get-started-aws.asciidoc
+++ b/docs/cloud-native-security/cspm-get-started-aws.asciidoc
@@ -86,7 +86,7 @@ When using manual authentication to onboard at the organization level, you need 
                 "iam:ListAccountAliases",
                 "iam:ListGroup",
                 "iam:ListRoles",
-                "iam:ListUsers",
+                "iam:ListUsers"
             ],
             "Resource": "*",
             "Effect": "Allow"


### PR DESCRIPTION
Related to changes in https://github.com/elastic/cloudbeat/pull/2009

- **update cloudbeat-root with new inline policy**
- **remove SecurityAudit assignment from cloudbeat-root**
