### PR TITLE
[8.1] [Redo][7.17-8.5] Highlight that rule exceptions are case-sensitive (#4806)

### DIFF
--- a/docs/detections/detections-ui-exceptions.asciidoc
+++ b/docs/detections/detections-ui-exceptions.asciidoc
@@ -123,6 +123,8 @@ the exception prevents the rule from generating alerts when the
 +
 [IMPORTANT]
 ============
+* Rule exceptions are case-sensitive, which means that any character that's entered as an uppercase or lowercase letter will be treated as such. In the event you _don't_ want a field evaluated as case-sensitive, some ECS fields have a `.caseless` version that you can use.
+
 * You can use nested conditions. However, this is only required for
 <<nested-field-list, these fields>>. For all other fields, nested conditions
 should not be used.
@@ -197,6 +199,9 @@ image::images/endpoint-add-exp.png[]
 . If required, modify the conditions.
 +
 NOTE: See <<ex-nested-conditions>> for more information on when nested conditions are required.
++
+IMPORTANT: Rule exceptions are case-sensitive, which means that any character that's entered as an uppercase or lowercase letter will be treated as such. In the event you _don't_ want a field evaluated as case-sensitive, some ECS fields have a `.caseless` version that you can use.
+
 
 . You can select any of the following:
 
@@ -301,4 +306,3 @@ To export or delete an exception list, select the required action button on the 
 
 [role="screenshot"]
 image::images/actions-exception-list.png[Detail of Exception lists table with export and delete buttons highlighted,400]
-


### PR DESCRIPTION
Backports the following commits to 8.1:
 - [Redo][7.17-8.5] Highlight that rule exceptions are case-sensitive (#4806)