### PR TITLE
[8.0] [Redo][7.17-8.5] Highlight that rule exceptions are case-sensitive (#4806)

### DIFF
--- a/docs/detections/detections-ui-exceptions.asciidoc
+++ b/docs/detections/detections-ui-exceptions.asciidoc
@@ -122,6 +122,8 @@ the exception prevents the rule from generating alerts when the
 +
 [IMPORTANT]
 ============
+* Rule exceptions are case-sensitive, which means that any character that's entered as an uppercase or lowercase letter will be treated as such. In the event you _don't_ want a field evaluated as case-sensitive, some ECS fields have a `.caseless` version that you can use.
+
 * You can use nested conditions. However, this is only required for
 <<nested-field-list, these fields>>. For all other fields, nested conditions
 should not be used.
@@ -196,6 +198,8 @@ image::images/endpoint-add-exp.png[]
 . If required, modify the conditions.
 +
 NOTE: See <<ex-nested-conditions>> for more information on when nested conditions are required.
++
+IMPORTANT: Rule exceptions are case-sensitive, which means that any character that's entered as an uppercase or lowercase letter will be treated as such. In the event you _don't_ want a field evaluated as case-sensitive, some ECS fields have a `.caseless` version that you can use.
 
 . You can select any of the following:
 
@@ -300,4 +304,3 @@ To export or delete an exception list, select the required action button on the 
 
 [role="screenshot"]
 image::images/actions-exception-list.png[Detail of Exceptions table with export and delete buttons highlighted,400]
-


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [Redo][7.17-8.5] Highlight that rule exceptions are case-sensitive (#4806)