### PR TITLE
Manual prebuilt rule updates support notice

### DIFF
--- a/docs/detections/prebuilt-rules-management.asciidoc
+++ b/docs/detections/prebuilt-rules-management.asciidoc
@@ -19,6 +19,8 @@ Follow these guidelines to start using the {security-app}'s <<prebuilt-rules, pr
 * Prebuilt rules don't start running by default. You must first install the rules, then enable them. After installation, only a few prebuilt rules will be enabled by default, such as the Endpoint Security rule.
 
 * You can't modify most settings on Elastic prebuilt rules. You can only edit <<rule-notifications, rule actions>> and <<add-exceptions, add exceptions>>. If you want to modify other settings on a prebuilt rule, you must first duplicate it, then make your changes to the duplicated rule. However, your customized rule is entirely separate from the original prebuilt rule, and will not get updates from Elastic if the prebuilt rule is updated.
+
+* Automatic updates of Elastic prebuilt rules are supported for the current {elastic-sec} version and the latest three previous minor releases. For example, if you’re on {elastic-sec} 8.10, you’ll be able to use the Rules UI to update your prebuilt rules until {elastic-sec} 8.14 is released. After that point, you can still manually download and install updated prebuilt rules, but consider upgrading to the latest {elastic-sec} version if you prefer automatic updates.
 ====
 
 [float]

--- a/docs/detections/prebuilt-rules-management.asciidoc
+++ b/docs/detections/prebuilt-rules-management.asciidoc
@@ -20,7 +20,7 @@ Follow these guidelines to start using the {security-app}'s <<prebuilt-rules, pr
 
 * You can't modify most settings on Elastic prebuilt rules. You can only edit <<rule-notifications, rule actions>> and <<add-exceptions, add exceptions>>. If you want to modify other settings on a prebuilt rule, you must first duplicate it, then make your changes to the duplicated rule. However, your customized rule is entirely separate from the original prebuilt rule, and will not get updates from Elastic if the prebuilt rule is updated.
 
-* Automatic updates of Elastic prebuilt rules are supported for the current {elastic-sec} version and the latest three previous minor releases. For example, if you’re on {elastic-sec} 8.10, you’ll be able to use the Rules UI to update your prebuilt rules until {elastic-sec} 8.14 is released. After that point, you can still manually download and install updated prebuilt rules, but consider upgrading to the latest {elastic-sec} version if you prefer automatic updates.
+* Automatic updates of Elastic prebuilt rules are supported for the current {elastic-sec} version and the latest three previous minor releases. For example, if you’re on {elastic-sec} 8.10, you’ll be able to use the Rules UI to update your prebuilt rules until {elastic-sec} 8.14 is released. After that point, you can still manually download and install updated prebuilt rules, but you must upgrade to the latest {elastic-sec} version to receive automatic updates.
 ====
 
 [float]

--- a/docs/upgrade/upgrade-security.asciidoc
+++ b/docs/upgrade/upgrade-security.asciidoc
@@ -37,6 +37,9 @@ IMPORTANT: You can upgrade to pre-release versions for testing,
 but upgrading from a pre-release to the Generally Available version is unsupported.
 You should use pre-release versions only for testing in a temporary environment.
 
+[float]
+=== Support for Elastic prebuilt detection rule automatic updates
+<<update-prebuilt-rules,Automatic updates of Elastic prebuilt detection rules>> are supported for the current {elastic-sec} version and the latest three previous minor releases. For example, if you’re upgrading to {elastic-sec} 8.10, you’ll be able to use the Rules UI to update your prebuilt rules until {elastic-sec} 8.14 is released. After that point, you can still manually download and install updated prebuilt rules, but consider upgrading to the latest {elastic-sec} version if you prefer automatic updates.
 
 [float]
 [[preventing-migration-failures]]

--- a/docs/upgrade/upgrade-security.asciidoc
+++ b/docs/upgrade/upgrade-security.asciidoc
@@ -39,7 +39,7 @@ You should use pre-release versions only for testing in a temporary environment.
 
 [float]
 === Support for Elastic prebuilt detection rule automatic updates
-<<update-prebuilt-rules,Automatic updates of Elastic prebuilt detection rules>> are supported for the current {elastic-sec} version and the latest three previous minor releases. For example, if you’re upgrading to {elastic-sec} 8.10, you’ll be able to use the Rules UI to update your prebuilt rules until {elastic-sec} 8.14 is released. After that point, you can still manually download and install updated prebuilt rules, but you must upgrade to the latest {elastic-sec} version if you prefer automatic updates.
+<<update-prebuilt-rules,Automatic updates of Elastic prebuilt detection rules>> are supported for the current {elastic-sec} version and the latest three previous minor releases. For example, if you’re upgrading to {elastic-sec} 8.10, you’ll be able to use the Rules UI to update your prebuilt rules until {elastic-sec} 8.14 is released. After that point, you can still manually download and install updated prebuilt rules, but you must upgrade to the latest {elastic-sec} version to receive automatic updates.
 
 [float]
 [[preventing-migration-failures]]

--- a/docs/upgrade/upgrade-security.asciidoc
+++ b/docs/upgrade/upgrade-security.asciidoc
@@ -39,7 +39,7 @@ You should use pre-release versions only for testing in a temporary environment.
 
 [float]
 === Support for Elastic prebuilt detection rule automatic updates
-<<update-prebuilt-rules,Automatic updates of Elastic prebuilt detection rules>> are supported for the current {elastic-sec} version and the latest three previous minor releases. For example, if you’re upgrading to {elastic-sec} 8.10, you’ll be able to use the Rules UI to update your prebuilt rules until {elastic-sec} 8.14 is released. After that point, you can still manually download and install updated prebuilt rules, but consider upgrading to the latest {elastic-sec} version if you prefer automatic updates.
+<<update-prebuilt-rules,Automatic updates of Elastic prebuilt detection rules>> are supported for the current {elastic-sec} version and the latest three previous minor releases. For example, if you’re upgrading to {elastic-sec} 8.10, you’ll be able to use the Rules UI to update your prebuilt rules until {elastic-sec} 8.14 is released. After that point, you can still manually download and install updated prebuilt rules, but you must upgrade to the latest {elastic-sec} version if you prefer automatic updates.
 
 [float]
 [[preventing-migration-failures]]


### PR DESCRIPTION
Resolves https://github.com/elastic/security-docs/issues/3622 by adding a note explaining how automatic updates for prebuilt rule are supported per Stack version.

### Previews
- [Upgrade Elastic Security](https://security-docs_bk_4934.docs-preview.app.elstc.co/guide/en/security/master/upgrade-intro.html#_support_for_elastic_prebuilt_detection_rule_automatic_updates) — New subsection
- [Install and manage Elastic prebuilt rules](https://security-docs_bk_4934.docs-preview.app.elstc.co/guide/en/security/master/prebuilt-rules-management.html) — Add new Note

### Serverless docs
No serverless docs needed, since it's versionless and always on the latest version.

### Backports
Backport this all the way back. At some point the Mergify backports will fail because we reorganized both pages; use the backport tool or manually open PRs for the rest.