### PR TITLE
[ESS][8.12&8.13] Updating list of available rule actions

### DIFF
--- a/docs/detections/api/rules/rules-api-bulk-actions.asciidoc
+++ b/docs/detections/api/rules/rules-api-bulk-actions.asciidoc
@@ -378,7 +378,7 @@ be:
 * `.slack`
 * `.slack_api`
 * `.email`
-* .index`
+* `.index`
 * `.pagerduty`
 * .swimlane`
 * `.webhook`

--- a/docs/detections/api/rules/rules-api-bulk-actions.asciidoc
+++ b/docs/detections/api/rules/rules-api-bulk-actions.asciidoc
@@ -376,9 +376,22 @@ These fields are required when calling `PUT` to modify the `actions` object:
 be:
 
 * `.slack`
+* `.slack_api`
 * `.email`
+* .index`
 * `.pagerduty`
+* .swimlane`
 * `.webhook`
+* `.servicenow`
+* `.servicenow-itom`
+* `.servicenow-sir`
+* `.jira`
+* `.resilient`
+* `.opsgenie`
+* `.teams`
+* `.torq`
+* `.tines`
+* `.d3security`
 
 |group |String |Optionally groups actions by use cases. Use `default` for alert
 notifications.

--- a/docs/detections/api/rules/rules-api-bulk-actions.asciidoc
+++ b/docs/detections/api/rules/rules-api-bulk-actions.asciidoc
@@ -380,7 +380,7 @@ be:
 * `.email`
 * `.index`
 * `.pagerduty`
-* .swimlane`
+* `.swimlane`
 * `.webhook`
 * `.servicenow`
 * `.servicenow-itom`

--- a/docs/detections/api/rules/rules-api-create.asciidoc
+++ b/docs/detections/api/rules/rules-api-create.asciidoc
@@ -540,7 +540,7 @@ be:
 * `.email`
 * `.index`
 * `.pagerduty`
-* .swimlane`
+* `.swimlane`
 * `.webhook`
 * `.servicenow`
 * `.servicenow-itom`

--- a/docs/detections/api/rules/rules-api-create.asciidoc
+++ b/docs/detections/api/rules/rules-api-create.asciidoc
@@ -536,9 +536,22 @@ All fields are required:
 be:
 
 * `.slack`
+* `.slack_api`
 * `.email`
+* .index`
 * `.pagerduty`
+* .swimlane`
 * `.webhook`
+* `.servicenow`
+* `.servicenow-itom`
+* `.servicenow-sir`
+* `.jira`
+* `.resilient`
+* `.opsgenie`
+* `.teams`
+* `.torq`
+* `.tines`
+* `.d3security`
 
 |group |String |Optionally groups actions by use cases. Use `default` for alert
 notifications.

--- a/docs/detections/api/rules/rules-api-create.asciidoc
+++ b/docs/detections/api/rules/rules-api-create.asciidoc
@@ -538,7 +538,7 @@ be:
 * `.slack`
 * `.slack_api`
 * `.email`
-* .index`
+* `.index`
 * `.pagerduty`
 * .swimlane`
 * `.webhook`

--- a/docs/detections/api/rules/rules-api-update.asciidoc
+++ b/docs/detections/api/rules/rules-api-update.asciidoc
@@ -394,7 +394,7 @@ be:
 * `.slack`
 * `.slack_api`
 * `.email`
-* .index`
+* `.index`
 * `.pagerduty`
 * .swimlane`
 * `.webhook`

--- a/docs/detections/api/rules/rules-api-update.asciidoc
+++ b/docs/detections/api/rules/rules-api-update.asciidoc
@@ -396,7 +396,7 @@ be:
 * `.email`
 * `.index`
 * `.pagerduty`
-* .swimlane`
+* `.swimlane`
 * `.webhook`
 * `.servicenow`
 * `.servicenow-itom`

--- a/docs/detections/api/rules/rules-api-update.asciidoc
+++ b/docs/detections/api/rules/rules-api-update.asciidoc
@@ -392,9 +392,22 @@ These fields are required when calling `PUT` to modify the `actions` object:
 be:
 
 * `.slack`
+* `.slack_api`
 * `.email`
+* .index`
 * `.pagerduty`
+* .swimlane`
 * `.webhook`
+* `.servicenow`
+* `.servicenow-itom`
+* `.servicenow-sir`
+* `.jira`
+* `.resilient`
+* `.opsgenie`
+* `.teams`
+* `.torq`
+* `.tines`
+* `.d3security`
 
 |group |String |Optionally groups actions by use cases. Use `default` for alert
 notifications.


### PR DESCRIPTION
Fixes https://github.com/elastic/security-docs/issues/3004

Updated description for the `action_type_id` param on the following pages:

- [Create rule](https://security-docs_bk_4935.docs-preview.app.elstc.co/guide/en/security/master/rules-api-create.html#actions-object-schema)
- [Update rule](https://security-docs_bk_4935.docs-preview.app.elstc.co/guide/en/security/master/rules-api-update.html#actions-object-schema-update)
- [Bulk rule actions](https://security-docs_bk_4935.docs-preview.app.elstc.co/guide/en/security/master/bulk-actions-rules-api.html#actions-object-schema-bulk)