### PR TITLE
Adds note that KSPM doesn't support govcloud

### DIFF
--- a/docs/cloud-native-security/kspm-get-started.asciidoc
+++ b/docs/cloud-native-security/kspm-get-started.asciidoc
@@ -7,7 +7,7 @@ This page explains how to configure the Kubernetes Security Posture Management (
 --
 * The KSPM integration is available to all Elastic Cloud users. For on-prem deployments, it requires an https://www.elastic.co/pricing[Enterprise subscription].
 * The KSPM integration only works in the `Default` Kibana space. Installing the KSPM integration on a different Kibana space will not work.
-* KSPM is supported on commercial cloud only. Government cloud is not supported (https://github.com/elastic/enhancements[request support]).
+* KSPM is not supported on EKS clusters in AWS Government Cloud (https://github.com/elastic/enhancements[request support for government cloud]).
 * To view posture data, ensure you have the `read` privilege for the following {es} indices:
 
 - `logs-cloud_security_posture.findings_latest-*`

--- a/docs/cloud-native-security/kspm-get-started.asciidoc
+++ b/docs/cloud-native-security/kspm-get-started.asciidoc
@@ -7,6 +7,7 @@ This page explains how to configure the Kubernetes Security Posture Management (
 --
 * The KSPM integration is available to all Elastic Cloud users. For on-prem deployments, it requires an https://www.elastic.co/pricing[Enterprise subscription].
 * The KSPM integration only works in the `Default` Kibana space. Installing the KSPM integration on a different Kibana space will not work.
+* KSPM is supported on commercial cloud only. Government cloud is not supported (https://github.com/elastic/enhancements[request support]).
 * To view posture data, ensure you have the `read` privilege for the following {es} indices:
 
 - `logs-cloud_security_posture.findings_latest-*`

--- a/docs/cloud-native-security/kspm.asciidoc
+++ b/docs/cloud-native-security/kspm.asciidoc
@@ -13,6 +13,7 @@ This integration supports Amazon EKS and unmanaged Kubernetes clusters. For setu
 [sidebar]
 --
 * The KSPM integration is available to all Elastic Cloud users. For on-prem deployments, it requires an https://www.elastic.co/pricing[Enterprise subscription].
+* KSPM is supported on commercial cloud only. Government cloud is not supported (https://github.com/elastic/enhancements[request support]).
 --
 
 [discrete]

--- a/docs/cloud-native-security/kspm.asciidoc
+++ b/docs/cloud-native-security/kspm.asciidoc
@@ -13,7 +13,7 @@ This integration supports Amazon EKS and unmanaged Kubernetes clusters. For setu
 [sidebar]
 --
 * The KSPM integration is available to all Elastic Cloud users. For on-prem deployments, it requires an https://www.elastic.co/pricing[Enterprise subscription].
-* KSPM is supported on commercial cloud only. Government cloud is not supported (https://github.com/elastic/enhancements[request support]).
+* KSPM is not supported on EKS clusters in AWS Government Cloud (https://github.com/elastic/enhancements[request support for government cloud]).
 --
 
 [discrete]


### PR DESCRIPTION
Small change to add a requirement for the KSPM integration

Twin PR: https://github.com/elastic/staging-serverless-security-docs/pull/302 

Previews: [here](https://security-docs_bk_4942.docs-preview.app.elstc.co/guide/en/security/master/kspm.html) and [here](https://security-docs_bk_4942.docs-preview.app.elstc.co/guide/en/security/master/get-started-with-kspm.html)