### PR TITLE
[7.17] Switch to global attributes and remove section-scoped `pull` and `issue`

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -45,11 +45,6 @@ This section summarizes the changes in each release.
 * <<release-notes-7.9.0, {elastic-sec} version 7.9.0>>
 
 
-// Use these for links to issue and pulls. Note issues and pulls redirect one to
-// each other on Github, so don't worry too much on using the right prefix.
-:issue: https://github.com/elastic/kibana/issues/
-:pull: https://github.com/elastic/kibana/pull/
-
 include::release-notes/7.17.asciidoc[]
 include::release-notes/7.16.asciidoc[]
 include::release-notes/7.15.asciidoc[]

--- a/docs/release-notes/7.10.asciidoc
+++ b/docs/release-notes/7.10.asciidoc
@@ -9,11 +9,11 @@
 [[bug-fixes-7.10.1]]
 ==== Bug fixes and enhancements
 
-* Fixes EQL previews which now accept all date formats ({pull}83939[#83939]).
-* Fixes incorrect time for DNS histograms ({pull}83781[#83781]).
+* Fixes EQL previews which now accept all date formats ({kibana-pull}83939[#83939]).
+* Fixes incorrect time for DNS histograms ({kibana-pull}83781[#83781]).
 * Fixes UI strings around indicator matching and mapping definitions
-({pull}82510[#82510]).
-* Fixes layout in "Severity override" drop-down when creating a new rule ({pull}82271[#82271]).
+({kibana-pull}82510[#82510]).
+* Fixes layout in "Severity override" drop-down when creating a new rule ({kibana-pull}82271[#82271]).
 
 
 [discrete]
@@ -43,7 +43,7 @@ In the new mapping, `signal.rule.risk_score` is a float.  After rolling over,
 there is a conflict between the old and new `signal.rule.risk_score` for some
 features, such as aggregations.
 
-This requires the `view_index_metadata` permission in Kibana. See ({pull}/80019[#80019]) for details.
+This requires the `view_index_metadata` permission in Kibana. See ({kibana-pull}/80019[#80019]) for details.
 
 *Connect incident fields allowed when cases are sent*
 
@@ -52,32 +52,32 @@ You can now specify connector incident fields when cases are sent. This includes
 * IBM Resilient: issue types, and severity.
 * ServiceNow: urgency, severity, and impact.
 
-See ({pull}77327[#77327]) for details.
+See ({kibana-pull}77327[#77327]) for details.
 
 [discrete]
 [[bug-fixes-7.10.0]]
 ==== Bug fixes and enhancements
-* Adds Metadata and Discovery Analysis Jobs to Security Integration ({pull}76023[#76023]).
-* Improves Alert Telemetry for the Security app ({pull}77200[#77200]).
-* Allows passwords to be visible on security screens ({pull}77394[#77394]).
-* Groups features for role management ({pull}78152[#78152]).
-* Warns users when security is not configured ({pull}78545[#78545]).
-* Enhancements for saved object management workflows ({pull}75444[#75444]).
-* Adds EQL search strategy for security ({pull}78645[#78645]).
-* Fetches related events from specified devices ({pull}78780[#78780]).
-* Excludes cloud alias index from EQL query ({pull}81551[#81551]).
-* Telemetry: Displays collected security event sample ({pull}78963[#78963]).
-* Analyze Events: Requests data from new event API ({pull}78782[#78782]).
-* Detections: Handle conflicts on alert status update ({pull}75492[#75492]).
+* Adds Metadata and Discovery Analysis Jobs to Security Integration ({kibana-pull}76023[#76023]).
+* Improves Alert Telemetry for the Security app ({kibana-pull}77200[#77200]).
+* Allows passwords to be visible on security screens ({kibana-pull}77394[#77394]).
+* Groups features for role management ({kibana-pull}78152[#78152]).
+* Warns users when security is not configured ({kibana-pull}78545[#78545]).
+* Enhancements for saved object management workflows ({kibana-pull}75444[#75444]).
+* Adds EQL search strategy for security ({kibana-pull}78645[#78645]).
+* Fetches related events from specified devices ({kibana-pull}78780[#78780]).
+* Excludes cloud alias index from EQL query ({kibana-pull}81551[#81551]).
+* Telemetry: Displays collected security event sample ({kibana-pull}78963[#78963]).
+* Analyze Events: Requests data from new event API ({kibana-pull}78782[#78782]).
+* Detections: Handle conflicts on alert status update ({kibana-pull}75492[#75492]).
 
 [discrete]
 [[known-issues-7.10.0]]
 ==== Known issues
 
-* If you edit a rule while that rule is running, the rule fails. Subsequent successful runs will retain the previous failure message ({pull}82320[#82320]).
+* If you edit a rule while that rule is running, the rule fails. Subsequent successful runs will retain the previous failure message ({kibana-pull}82320[#82320]).
 +
 [role="screenshot"]
 image::images/detection-rule-failure.png[]
 
-* When adding a rule exception, you cannot select value lists of type `ip_range`. Lists of type `ip_range` will not appear in the **Add Exception** dropdown as possible values after selecting the is in list operator. ({pull}79511[#79511]).
+* When adding a rule exception, you cannot select value lists of type `ip_range`. Lists of type `ip_range` will not appear in the **Add Exception** dropdown as possible values after selecting the is in list operator. ({kibana-pull}79511[#79511]).
 

--- a/docs/release-notes/7.11.asciidoc
+++ b/docs/release-notes/7.11.asciidoc
@@ -9,12 +9,12 @@
 [[bug-fixes-7.11.2]]
 ==== Bug fixes and enhancements
 
-- Updates warning message when no indices match provided index patterns ({pull}93094[#93094]).
-- Fixes rule edit bug with `max_signals` ({pull}92748[#92748]).
-- Fixes issue where the file name in a value modal list would be truncated ({pull}91952[#91952]).
-- Adds an overflow text wrap for rule descriptions ({pull}91945[#91945]).
-- Fixes issue in detection search where searching with the timestamp override field would yield a 400 error({pull}91597[#91597]).
-- Replaces `partial failure` with `warning` for rule statuses ({pull}91167[#91167]).
+- Updates warning message when no indices match provided index patterns ({kibana-pull}93094[#93094]).
+- Fixes rule edit bug with `max_signals` ({kibana-pull}92748[#92748]).
+- Fixes issue where the file name in a value modal list would be truncated ({kibana-pull}91952[#91952]).
+- Adds an overflow text wrap for rule descriptions ({kibana-pull}91945[#91945]).
+- Fixes issue in detection search where searching with the timestamp override field would yield a 400 error({kibana-pull}91597[#91597]).
+- Replaces `partial failure` with `warning` for rule statuses ({kibana-pull}91167[#91167]).
 
 [discrete]
 [[release-notes-7.11.0]]
@@ -32,16 +32,16 @@ The `/api/lists` `DELETE` API has been updated to check for references before re
 [[bug-fixes-7.11.0]]
 ==== Bug fixes and enhancements
 
-* Corrects look-back time logic now displays whatever unit the user selects ({pull}81383[#81383]).
-* Fixes a bug where mapping browser fields were automatically reduced ({pull}81675[#81675]).
-* Allows both status data for enabled and disabled rules are now fetchable ({pull}81783[#81783]).
-* Allows autorefresh to be toggled in **Advanced Settings** ({pull}82062[#82062]).
-* Makes severity and risk score overrides more flexible ({pull}83723[#83723]).
-* Improves DE query build times for large lists ({pull}85051[#85051]).
-* Adds skeleton exceptions list tab to all rules page ({pull}85465[#85465]).
-* Fixes export on exceptions functionality list view ({pull}86135[#86135]).
-* Fixes exception list table referential deletion ({pull}87231[#87231]).
-* Disables delete button for endpoint exceptions ({pull}87694[#87694]).
+* Corrects look-back time logic now displays whatever unit the user selects ({kibana-pull}81383[#81383]).
+* Fixes a bug where mapping browser fields were automatically reduced ({kibana-pull}81675[#81675]).
+* Allows both status data for enabled and disabled rules are now fetchable ({kibana-pull}81783[#81783]).
+* Allows autorefresh to be toggled in **Advanced Settings** ({kibana-pull}82062[#82062]).
+* Makes severity and risk score overrides more flexible ({kibana-pull}83723[#83723]).
+* Improves DE query build times for large lists ({kibana-pull}85051[#85051]).
+* Adds skeleton exceptions list tab to all rules page ({kibana-pull}85465[#85465]).
+* Fixes export on exceptions functionality list view ({kibana-pull}86135[#86135]).
+* Fixes exception list table referential deletion ({kibana-pull}87231[#87231]).
+* Disables delete button for endpoint exceptions ({kibana-pull}87694[#87694]).
 
 [discrete]
 [[known-issues-7.11.0]]

--- a/docs/release-notes/7.11.asciidoc
+++ b/docs/release-notes/7.11.asciidoc
@@ -47,6 +47,6 @@ The `/api/lists` `DELETE` API has been updated to check for references before re
 [[known-issues-7.11.0]]
 ==== Known issues
 
-* The Elastic Endpoint Security rule will report a failure status until the Endpoint sends an alert for the first time. At that point, the next rule execution will succeed.  `logs-endpoint.alerts-*` index pattern does not get created until the Endpoint sends the first alert ({issue}90401[#90401]).
+* The Elastic Endpoint Security rule will report a failure status until the Endpoint sends an alert for the first time. At that point, the next rule execution will succeed.  `logs-endpoint.alerts-*` index pattern does not get created until the Endpoint sends the first alert ({kibana-issue}90401[#90401]).
 
-* In the Alert Details Summary view, values for some fields appear truncated. You'll only be able to see the first character ({issue}90539[#90539]).
+* In the Alert Details Summary view, values for some fields appear truncated. You'll only be able to see the first character ({kibana-issue}90539[#90539]).

--- a/docs/release-notes/7.12.asciidoc
+++ b/docs/release-notes/7.12.asciidoc
@@ -8,13 +8,13 @@
 [discrete]
 [[bug-fixes-7.12.1]]
 ==== Bug fixes and enhancements
-* Removes empty values in the `threshold.field` array for threshold rules ({pull}97111[#97111]).
-* Fixes the issue where the *Read Less* button in the Event Details flyout is rendered below the fold if an event's message field is too large ({pull}96524[#96524]).
-* Resolves regression where Elastic Endgame rules would warn about the unmapped timestamp override field ({pull}96394[#96394]).
-* Standardizes process fields in Endpoint Security telemetry ({pull}95836[#95836]).
-* Adds `threshold_result` to the alert notification context ({pull}95354[#95354]).
-* Updates the threshold preview to account for threshold field groups and cardinality ({pull}94224[#94224]).
-* Fixes bug for pre-populated endpoint exceptions ({pull}94025[#94025]).
+* Removes empty values in the `threshold.field` array for threshold rules ({kibana-pull}97111[#97111]).
+* Fixes the issue where the *Read Less* button in the Event Details flyout is rendered below the fold if an event's message field is too large ({kibana-pull}96524[#96524]).
+* Resolves regression where Elastic Endgame rules would warn about the unmapped timestamp override field ({kibana-pull}96394[#96394]).
+* Standardizes process fields in Endpoint Security telemetry ({kibana-pull}95836[#95836]).
+* Adds `threshold_result` to the alert notification context ({kibana-pull}95354[#95354]).
+* Updates the threshold preview to account for threshold field groups and cardinality ({kibana-pull}94224[#94224]).
+* Fixes bug for pre-populated endpoint exceptions ({kibana-pull}94025[#94025]).
 
 [discrete]
 [[release-notes-7.12.0]]
@@ -23,41 +23,41 @@
 [discrete]
 [[features-7.12.0]]
 ==== Features
-* Implements a connector for ServiceNow SIR ({pull}88190[#88190]).
-* Implements the case's fields for the ServiceNow SIR connector ({pull}88655[#88655]).
+* Implements a connector for ServiceNow SIR ({kibana-pull}88190[#88190]).
+* Implements the case's fields for the ServiceNow SIR connector ({kibana-pull}88655[#88655]).
 
 [discrete]
 [[bug-fixes-7.12.0]]
 ==== Bug fixes and enhancements
-* Enables the Microsoft Team's action type for the detection engine ({pull}94239[#94239]).
-* Fixes bug for pre-populated endpoint exceptions ({pull}94025[#94025]).
-* Pushes ServiceNow ITSM comments on cases and alerts as work notes and improves error messaging ({pull}93916[#93916]).
-* Alert migrations can be finalized and cleaned up in all spaces ({pull}93809[#93809]).
-* Updates error handling logic to produce a cleaner message when deeply nested fields in KQL queries are greater than the default or what is set for the config property ({pull}93536[#93536]).
-* Updates shellcode telemetry for schema adjustment ({pull}93143[#93143]).
-* Fixes bug in the allowlist layout for security telemetry  ({pull}92850[#92850]).
-* Updates exceptions modal to use existing lists plug-in ({pull}92348[#92348]).
-* Moves PE details out of Ext context ({pull}92146[#92146]).
-* Fixes loading indicators in the rules management table ({pull}91925[#91925]).
-* Adds missing fields for security telemetry ({pull}91920[#91920]).
-* Fixes issues when pushing a case, that has alerts attached, to an external service ({pull}91638[#91638]).
-* Updates error banner when refreshing the rule status ({pull}91051[#91051]).
-* Fixes bug in the exceptions builder UI that causes invalid values to overwrite other values ({pull}90634[#90634]).
-* Fixes issues with searching the Exceptions list table by name ({pull}88701[#88701]).
-* Threshold rule fixes ({pull}93553[#93553])({pull}92667[#92667]).
-* Adds sub cases to the case list and a case details page ({pull}91434[#91434]).
-* Upgrades to use the IndexPatternService to get fields ({pull}91153[#91153]).
-* Adds new fields to the allowlist for alert telemetry ({pull}90868[#90868]).
-* Adds support for multiple `terms` aggregations within a Threshold Rule, as well as an additional `cardinality` aggregation for matching a specific number of unique values across a field. ({pull}90826[#90826]).
-* Introduces the network details and host details to the side panel. ({pull}90064[#90064]).
-* Adds ransomware exceptions  ({pull}89974[#89974]).
-* Extends the daily usage collection to include perf and run information on active security ML jobs. ({pull}89705[#89705]).
-* Reduces the detection engine's reliance on `_source` ({pull}89371[#89371]).
-* Pushes a new case to the connector when created ({pull}89131[#89131]).
-* Disallows JIRA labels with spaces ({pull}90548[#90548]).
-* Fixes "Error loading data" displaying under Analyze Event ({pull}91718[#91718]).
+* Enables the Microsoft Team's action type for the detection engine ({kibana-pull}94239[#94239]).
+* Fixes bug for pre-populated endpoint exceptions ({kibana-pull}94025[#94025]).
+* Pushes ServiceNow ITSM comments on cases and alerts as work notes and improves error messaging ({kibana-pull}93916[#93916]).
+* Alert migrations can be finalized and cleaned up in all spaces ({kibana-pull}93809[#93809]).
+* Updates error handling logic to produce a cleaner message when deeply nested fields in KQL queries are greater than the default or what is set for the config property ({kibana-pull}93536[#93536]).
+* Updates shellcode telemetry for schema adjustment ({kibana-pull}93143[#93143]).
+* Fixes bug in the allowlist layout for security telemetry  ({kibana-pull}92850[#92850]).
+* Updates exceptions modal to use existing lists plug-in ({kibana-pull}92348[#92348]).
+* Moves PE details out of Ext context ({kibana-pull}92146[#92146]).
+* Fixes loading indicators in the rules management table ({kibana-pull}91925[#91925]).
+* Adds missing fields for security telemetry ({kibana-pull}91920[#91920]).
+* Fixes issues when pushing a case, that has alerts attached, to an external service ({kibana-pull}91638[#91638]).
+* Updates error banner when refreshing the rule status ({kibana-pull}91051[#91051]).
+* Fixes bug in the exceptions builder UI that causes invalid values to overwrite other values ({kibana-pull}90634[#90634]).
+* Fixes issues with searching the Exceptions list table by name ({kibana-pull}88701[#88701]).
+* Threshold rule fixes ({kibana-pull}93553[#93553])({kibana-pull}92667[#92667]).
+* Adds sub cases to the case list and a case details page ({kibana-pull}91434[#91434]).
+* Upgrades to use the IndexPatternService to get fields ({kibana-pull}91153[#91153]).
+* Adds new fields to the allowlist for alert telemetry ({kibana-pull}90868[#90868]).
+* Adds support for multiple `terms` aggregations within a Threshold Rule, as well as an additional `cardinality` aggregation for matching a specific number of unique values across a field. ({kibana-pull}90826[#90826]).
+* Introduces the network details and host details to the side panel. ({kibana-pull}90064[#90064]).
+* Adds ransomware exceptions  ({kibana-pull}89974[#89974]).
+* Extends the daily usage collection to include perf and run information on active security ML jobs. ({kibana-pull}89705[#89705]).
+* Reduces the detection engine's reliance on `_source` ({kibana-pull}89371[#89371]).
+* Pushes a new case to the connector when created ({kibana-pull}89131[#89131]).
+* Disallows JIRA labels with spaces ({kibana-pull}90548[#90548]).
+* Fixes "Error loading data" displaying under Analyze Event ({kibana-pull}91718[#91718]).
 
 [discrete]
 [[known-issues-7.12.0]]
 ==== Known Issues
-* Pagination does not work in the All Cases table. To circumvent this, increase the total number of rows that are displayed per page by selecting an option from the *Rows per page* menu. Alternatively, decrease the number of rows displayed in the table by filtering the list of cases that are returned. Finally, if you know which case you want to view, enter descriptive text about it into the search bar at the top of the table. ({pull}94929[#94929]).
+* Pagination does not work in the All Cases table. To circumvent this, increase the total number of rows that are displayed per page by selecting an option from the *Rows per page* menu. Alternatively, decrease the number of rows displayed in the table by filtering the list of cases that are returned. Finally, if you know which case you want to view, enter descriptive text about it into the search bar at the top of the table. ({kibana-pull}94929[#94929]).

--- a/docs/release-notes/7.13.asciidoc
+++ b/docs/release-notes/7.13.asciidoc
@@ -8,7 +8,7 @@
 [discrete]
 [[bug-fixes-7.13.3]]
 ==== Bug fixes and enhancements
-* Fixes the JavaScript error that occurred when users opened an alert's detailed view while an event's detailed view was still open ({pull}103970[#103970]).
+* Fixes the JavaScript error that occurred when users opened an alert's detailed view while an event's detailed view was still open ({kibana-pull}103970[#103970]).
 
 [discrete]
 [[release-notes-7.13.2]]
@@ -41,38 +41,38 @@ To ensure these rules can successfully run, duplicate the rule and edit it using
 [[features-7.13.0]]
 ==== Features
 * A new Osquery Manager integration is now available as a beta in Fleet. Osquery provides a search box into hosts, leveraging security, compliance, and operations use cases. The integration enables users to centrally manage osquery deployment to Elastic Agents, run live queries against those agents, and schedule recurring queries. For more information about this new integration see https://github.com/elastic/integrations/tree/master/packages/osquery_manager[the package readme].
-* Adds pre-packaged rule updates through the "Prebuilt Security Detection Rules" Fleet integration ({pull}96698[#96698]).
-* Filters the Alerts table by threat presence ({pull}96096[#96096]).
-* Populates `threat.indicator.event` with `source.event` data ({pull}95697[#95697]).
-* Adds the threat summary to the *Summary* tab in the Alert details flyout and introduces the *Threat Intel* tab ({pull}95604[#95604]) ({pull}97185[#97185]).
-* Updates Cloud plugin to handle new config values in kibana.yml ({pull}95569[#95569]).
+* Adds pre-packaged rule updates through the "Prebuilt Security Detection Rules" Fleet integration ({kibana-pull}96698[#96698]).
+* Filters the Alerts table by threat presence ({kibana-pull}96096[#96096]).
+* Populates `threat.indicator.event` with `source.event` data ({kibana-pull}95697[#95697]).
+* Adds the threat summary to the *Summary* tab in the Alert details flyout and introduces the *Threat Intel* tab ({kibana-pull}95604[#95604]) ({kibana-pull}97185[#97185]).
+* Updates Cloud plugin to handle new config values in kibana.yml ({kibana-pull}95569[#95569]).
 
 [discrete]
 [[bug-fixes-7.13.0]]
 ==== Bug fixes and enhancements
-* Fetches detection adoption metrics  ({pull}97789[#97789]).
-* Updates fields with Beats metadata ({pull}97719[#97719]).
-* Updates detection alert mappings to ECS 1.9 ({pull}97573[#97573]).
-* ML rules accept multiple ML job IDs ({pull}97073[#97073]).
-* Adds the Security Network ML Module to the list of available jobs ({pull}97014[#97014]).
-* Updates MITRE tactics, techniques, and subtechniques ({pull}97011[#97011]).
-* Improves user experience duplicating rules ({pull}96760[#96760]).
-* Introduces a nested CTI row renderer ({pull}96275[#96275]).
-* Rebuilds nested fields structure from field's response ({pull}96187[#96187]).
-* Combines multiple timestamp searches into a single request ({pull}96078[#96078]).
-* Adds the Indicator Match Timeline template ({pull}95840[#95840]).
-* Fetches additional detection rule adoption metrics ({pull}95659[#95659]).
-* Adds HTTP endpoints for the Timeline ({pull}95036[#95036]).
-* Updates the agent status labels and colors ({pull}99314[#99314]).
-* Fixes an issue where many `OR` clauses take up too much vertical space ({pull}98706[#98706]).
-* Adds network responses to error toasters ({pull}97945[#97945]).
-* Fixes issue where long hostnames were truncated in the agent detail flyout.({pull}97253[#97253]).
-* Fixes a bug with DNS query that caused additional terms to be accidentally requested. ({pull}97069[#97069]).
-* Allows a preview of query results when creating a new rule or editing an existing one. ({pull}94018[#94018]).
-* Fixes the rule details page to show the rule details loading when the *Activated* switch is toggled. ({pull}94010[#94010]).
-* Sets the default date time on the timepicker to `today` instead of `Last 24 hours` to enable cachability. Also fixes a date math bug in the URL ({pull}93548[#93548]).
-* Fixes size issue with detection rule telemetry ({pull}99900[#99900]).
-* Excludes meta fields from the fields API request({pull}99443[#99443]).
+* Fetches detection adoption metrics  ({kibana-pull}97789[#97789]).
+* Updates fields with Beats metadata ({kibana-pull}97719[#97719]).
+* Updates detection alert mappings to ECS 1.9 ({kibana-pull}97573[#97573]).
+* ML rules accept multiple ML job IDs ({kibana-pull}97073[#97073]).
+* Adds the Security Network ML Module to the list of available jobs ({kibana-pull}97014[#97014]).
+* Updates MITRE tactics, techniques, and subtechniques ({kibana-pull}97011[#97011]).
+* Improves user experience duplicating rules ({kibana-pull}96760[#96760]).
+* Introduces a nested CTI row renderer ({kibana-pull}96275[#96275]).
+* Rebuilds nested fields structure from field's response ({kibana-pull}96187[#96187]).
+* Combines multiple timestamp searches into a single request ({kibana-pull}96078[#96078]).
+* Adds the Indicator Match Timeline template ({kibana-pull}95840[#95840]).
+* Fetches additional detection rule adoption metrics ({kibana-pull}95659[#95659]).
+* Adds HTTP endpoints for the Timeline ({kibana-pull}95036[#95036]).
+* Updates the agent status labels and colors ({kibana-pull}99314[#99314]).
+* Fixes an issue where many `OR` clauses take up too much vertical space ({kibana-pull}98706[#98706]).
+* Adds network responses to error toasters ({kibana-pull}97945[#97945]).
+* Fixes issue where long hostnames were truncated in the agent detail flyout.({kibana-pull}97253[#97253]).
+* Fixes a bug with DNS query that caused additional terms to be accidentally requested. ({kibana-pull}97069[#97069]).
+* Allows a preview of query results when creating a new rule or editing an existing one. ({kibana-pull}94018[#94018]).
+* Fixes the rule details page to show the rule details loading when the *Activated* switch is toggled. ({kibana-pull}94010[#94010]).
+* Sets the default date time on the timepicker to `today` instead of `Last 24 hours` to enable cachability. Also fixes a date math bug in the URL ({kibana-pull}93548[#93548]).
+* Fixes size issue with detection rule telemetry ({kibana-pull}99900[#99900]).
+* Excludes meta fields from the fields API request({kibana-pull}99443[#99443]).
 
 [discrete]
 [[known-issues-7.13.0]]

--- a/docs/release-notes/7.13.asciidoc
+++ b/docs/release-notes/7.13.asciidoc
@@ -17,7 +17,7 @@
 [discrete]
 [[known-issue-7.13.2]]
 ==== Known issue
-The following {ml-cap} rules contain incorrectly configured ML job IDs (underscores were used instead of dashes between words) and cannot be successfully activated after they are enabled. Running these rules will cause an error message to display, indicating that an error occurred during the rule's execution. This issue is present in {stack} 7.13, 7.13.1, and 7.13.2. ({issue}102146[#102146])
+The following {ml-cap} rules contain incorrectly configured ML job IDs (underscores were used instead of dashes between words) and cannot be successfully activated after they are enabled. Running these rules will cause an error message to display, indicating that an error occurred during the rule's execution. This issue is present in {stack} 7.13, 7.13.1, and 7.13.2. ({kibana-issue}102146[#102146])
 
 * `high-count-by-destination-country`
 * `high-count-network-denies`

--- a/docs/release-notes/7.14.asciidoc
+++ b/docs/release-notes/7.14.asciidoc
@@ -9,9 +9,9 @@
 [discrete]
 [[bug-fixes-7.14.2]]
 ==== Bug fixes and enhancements
-* Detects and fixes corrupt user artifacts that intermittently caused Endpoint Integration Policy responses to fail ({pull}111853[#111853]).
-* Fixes the filter in and filter out functionality in Timeline hover actions ({pull}111211[#111211]).
-* Adds the ability to ignore fields during alert indexing and introduces a workaround for an EQL bug ({pull}110927[#110927]).
+* Detects and fixes corrupt user artifacts that intermittently caused Endpoint Integration Policy responses to fail ({kibana-pull}111853[#111853]).
+* Fixes the filter in and filter out functionality in Timeline hover actions ({kibana-pull}111211[#111211]).
+* Adds the ability to ignore fields during alert indexing and introduces a workaround for an EQL bug ({kibana-pull}110927[#110927]).
 
 [discrete]
 [[release-notes-7.14.1]]
@@ -20,14 +20,14 @@
 [discrete]
 [[features-7.14.1]]
 ==== Features
-* The `securitySolution:defaultThreatIndex` advanced setting defines threat intelligence indices that {elastic-sec} will use when collecting threat indicators. The setting controls features that query threat indices, such as the Threat Intelligence view on the Overview page and the default indicator index values for indicator match rules. One or more threat intelligence indices can be defined; the `filebeat-*` index is specified by default. See <<update-threat-intel-indices, Update default Elastic Security threat intelligence indices>> for more information ({pull}108389[#108389]).
+* The `securitySolution:defaultThreatIndex` advanced setting defines threat intelligence indices that {elastic-sec} will use when collecting threat indicators. The setting controls features that query threat indices, such as the Threat Intelligence view on the Overview page and the default indicator index values for indicator match rules. One or more threat intelligence indices can be defined; the `filebeat-*` index is specified by default. See <<update-threat-intel-indices, Update default Elastic Security threat intelligence indices>> for more information ({kibana-pull}108389[#108389]).
 
 [discrete]
 [[bug-fixes-7.14.1]]
 ==== Bug fixes and enhancements
-* Fixes the AlienVault OTX event count on the Threat Intelligence view ({pull}108448[#108448]).
-* Fixes a Cases configuration error in the `kibana.json` file ({pull}107637[#107637]).
-* Fixes UI errors that were caused by the rule `author` field not being migrated ({pull}107230[#107230]).
+* Fixes the AlienVault OTX event count on the Threat Intelligence view ({kibana-pull}108448[#108448]).
+* Fixes a Cases configuration error in the `kibana.json` file ({kibana-pull}107637[#107637]).
+* Fixes UI errors that were caused by the rule `author` field not being migrated ({kibana-pull}107230[#107230]).
 
 [discrete]
 [[release-notes-7.14.0]]
@@ -37,57 +37,57 @@
 [[features-7.14.0]]
 ==== Features
 * Host isolation allows analysts to isolate hosts from their networks while investigating a potential attack. Analysts can use this feature to respond to malicious activity by containing infected hosts, curbing potential attacks, and preventing lateral movement to other hosts. This feature is supported on Windows and macOS.
-* Adds malware protection for Linux endpoints. Users can enable Linux malware protection in their policy to receive detection alerts ({pull}103404[#103404])({pull}95014[#95014])({pull}104984[#104984]).
-* Adds threat intelligence to alerts ({pull}101553[#101553])({pull}103383[#103383]).
-* Introduces the Swimlane connector for rules and cases ({pull}100086[#100086]).
-* Introduces role-based access control for cases and allows users to be given all, write, or no access to cases ({pull}95058[#95058]).
+* Adds malware protection for Linux endpoints. Users can enable Linux malware protection in their policy to receive detection alerts ({kibana-pull}103404[#103404])({kibana-pull}95014[#95014])({kibana-pull}104984[#104984]).
+* Adds threat intelligence to alerts ({kibana-pull}101553[#101553])({kibana-pull}103383[#103383]).
+* Introduces the Swimlane connector for rules and cases ({kibana-pull}100086[#100086]).
+* Introduces role-based access control for cases and allows users to be given all, write, or no access to cases ({kibana-pull}95058[#95058]).
 * Adds new functionality and usability improvements to the Osquery Manager integration:
 ** Users can create and curate a library of saved queries.
 ** When running a live query, users can select a saved query or create a new one.
 ** Scheduled queries can be constrained to a particular OS or osquery version.
 ** Users can view who ran or scheduled a query, which is helpful during auditing.
 ** The agent list for live queries only shows enrolled agents to make selecting targets easier.
-* Enhances alert documents to have the fields of `constant_keyword`, runtime fields, aliases, and `copy_to` ({pull}102280[#102280]).
-* Paginates long activity logs ({pull}102261[#102261]).
-* Validates path values for trusted apps ({pull}99035[#99035]).
-* Allows the wildcard symbol in trusted app paths ({pull}97623[#97623]).
-* Adds the option to select all rules within the Rules table that match the currently selected filter ({pull}100554[#100554]).
+* Enhances alert documents to have the fields of `constant_keyword`, runtime fields, aliases, and `copy_to` ({kibana-pull}102280[#102280]).
+* Paginates long activity logs ({kibana-pull}102261[#102261]).
+* Validates path values for trusted apps ({kibana-pull}99035[#99035]).
+* Allows the wildcard symbol in trusted app paths ({kibana-pull}97623[#97623]).
+* Adds the option to select all rules within the Rules table that match the currently selected filter ({kibana-pull}100554[#100554]).
 
 [discrete]
 [[bug-fixes-7.14.0]]
 ==== Bug fixes and enhancements
-* The Prebuilt Security Detection Rules package updates automatically ({pull}101846[#101846]).
-* Adds a merge strategy key to `kibana.yml` and adds additional security keys to the Docker container that Elastic Security previously overlooked ({pull}103800[#103800]).
-* Adds an overflow container to the rule name column in the Exceptions table for exceptions that have been assigned to three or more rules ({pull}103377[#103377]).
-* Adds the Threat Intelligence view to the Overview page ({pull}100423[#100423]).
-* Enhances the callout that describes missing privileges and feature access ({pull}98125[#98125]).
-* Fixes the rule preview issue that occurred if users created a threshold rule that was configured to group the IP data type ({pull}105126[#105126]).
-* Removes the comma delimiter for the `is one of` operator when defining rule exception conditions ({pull}104960[#104960]).
-* Resolves bug that left outdated validation messages on the action type selection form ({pull}104868[#104868]).
-* Fixes the sort logic that didn't work for certain fields within the Rules table ({pull}103960[#103960]).
-* Allows activity log scrolling on small screens ({pull}103852[#103852]).
-* Fixes the bug that caused the checkbox value for *Show only threat indicator alerts* from updating properly within the Alerts table ({pull}103746[#103746]).
-* Disables the *Load Elastic prebuilt rules and timeline templates* button when pre-built rules are loading ({pull}103568[#103568]).
-* Allows users to view the details of a deleted rule ({pull}103491[#103491]).
-* Includes actions and responses for endpoints only ({pull}103159[#103159]).
-* Resolves the issue that cause an error message to display if users created rule exceptions with empty fields ({pull}102583[#102583]).
-* Removes the search bar on the *Activity log* tab ({pull}102550[#102550]).
-* Does not show activity log error popups ({pull}102450[#102450]).
-* Shows up to one hour of relative time in the activity log when viewing it from the endpoint details flyout ({pull}102162[#102162]).
-* Updates mappings for detection alerts to ECS v1.10.0 ({pull}101680[#101680]).
-* Fixes timestamp bugs within source indexes when the formats are not in ISO 8601 format ({pull}101349[#101349]).
-* Exposes the EQL query in Kibana logs for detections ({pull}100565[#100565]).
-* Resolves bugs linked to invalid KQL queries ({pull}99442[#99442]).
-* Allows users to view the details of a rule after the rule's been deleted ({pull}99406[#99406]).
-* Fixes the histogram IP legend error ({pull}99468[#99468]).
+* The Prebuilt Security Detection Rules package updates automatically ({kibana-pull}101846[#101846]).
+* Adds a merge strategy key to `kibana.yml` and adds additional security keys to the Docker container that Elastic Security previously overlooked ({kibana-pull}103800[#103800]).
+* Adds an overflow container to the rule name column in the Exceptions table for exceptions that have been assigned to three or more rules ({kibana-pull}103377[#103377]).
+* Adds the Threat Intelligence view to the Overview page ({kibana-pull}100423[#100423]).
+* Enhances the callout that describes missing privileges and feature access ({kibana-pull}98125[#98125]).
+* Fixes the rule preview issue that occurred if users created a threshold rule that was configured to group the IP data type ({kibana-pull}105126[#105126]).
+* Removes the comma delimiter for the `is one of` operator when defining rule exception conditions ({kibana-pull}104960[#104960]).
+* Resolves bug that left outdated validation messages on the action type selection form ({kibana-pull}104868[#104868]).
+* Fixes the sort logic that didn't work for certain fields within the Rules table ({kibana-pull}103960[#103960]).
+* Allows activity log scrolling on small screens ({kibana-pull}103852[#103852]).
+* Fixes the bug that caused the checkbox value for *Show only threat indicator alerts* from updating properly within the Alerts table ({kibana-pull}103746[#103746]).
+* Disables the *Load Elastic prebuilt rules and timeline templates* button when pre-built rules are loading ({kibana-pull}103568[#103568]).
+* Allows users to view the details of a deleted rule ({kibana-pull}103491[#103491]).
+* Includes actions and responses for endpoints only ({kibana-pull}103159[#103159]).
+* Resolves the issue that cause an error message to display if users created rule exceptions with empty fields ({kibana-pull}102583[#102583]).
+* Removes the search bar on the *Activity log* tab ({kibana-pull}102550[#102550]).
+* Does not show activity log error popups ({kibana-pull}102450[#102450]).
+* Shows up to one hour of relative time in the activity log when viewing it from the endpoint details flyout ({kibana-pull}102162[#102162]).
+* Updates mappings for detection alerts to ECS v1.10.0 ({kibana-pull}101680[#101680]).
+* Fixes timestamp bugs within source indexes when the formats are not in ISO 8601 format ({kibana-pull}101349[#101349]).
+* Exposes the EQL query in Kibana logs for detections ({kibana-pull}100565[#100565]).
+* Resolves bugs linked to invalid KQL queries ({kibana-pull}99442[#99442]).
+* Allows users to view the details of a rule after the rule's been deleted ({kibana-pull}99406[#99406]).
+* Fixes the histogram IP legend error ({kibana-pull}99468[#99468]).
 
 [discrete]
 [[known-issue-7.14.0]]
 ==== Known issues
-* The {agent} must be upgraded to the newest version to use the Osquery Manager integration in 7.14.0. Upgrade instructions are available at {fleet-guide}/upgrade-elastic-agent.html[Upgrade {agent}] ({pull}26545[#26545]).
-* Customized event rendering settings do not persist on the Alerts page ({pull}106819[#106819]).
-* Fields that have been added to the Alerts table don’t display in the table, but do in the alert details ({pull}106840[#106840]).
-* After upgrading from 7.8 to 7.14, rules sometimes fail to execute, activate, or deactivate. To resolve this, use the <<rules-api-update, PATCH rule API>> to update each rule that encounters this problem. The payload of the PATCH call should set the `author` field to `[]`, as shown in the example below. After the `author` field is populated, the rule works as expected ({pull}106233[#106233]).
+* The {agent} must be upgraded to the newest version to use the Osquery Manager integration in 7.14.0. Upgrade instructions are available at {fleet-guide}/upgrade-elastic-agent.html[Upgrade {agent}] ({kibana-pull}26545[#26545]).
+* Customized event rendering settings do not persist on the Alerts page ({kibana-pull}106819[#106819]).
+* Fields that have been added to the Alerts table don’t display in the table, but do in the alert details ({kibana-pull}106840[#106840]).
+* After upgrading from 7.8 to 7.14, rules sometimes fail to execute, activate, or deactivate. To resolve this, use the <<rules-api-update, PATCH rule API>> to update each rule that encounters this problem. The payload of the PATCH call should set the `author` field to `[]`, as shown in the example below. After the `author` field is populated, the rule works as expected ({kibana-pull}106233[#106233]).
 +
 --
 [source,json]

--- a/docs/release-notes/7.15.asciidoc
+++ b/docs/release-notes/7.15.asciidoc
@@ -8,10 +8,10 @@
 [discrete]
 [[bug-fixes-7.15.2]]
 ==== Bug fixes and enhancements
-* Moves the *Analyze event* option from the overflow menu to the *Actions* column within the Alerts and Events tables. It now only displays events that can be opened in the visual event analyzer ({pull}115478[#115478]).
-* Fixes a table height issue that occurs when the Alerts table only has a few alerts ({pull}114718[#114718]).
-* Fixes a rule execution bug that intermittently caused large status documents to be generated and indexed, which contributed to Kibana upgrades failing ({pull}112257[#112257]).
-* Updates status queries to use the new `kibana.alert.workflow_status` field, and removes `replaceAll` references that caused older browser versions to crash if they didn’t support it ({pull}114481[#114481]).
+* Moves the *Analyze event* option from the overflow menu to the *Actions* column within the Alerts and Events tables. It now only displays events that can be opened in the visual event analyzer ({kibana-pull}115478[#115478]).
+* Fixes a table height issue that occurs when the Alerts table only has a few alerts ({kibana-pull}114718[#114718]).
+* Fixes a rule execution bug that intermittently caused large status documents to be generated and indexed, which contributed to Kibana upgrades failing ({kibana-pull}112257[#112257]).
+* Updates status queries to use the new `kibana.alert.workflow_status` field, and removes `replaceAll` references that caused older browser versions to crash if they didn’t support it ({kibana-pull}114481[#114481]).
 
 [discrete]
 [[release-notes-7.15.1]]
@@ -20,10 +20,10 @@
 [discrete]
 [[bug-fixes-7.15.1]]
 ==== Bug fixes and enhancements
-* Supports newlines in the {jira} summary field. Newlines are replaced with commas ({pull}113571[#113571]).
-* Fixes a bug that prevented the Endpoints table from resetting after the KQL query was removed ({pull}112595[#112595]).
-* Fixes a bug that caused threshold and indicator match rules to ignore custom rule filters if a saved query was used in the rule definition ({pull}109253[#109253]).
-* Fixes a bug on the Alerts page that prevented the Trend histogram and Count table from being updated after an alert’s status was changed. With this fix, refreshing the Alerts page is no longer necessary to view the updates ({pull}111042[#111042]).
+* Supports newlines in the {jira} summary field. Newlines are replaced with commas ({kibana-pull}113571[#113571]).
+* Fixes a bug that prevented the Endpoints table from resetting after the KQL query was removed ({kibana-pull}112595[#112595]).
+* Fixes a bug that caused threshold and indicator match rules to ignore custom rule filters if a saved query was used in the rule definition ({kibana-pull}109253[#109253]).
+* Fixes a bug on the Alerts page that prevented the Trend histogram and Count table from being updated after an alert’s status was changed. With this fix, refreshing the Alerts page is no longer necessary to view the updates ({kibana-pull}111042[#111042]).
 
 [discrete]
 [[release-notes-7.15.0]]
@@ -32,35 +32,35 @@
 [discrete]
 [[known-issue-7.15.0]]
 ==== Known issues
-* Case comments containing https://github.github.com/gfm/#what-is-github-flavored-markdown-[GitHub Flavored Markdown (GFM)] will cause migrations to fail when upgrading to {stack} version 7.15.0 or later. To prevent this, remove GFM from the case comment before upgrading ({pull}119509[#119509]).
+* Case comments containing https://github.github.com/gfm/#what-is-github-flavored-markdown-[GitHub Flavored Markdown (GFM)] will cause migrations to fail when upgrading to {stack} version 7.15.0 or later. To prevent this, remove GFM from the case comment before upgrading ({kibana-pull}119509[#119509]).
 
 [discrete]
 [[breaking-changes-7.15.0]]
 ==== Breaking changes
-* After upgrading to {stack} version 7.15.x from release versions 7.12.0 through 7.14.2, you need to migrate detection alerts enriched with threat intelligence data to ensure threat intelligence properly displays in {elastic-sec}. For more information, refer to instructions for <<post-upgrade-req-cti-alerts, migrating detection alerts enriched with threat intelligence data>> ({pull}1102[#1102]).
-* Removes the metadata query strategy v1 ({pull}104196[#104196]).
+* After upgrading to {stack} version 7.15.x from release versions 7.12.0 through 7.14.2, you need to migrate detection alerts enriched with threat intelligence data to ensure threat intelligence properly displays in {elastic-sec}. For more information, refer to instructions for <<post-upgrade-req-cti-alerts, migrating detection alerts enriched with threat intelligence data>> ({kibana-pull}1102[#1102]).
+* Removes the metadata query strategy v1 ({kibana-pull}104196[#104196]).
 
 [discrete]
 [[features-7.15.0]]
 ==== Features
-* The `securitySolution:defaultThreatIndex` advanced setting defines threat intelligence indices that {elastic-sec} will use when collecting threat indicators. The setting controls features that query threat indices, such as the Threat Intelligence view on the Overview page and the default indicator index values for indicator match rules. One or more threat intelligence indices can be defined; the `filebeat-*` index is specified by default. See <<update-threat-intel-indices, Update default Elastic Security threat intelligence indices>> for more information ({pull}108389[#108389]).
+* The `securitySolution:defaultThreatIndex` advanced setting defines threat intelligence indices that {elastic-sec} will use when collecting threat indicators. The setting controls features that query threat indices, such as the Threat Intelligence view on the Overview page and the default indicator index values for indicator match rules. One or more threat intelligence indices can be defined; the `filebeat-*` index is specified by default. See <<update-threat-intel-indices, Update default Elastic Security threat intelligence indices>> for more information ({kibana-pull}108389[#108389]).
 * Adds new functionality and usability improvements to the Alerts page:
-** Introduces the Grid view and Event renderer view, which allows users to view data in a tabular format or rendered as an event flow ({pull}#108644[#108644]).
-** Adds a *Reason* field to Alerts details flyout to describe the event that caused the alert ({pull}#108449[#108449], {pull}#107532[#107532]).
+** Introduces the Grid view and Event renderer view, which allows users to view data in a tabular format or rendered as an event flow ({kibana-pull}#108644[#108644]).
+** Adds a *Reason* field to Alerts details flyout to describe the event that caused the alert ({kibana-pull}#108449[#108449], {kibana-pull}#107532[#107532]).
 ** Adds a row renderer popover to the *Reason* field
-({pull}#108054[#108054]).
-** Renames the *In-progress* detection alert status to *Acknowledged* ({pull}#107972[#107972]).
-** Refactors the status filter ({pull}#107249[#107249]).
-** Removes the drag and drop functionality ({pull}#107162[#107162], {pull}#106721[#106721]).
-** Changes the *JSON View* tab name to *JSON* ({pull}#106524[#106524]).
-** Adds actions to fields within the Alert details flyout ({pull}#106362[#106362]).
-** Adds the Count table ({pull}#106358[#106358]).
-** Updates the design of the *Table* tab in the Alert details flyout ({pull}#105996[#105996]).
-* Adds the ability to attach a Lens visualization to a case ({pull}96703[#96703], {pull}109178[#109178]).
-* Adds a date time picker to the *Threat Intel* tab that allows users to query the alert for indicator matches from a specific time range ({pull}107234[#107234]).
-* Adds memory threat protection as an option for configuring integration policies. This option detects and stops in-memory threats on Windows systems, such as shellcode injection, which are used to evade traditional file-based detection techniques. Users can also make exceptions for memory protection alerts ({pull}102196[#102196], {pull}101365[#101365]).
-* Adds malicious behavior protection as an option for configuring integration policies. This option detects and stops threats by monitoring the behavior of system processes for suspicious activity. Behavioral signals are much more difficult for adversaries to evade than traditional file-based detection techniques. Users can also create exceptions for behavior protection alerts ({pull}106853[#106853], {pull}106247[#106247]).
-* For {stack} version >= 7.15.0, adds support for host isolation for endpoints in Windows, macOS, and these Linux distributions ({pull}108230[#108230]):
+({kibana-pull}#108054[#108054]).
+** Renames the *In-progress* detection alert status to *Acknowledged* ({kibana-pull}#107972[#107972]).
+** Refactors the status filter ({kibana-pull}#107249[#107249]).
+** Removes the drag and drop functionality ({kibana-pull}#107162[#107162], {kibana-pull}#106721[#106721]).
+** Changes the *JSON View* tab name to *JSON* ({kibana-pull}#106524[#106524]).
+** Adds actions to fields within the Alert details flyout ({kibana-pull}#106362[#106362]).
+** Adds the Count table ({kibana-pull}#106358[#106358]).
+** Updates the design of the *Table* tab in the Alert details flyout ({kibana-pull}#105996[#105996]).
+* Adds the ability to attach a Lens visualization to a case ({kibana-pull}96703[#96703], {kibana-pull}109178[#109178]).
+* Adds a date time picker to the *Threat Intel* tab that allows users to query the alert for indicator matches from a specific time range ({kibana-pull}107234[#107234]).
+* Adds memory threat protection as an option for configuring integration policies. This option detects and stops in-memory threats on Windows systems, such as shellcode injection, which are used to evade traditional file-based detection techniques. Users can also make exceptions for memory protection alerts ({kibana-pull}102196[#102196], {kibana-pull}101365[#101365]).
+* Adds malicious behavior protection as an option for configuring integration policies. This option detects and stops threats by monitoring the behavior of system processes for suspicious activity. Behavioral signals are much more difficult for adversaries to evade than traditional file-based detection techniques. Users can also create exceptions for behavior protection alerts ({kibana-pull}106853[#106853], {kibana-pull}106247[#106247]).
+* For {stack} version >= 7.15.0, adds support for host isolation for endpoints in Windows, macOS, and these Linux distributions ({kibana-pull}108230[#108230]):
 
 ** CentOS 8
 ** RHEL 8
@@ -68,30 +68,30 @@
 ** Ubuntu 20.04
 ** AWS Linux 2
 
-* Implements the accordion view on the *Threat Intel* tab so that threat matches and their details can be easily viewed ({pull}106609[#106609]).
-* Improves the event enrichment query performance ({pull}106150[#106150]).
-* Allows users to select a custom date range when exploring their endpoint’s activity log ({pull}104085[#104085]).
-* Adds advanced policy keys for memory signature and shellcode protection ({pull}101721[#101721]).
+* Implements the accordion view on the *Threat Intel* tab so that threat matches and their details can be easily viewed ({kibana-pull}106609[#106609]).
+* Improves the event enrichment query performance ({kibana-pull}106150[#106150]).
+* Allows users to select a custom date range when exploring their endpoint’s activity log ({kibana-pull}104085[#104085]).
+* Adds advanced policy keys for memory signature and shellcode protection ({kibana-pull}101721[#101721]).
 
 [discrete]
 [[bug-fixes-7.15.0]]
 ==== Bug fixes and enhancements
-* Allows users to bulk close exceptions to close acknowledged alerts ({pull}110147[#110147]).
-* Removes missing fields from the Trend histogram and Count table on the Alerts page ({pull}108843[#108843]).
-* Updates ECS 1.11 signal mappings ({pull}108764[#108764]).
-* Adds the `operatorsList` property in exceptions builder, which allows users to define options in the operators list ({pull}108015[#108015]).
-* Updates alerts enriched with threat intelligence data to use the latest ECS threat fields ({pull}107988[#107988]).
-* Highlights building block alerts in the Alerts table ({pull}107727[#107727]).
-* Updates MITRE ATT&CK mappings to v9.0 ({pull}107708[#107708]).
-* Makes improvements to the Timeline title and moves the Timeline description to the *Notes* tab ({pull}106544[#106544]).
-* Adds more actions to the *Take action* menu in the Alert details flyout ({pull}105767[#105767]).
-* Fixes the wrong nested package object assignation in the policy delete response ({pull}110824[#110824]).
-* Fixes a bug where parts of the *Activity Log* tab are loaded twice because data was being fetched twice ({pull}110233[#110233]).
-* Removes the clear field button (*x*) within the date and time picker on the *Activity Log* tab ({pull}110035[#110035]).
-* Removes restrictions on minimum and maximum dates in the date time picker ({pull}109452[#109452]).
-* Fixes the bug that causes fields to reset on the Timeline page when users viewed the alert in Timeline ({pull}109086[#109086]).
-* Ensures Fleet is set up before installing or upgrading the Endpoint Integration ({pull}107929[#107929]).
-* Fixes an issue with the Endpoint page's search bar and ensures that `page_index` is reset when new KQL is entered ({pull}106918[#106918]).
-* Adds the `Responses` field to telemetry ({pull}111892[#111892]).
-* Fixes issues with the pagination on the Exceptions table ({pull}111000[#111000]).
-* Fixes a bug that caused empty comments to display in an endpoint's activity log ({pull}111163[#111163]).
+* Allows users to bulk close exceptions to close acknowledged alerts ({kibana-pull}110147[#110147]).
+* Removes missing fields from the Trend histogram and Count table on the Alerts page ({kibana-pull}108843[#108843]).
+* Updates ECS 1.11 signal mappings ({kibana-pull}108764[#108764]).
+* Adds the `operatorsList` property in exceptions builder, which allows users to define options in the operators list ({kibana-pull}108015[#108015]).
+* Updates alerts enriched with threat intelligence data to use the latest ECS threat fields ({kibana-pull}107988[#107988]).
+* Highlights building block alerts in the Alerts table ({kibana-pull}107727[#107727]).
+* Updates MITRE ATT&CK mappings to v9.0 ({kibana-pull}107708[#107708]).
+* Makes improvements to the Timeline title and moves the Timeline description to the *Notes* tab ({kibana-pull}106544[#106544]).
+* Adds more actions to the *Take action* menu in the Alert details flyout ({kibana-pull}105767[#105767]).
+* Fixes the wrong nested package object assignation in the policy delete response ({kibana-pull}110824[#110824]).
+* Fixes a bug where parts of the *Activity Log* tab are loaded twice because data was being fetched twice ({kibana-pull}110233[#110233]).
+* Removes the clear field button (*x*) within the date and time picker on the *Activity Log* tab ({kibana-pull}110035[#110035]).
+* Removes restrictions on minimum and maximum dates in the date time picker ({kibana-pull}109452[#109452]).
+* Fixes the bug that causes fields to reset on the Timeline page when users viewed the alert in Timeline ({kibana-pull}109086[#109086]).
+* Ensures Fleet is set up before installing or upgrading the Endpoint Integration ({kibana-pull}107929[#107929]).
+* Fixes an issue with the Endpoint page's search bar and ensures that `page_index` is reset when new KQL is entered ({kibana-pull}106918[#106918]).
+* Adds the `Responses` field to telemetry ({kibana-pull}111892[#111892]).
+* Fixes issues with the pagination on the Exceptions table ({kibana-pull}111000[#111000]).
+* Fixes a bug that caused empty comments to display in an endpoint's activity log ({kibana-pull}111163[#111163]).

--- a/docs/release-notes/7.16.asciidoc
+++ b/docs/release-notes/7.16.asciidoc
@@ -28,9 +28,9 @@ There are no user-facing changes in the 7.16.2 release.
 [discrete]
 [[bug-fixes-7.16.1]]
 ==== Bug fixes and enhancements
-* Fixes a 409 conflict error that occurred when users enabled a rule ({pull}120088[#120088]).
-* Fixes a bug where case comments containing https://github.github.com/gfm/#what-is-github-flavored-markdown-[GitHub Flavored Markdown (GFM)] caused migrations to fail when upgrading to {stack} version 7.15.0 or later ({pull}119995[#119995]).
-* Adds the {fleet} host isolation exceptions summary card in the {fleet} integration *Advance* tab ({pull}119029[#119029]).
+* Fixes a 409 conflict error that occurred when users enabled a rule ({kibana-pull}120088[#120088]).
+* Fixes a bug where case comments containing https://github.github.com/gfm/#what-is-github-flavored-markdown-[GitHub Flavored Markdown (GFM)] caused migrations to fail when upgrading to {stack} version 7.15.0 or later ({kibana-pull}119995[#119995]).
+* Adds the {fleet} host isolation exceptions summary card in the {fleet} integration *Advance* tab ({kibana-pull}119029[#119029]).
 
 [discrete]
 [[release-notes-7.16.0]]
@@ -39,56 +39,56 @@ There are no user-facing changes in the 7.16.2 release.
 [discrete]
 [[features-7.16.0]]
 ==== Features
-* Adds the ability to configure trusted applications on a per-policy basis, allowing security administrators to target a set of hosts with specific configurations and settings. For example, trusted applications can be tailored to certain functions within an organization or for testing and troubleshooting purposes ({pull}112182[#112182], {pull}111051[#111051], {pull}110966[#110966]).
-* Adds memory threat protection for macOS and Linux systems  ({pull}114799[#114799]).
-* Provides certified applications for {sn} Security Operations (SecOps) and {sn} IT Service Management (ITSM), and introduces a new {sn} IT Operations Management (ITOM) connector ({pull}105440[#105440], {pull}114125[#114125]).
-* Updates logic for deciding whether a host's isolation or release status appears as `Pending` for endpoints added to {elastic-sec} in {stack} version 7.16.0 or later ({pull}115441[#115441]).
-* Adds {Fleet} actions and responses to the endpoint activity log; enriches the log by showing successful or failed action responses that were completed when the endpoint finished executing the action request ({pull}114905[#114905]).
-* Updates the resolution logic for ID-based links to cases ({pull}111984[#111984]).
-* Allows users to create host isolation exceptions ({pull}111253[#111253]).
-* Allows cases to be imported and exported as saved objects ({pull}110148[#110148]).
-* Highlights the top riskiest hosts in a user's environment, based on a normalized host risk score scale of 0 to 100.  ({pull}109553[#109553]).
-* Adds host risk metadata to alert details ({pull}113274[#113274]).
-* Switches the order of the *Count* table and the *Trend* histogram on the Alerts page ({pull}117878[#117878]).
-* Removes assigned policies from trusted applications when removing the {endpoint-sec} integration ({pull}108347[#108347]).
+* Adds the ability to configure trusted applications on a per-policy basis, allowing security administrators to target a set of hosts with specific configurations and settings. For example, trusted applications can be tailored to certain functions within an organization or for testing and troubleshooting purposes ({kibana-pull}112182[#112182], {kibana-pull}111051[#111051], {kibana-pull}110966[#110966]).
+* Adds memory threat protection for macOS and Linux systems  ({kibana-pull}114799[#114799]).
+* Provides certified applications for {sn} Security Operations (SecOps) and {sn} IT Service Management (ITSM), and introduces a new {sn} IT Operations Management (ITOM) connector ({kibana-pull}105440[#105440], {kibana-pull}114125[#114125]).
+* Updates logic for deciding whether a host's isolation or release status appears as `Pending` for endpoints added to {elastic-sec} in {stack} version 7.16.0 or later ({kibana-pull}115441[#115441]).
+* Adds {Fleet} actions and responses to the endpoint activity log; enriches the log by showing successful or failed action responses that were completed when the endpoint finished executing the action request ({kibana-pull}114905[#114905]).
+* Updates the resolution logic for ID-based links to cases ({kibana-pull}111984[#111984]).
+* Allows users to create host isolation exceptions ({kibana-pull}111253[#111253]).
+* Allows cases to be imported and exported as saved objects ({kibana-pull}110148[#110148]).
+* Highlights the top riskiest hosts in a user's environment, based on a normalized host risk score scale of 0 to 100.  ({kibana-pull}109553[#109553]).
+* Adds host risk metadata to alert details ({kibana-pull}113274[#113274]).
+* Switches the order of the *Count* table and the *Trend* histogram on the Alerts page ({kibana-pull}117878[#117878]).
+* Removes assigned policies from trusted applications when removing the {endpoint-sec} integration ({kibana-pull}108347[#108347]).
 
 [discrete]
 [[bug-fixes-7.16.0]]
 ==== Bug fixes and enhancements
-* Moves the *Analyze event* option from the overflow menu to the *Actions* column within the Alerts and Events tables. It now only displays events that can be opened in the visual event analyzer ({pull}115478[#115478]).
-* Halts indicator match rule execution after the allotted time interval has passed ({pull}115288[#115288]).
-* Allows detection rule actions to be migrated to a centralized Kibana alerting framework. Users may receive notifications sooner after alerts have been generated, depending on rule configuration and actions frequency ({pull}115243[#115243], {pull}115101[#115101]).
-* Changes the prebuilt indicator match rule's interval and lookback time to one hour ({pull}115185[#115185]).
-* Allows exceptions to be exported with rules ({pull}115144[#115144]).
-* Improves the formatting of array values and JSON in the *Table* and *JSON* tabs ({pull}115141[#115141]).
-* Provides users with a new, simpler way to add data to their environments through the {agent} ({pull}115016[#115016], {pull}112142[#112142]).
-* Enables the Index connector and action for the Detection engine ({pull}111813[#111813]).
-* Hides building block rules on the Overview page ({pull}105611[#105611]).
-* Corrects the distorted view of the "Status" badge in the Alert details flyout ({pull}116237[#116237]).
-* Improves the display of rule status errors caused by user permissions to the source index ({pull}115114[#115114]).
-* Fixes the exceptions export route ({pull}114920[#114920]).
-* Restores local storage persistence for the Alerts table and the Remove Column action ({pull}114742[#114742]).
-* Fixes issues that occurred when adding the {endpoint-sec} integration to an {agent} policy in {fleet} ({pull}114467[#114467]).
-* Updates the Indexing Time and Query Time columns in the Rule Monitoring table to be SUM, instead of MAX ({pull}114023[#114023]).
-* Fixes a bug that prevented dialogs on the Overview page from opening when users clicked on the *Inspect* button ({pull}113161[#113161]).
-* Sets a new default indicator index query that checks indicator index patterns for matched indicators that have occurred in the past 30 days ({pull}112300[#112300]).
-* Decodes file names on uploaded value lists and fixes a bug that stopped value lists from being deleted ({pull}111838[#111838]).
-* Fixes a bug that allowed users to create a trusted application with an empty `name` field ({pull}111508[#111508]).
-* Removes duplicate exception lists on rule export when multiple rules reference the same list ({pull}116698[#116698]).
-* Disables scrolling when activity data isn't present in the endpoint activity log ({pull}118406[#118406]).
-* Updates the description in the import rules dialog ({pull}118216[#118216]).
-* Fixes a faulty status API call if the user selects the same status that's already selected ({pull}118115[#118115]).
-* Prevents autofocus from jumping to the wrong field ({pull}117950[#117950]).
-* Removes validation that required the action ID to be a UUID ({pull}116524[#116524]).
-* Changes the detections log level from info to debug within the detection engine ({pull}116518[#116518]).
-* Fixes truncated values in columns within the Rules table ({pull}115825[#115825]).
+* Moves the *Analyze event* option from the overflow menu to the *Actions* column within the Alerts and Events tables. It now only displays events that can be opened in the visual event analyzer ({kibana-pull}115478[#115478]).
+* Halts indicator match rule execution after the allotted time interval has passed ({kibana-pull}115288[#115288]).
+* Allows detection rule actions to be migrated to a centralized Kibana alerting framework. Users may receive notifications sooner after alerts have been generated, depending on rule configuration and actions frequency ({kibana-pull}115243[#115243], {kibana-pull}115101[#115101]).
+* Changes the prebuilt indicator match rule's interval and lookback time to one hour ({kibana-pull}115185[#115185]).
+* Allows exceptions to be exported with rules ({kibana-pull}115144[#115144]).
+* Improves the formatting of array values and JSON in the *Table* and *JSON* tabs ({kibana-pull}115141[#115141]).
+* Provides users with a new, simpler way to add data to their environments through the {agent} ({kibana-pull}115016[#115016], {kibana-pull}112142[#112142]).
+* Enables the Index connector and action for the Detection engine ({kibana-pull}111813[#111813]).
+* Hides building block rules on the Overview page ({kibana-pull}105611[#105611]).
+* Corrects the distorted view of the "Status" badge in the Alert details flyout ({kibana-pull}116237[#116237]).
+* Improves the display of rule status errors caused by user permissions to the source index ({kibana-pull}115114[#115114]).
+* Fixes the exceptions export route ({kibana-pull}114920[#114920]).
+* Restores local storage persistence for the Alerts table and the Remove Column action ({kibana-pull}114742[#114742]).
+* Fixes issues that occurred when adding the {endpoint-sec} integration to an {agent} policy in {fleet} ({kibana-pull}114467[#114467]).
+* Updates the Indexing Time and Query Time columns in the Rule Monitoring table to be SUM, instead of MAX ({kibana-pull}114023[#114023]).
+* Fixes a bug that prevented dialogs on the Overview page from opening when users clicked on the *Inspect* button ({kibana-pull}113161[#113161]).
+* Sets a new default indicator index query that checks indicator index patterns for matched indicators that have occurred in the past 30 days ({kibana-pull}112300[#112300]).
+* Decodes file names on uploaded value lists and fixes a bug that stopped value lists from being deleted ({kibana-pull}111838[#111838]).
+* Fixes a bug that allowed users to create a trusted application with an empty `name` field ({kibana-pull}111508[#111508]).
+* Removes duplicate exception lists on rule export when multiple rules reference the same list ({kibana-pull}116698[#116698]).
+* Disables scrolling when activity data isn't present in the endpoint activity log ({kibana-pull}118406[#118406]).
+* Updates the description in the import rules dialog ({kibana-pull}118216[#118216]).
+* Fixes a faulty status API call if the user selects the same status that's already selected ({kibana-pull}118115[#118115]).
+* Prevents autofocus from jumping to the wrong field ({kibana-pull}117950[#117950]).
+* Removes validation that required the action ID to be a UUID ({kibana-pull}116524[#116524]).
+* Changes the detections log level from info to debug within the detection engine ({kibana-pull}116518[#116518]).
+* Fixes truncated values in columns within the Rules table ({kibana-pull}115825[#115825]).
 
 [discrete]
 [[upcoming-breaking-changes-7.16.0]]
 ==== Upcoming breaking changes
 *Changes to detection rule preview functionality:*
 
-To improve the detection engine's rule preview functionality in 8.0.0, preview alerts will be written to a new index called the signals preview index (`.siem-signals-preview*`). In order to view this index and use the updated rule preview functionality, roles must have `read` privileges to the new signals preview index. Also note that, other than their index lifecycle management policies, signal preview indices are nearly identical to existing signal indices ({pull}116374[#116374]).
+To improve the detection engine's rule preview functionality in 8.0.0, preview alerts will be written to a new index called the signals preview index (`.siem-signals-preview*`). In order to view this index and use the updated rule preview functionality, roles must have `read` privileges to the new signals preview index. Also note that, other than their index lifecycle management policies, signal preview indices are nearly identical to existing signal indices ({kibana-pull}116374[#116374]).
 
 To give a role `read` privileges to the new signals preview index:
 
@@ -101,4 +101,4 @@ To give a role `read` privileges to the new signals preview index:
 
 *Upcoming changes to case feature privileges*
 
-In 8.0.0, case feature privileges will no longer be a sub-feature under {elastic-sec} ({pull}113172[#113172]).
+In 8.0.0, case feature privileges will no longer be a sub-feature under {elastic-sec} ({kibana-pull}113172[#113172]).

--- a/docs/release-notes/7.17.asciidoc
+++ b/docs/release-notes/7.17.asciidoc
@@ -224,7 +224,7 @@ NOTE: Uninstalling the {endpoint-sec} integration may temporarily cause {agent}'
 [discrete]
 [[bug-fixes-7.17.5]]
 ==== Bug fixes and enhancements
-* Fixes a sorting and tooltip issue in Timeline for non-ECS fields without nested values ({pull}132570[#132570]).
+* Fixes a sorting and tooltip issue in Timeline for non-ECS fields without nested values ({kibana-pull}132570[#132570]).
 * Fixes a bug that interfered with Windows' boot up process if {elastic-endpoint}'s Protected Process Light (PPL) service wasn't fully uninstalled on the machine (https://github.com/elastic/endpoint/issues/20[#20]).
 
 [discrete]
@@ -235,9 +235,9 @@ NOTE: Uninstalling the {endpoint-sec} integration may temporarily cause {agent}'
 [[bug-fixes-7.17.4]]
 ==== Bug fixes and enhancements
 
-* Allows {kibana-ref}/pre-configured-connectors.html[preconfigured connectors] to be used with cases ({pull}130372[#130372]).
-* Fixes a trusted applications path bug that caused a timeout error when users defined a matching `Path` value without wildcards ({pull}131085[#131085]).
-* Fixes sorting issues that were related to unmapped fields ({pull}132190[#132190]).
+* Allows {kibana-ref}/pre-configured-connectors.html[preconfigured connectors] to be used with cases ({kibana-pull}130372[#130372]).
+* Fixes a trusted applications path bug that caused a timeout error when users defined a matching `Path` value without wildcards ({kibana-pull}131085[#131085]).
+* Fixes sorting issues that were related to unmapped fields ({kibana-pull}132190[#132190]).
 
 [discrete]
 [[release-notes-7.17.3]]
@@ -246,8 +246,8 @@ NOTE: Uninstalling the {endpoint-sec} integration may temporarily cause {agent}'
 [discrete]
 [[bug-fixes-7.17.3]]
 ==== Bug fixes and enhancements
-* Fixes a bug that prevented more than 20 pinned events from displaying when opening an existing Timeline ({pull}128852[#128852]).
-* Allows alerts without a populated `meta` field to be investigated in a Timeline ({pull}129427[#129427]).
+* Fixes a bug that prevented more than 20 pinned events from displaying when opening an existing Timeline ({kibana-pull}128852[#128852]).
+* Allows alerts without a populated `meta` field to be investigated in a Timeline ({kibana-pull}129427[#129427]).
 
 [discrete]
 [[release-notes-7.17.2]]
@@ -258,7 +258,7 @@ NOTE: Uninstalling the {endpoint-sec} integration may temporarily cause {agent}'
 ==== Bug fixes and enhancements
 * Fixes an {endpoint-sec} integration bug that prevented benign Windows files from being deleted under certain circumstances.
 * Ensures {endpoint-sec} continues to run on all supported Windows versions by changing the primary signer of the `elastic-endpoint.exe` file from `ELASTICSEARCH B.V.` to `Elasticsearch, Inc.` (https://github.com/elastic/endpoint/issues/15[#15]).
-* Updates the minimum role permissions needed to import rules with actions. After this change, roles must have at least `Read` privileges for the `Actions and Connectors` feature to import rules with actions ({pull}126203[#126203]).
+* Updates the minimum role permissions needed to import rules with actions. After this change, roles must have at least `Read` privileges for the `Actions and Connectors` feature to import rules with actions ({kibana-pull}126203[#126203]).
 
 [discrete]
 [[release-notes-7.17.1]]
@@ -281,16 +281,16 @@ NOTE: Uninstalling the {endpoint-sec} integration may temporarily cause {agent}'
 [discrete]
 [[breaking-changes-7.17.0]]
 ==== Breaking changes
-* {kibana-ref}/pre-configured-connectors.html[Preconfigured connectors] cannot be used with cases ({pull}120686[#120686]).
+* {kibana-ref}/pre-configured-connectors.html[Preconfigured connectors] cannot be used with cases ({kibana-pull}120686[#120686]).
 
 [discrete]
 [[bug-fixes-7.17.0]]
 ==== Bug fixes and enhancements
-* Adds detailed telemetry statistics for legacy and regular notifications ({pull}123332[#123332], {pull}122472[#122472]).
-* Fixes a bug that changed the message in the *Activity Log* tab when users re-fetched log data for a date range without data ({pull}123039[#123039]).
-* Updates privilege checks when users view the *Exceptions* page ({pull}122902[#122902]).
-* Removes leftover alert notifications after a rule is deleted ({pull}122610[#122610]).
-* Enables cross-space telemetry for cases ({pull}122477[#122477]).
-* Updates the *Reporter* column in the Cases table to use usernames instead of full names ({pull}121820[#121820]).
-* Improves endpoint performance and warns users that trusted applications with a wildcard path might experience performance impacts ({pull}120349[#120349]).
-* Fixes an issue that caused the Cases feature to crash the UI when determining if a connector was deprecated ({pull}120686[#120686]).
+* Adds detailed telemetry statistics for legacy and regular notifications ({kibana-pull}123332[#123332], {kibana-pull}122472[#122472]).
+* Fixes a bug that changed the message in the *Activity Log* tab when users re-fetched log data for a date range without data ({kibana-pull}123039[#123039]).
+* Updates privilege checks when users view the *Exceptions* page ({kibana-pull}122902[#122902]).
+* Removes leftover alert notifications after a rule is deleted ({kibana-pull}122610[#122610]).
+* Enables cross-space telemetry for cases ({kibana-pull}122477[#122477]).
+* Updates the *Reporter* column in the Cases table to use usernames instead of full names ({kibana-pull}121820[#121820]).
+* Improves endpoint performance and warns users that trusted applications with a wildcard path might experience performance impacts ({kibana-pull}120349[#120349]).
+* Fixes an issue that caused the Cases feature to crash the UI when determining if a connector was deprecated ({kibana-pull}120686[#120686]).

--- a/docs/release-notes/7.9.asciidoc
+++ b/docs/release-notes/7.9.asciidoc
@@ -22,15 +22,15 @@ required to enable the UI.
 [[bug-fixes-7.9.1]]
 ==== Bug fixes and enhancements
 
-* Fixes closing alerts via exceptions ({pull}76145[#76145]).
-* Fixes selecting all alerts issue ({pull}75945[#75945]).
+* Fixes closing alerts via exceptions ({kibana-pull}76145[#76145]).
+* Fixes selecting all alerts issue ({kibana-pull}75945[#75945]).
 * Fixes issues when exceptions are no longer associated with a rule
-({pull}76012[#76012]).
-* Prevents adding exceptions to unsupported rule types ({pull}75802[#75802]).
+({kibana-pull}76012[#76012]).
+* Prevents adding exceptions to unsupported rule types ({kibana-pull}75802[#75802]).
 * Corrects error messages for insufficient {ml} permissions
-({pull}74582[#74582]).
+({kibana-pull}74582[#74582]).
 * Increases permissions granularity for the `.lists` system index
-({pull}75378[#75378]).
+({kibana-pull}75378[#75378]).
 
 
 [discrete]
@@ -73,11 +73,11 @@ Timeline or navigate to a different page ({issue}75292[#75292]).
 ==== Bug fixes and enhancements
 
 * Fixes rule tags to accept special characters and keywords: `AND`, `OR`, `(`,
-`)`, `"`, and `*` ({pull}74003[#74003]).
+`)`, `"`, and `*` ({kibana-pull}74003[#74003]).
 * Fixes broken link from the Network map to {kib} index management
-({pull}73757[#73757]).
+({kibana-pull}73757[#73757]).
 * Fixes unresponsive Timeline issues when dragging the `process.hash.sha256`
-field to Timeline ({pull}72142[#72142]).
-* Fixes Timeline page scrolling with saved queries issue ({pull}69433[#69433]).
-* Fixes a UI issue with opening and closing alerts ({pull}69217[#69217]).
-* Fixes display of long rule reference URLs ({pull}68640[#68640]).
+field to Timeline ({kibana-pull}72142[#72142]).
+* Fixes Timeline page scrolling with saved queries issue ({kibana-pull}69433[#69433]).
+* Fixes a UI issue with opening and closing alerts ({kibana-pull}69217[#69217]).
+* Fixes display of long rule reference URLs ({kibana-pull}68640[#68640]).

--- a/docs/release-notes/7.9.asciidoc
+++ b/docs/release-notes/7.9.asciidoc
@@ -57,16 +57,16 @@ IMPORTANT: These changes only apply to {sn} connectors.
 
 * After changing the `xpack.encryptedSavedObjects.encryptionKey` setting value
 and restarting Kibana, you must restart all detection rules
-({issue}74393[#74393]).
+({kibana-issue}74393[#74393]).
 * When selecting all alerts on the *Detections* page, some alerts are not marked
-as selected in the UI ({issue}75194[#75194]).
+as selected in the UI ({kibana-issue}75194[#75194]).
 * When creating rules, if you have more than one Timeline template the template
-drop-down list is truncated ({issue}75196[#75196]).
+drop-down list is truncated ({kibana-issue}75196[#75196]).
 * Exceptions cannot be added to or viewed in imported rules when the exception
 list has been deleted or does not exist in the {kib} space
-({issue}75182[#75182]).
+({kibana-issue}75182[#75182]).
 * Updates to a Timeline may not be saved when you immediately close the
-Timeline or navigate to a different page ({issue}75292[#75292]).
+Timeline or navigate to a different page ({kibana-issue}75292[#75292]).
 
 [discrete]
 [[bug-fixes-7.9.0]]

--- a/docs/whats-new.asciidoc
+++ b/docs/whats-new.asciidoc
@@ -4,7 +4,7 @@
 
 Here are the highlights of what’s new and improved in {elastic-sec}!
 
-For detailed information about this release, see the <<release-notes, Release notes>>.
+For detailed information about this release, refer to the <<release-notes, Release notes>>.
 
 Other versions: {security-guide-all}/7.16/whats-new.html[7.16] | {security-guide-all}/7.15/whats-new.html[7.15] | {security-guide-all}/7.14/whats-new.html[7.14] | {security-guide-all}/7.13/whats-new.html[7.13] | {security-guide-all}/7.12/whats-new.html[7.12] | {security-guide-all}/7.11/whats-new.html[7.11] | {security-guide-all}/7.10/whats-new.html[7.10] |
 {security-guide-all}/7.9/whats-new.html[7.9]


### PR DESCRIPTION
Changes all instances of book/section-scoped attributes `{pull}` and `{issue}` to global attributes `{kibana-pull}` and `{kibana-issue}`, within the 7.17 branch.

Also removes the book/section-scoped definitions from the index file `release-notes.asciidoc`.