### PR TITLE
Updates EA dashboard behavior

### DIFF
--- a/docs/advanced-entity-analytics/asset-criticality.asciidoc
+++ b/docs/advanced-entity-analytics/asset-criticality.asciidoc
@@ -74,4 +74,4 @@ To view the impact of asset criticality on an entity's risk score, follow these 
 NOTE: The risk summary and **Risk contributions** sections display an entity's asset criticality from the latest risk scoring execution. If you change the asset criticality level, subsequent risk calculations will automatically factor in the newest criticality level.
 
 [role="screenshot"]
-image::images/asset-criticality-impact.png[View asset criticality impact on host risks core]
+image::images/asset-criticality-impact.png[View asset criticality impact on host risk score]

--- a/docs/dashboards/entity-dashboard.asciidoc
+++ b/docs/dashboards/entity-dashboard.asciidoc
@@ -34,7 +34,7 @@ Displays the total number of critical hosts, critical users, and anomalies. Sele
 [float]
 == Host Risk Scores
 
-Displays host risk score data for your environment, including the total number of hosts, and the five most recently recorded host risk scores, with their associated host names, risk classifications, and number of detection alerts. Host risk scores are calculated using a weighted sum on a scale of 0 (lowest) to 100 (highest). 
+Displays host risk score data for your environment, including the total number of hosts, and the five most recently recorded host risk scores, with their associated host names, risk data, and number of detection alerts. Host risk scores are calculated using a weighted sum on a scale of 0 (lowest) to 100 (highest). 
 
 [role="screenshot"]
 image::images/host-score-data.png[Host risk scores table]
@@ -42,8 +42,8 @@ image::images/host-score-data.png[Host risk scores table]
 
 Interact with the table to filter data, view more details, and take action: 
 
-* Select the *Host risk classification* menu to filter the chart by the selected classification. 
-* Click a host name link to go to the Host details page.
+* Select the *Host risk level* menu to filter the chart by the selected level. 
+* Click a host name link to open the host details flyout.
 * Hover over a host name link to display inline actions: *Add to timeline*, which adds the selected value to Timeline, and *Copy to Clipboard*, which copies the host name value for you to paste later. 
 * Click *View all* in the upper-right to display all host risk information on the Hosts page. 
 * Click the number link in the *Alerts* column to view the alerts on the Alerts page. Hover over the number and select *Investigate in timeline* (image:images/timeline-button-osquery.png[Investigate in timeline icon,20,20]) to launch Timeline with a query that includes the associated host name value.
@@ -54,15 +54,15 @@ For more information about host risk scores, refer to <<entity-risk-scoring>>.
 [float]
 == User Risk Scores
 
-Displays user risk score data for your environment, including the total number of users, and the five most recently recorded user risk scores, with their associated user names, risk classifications, and number of detection alerts. Like host risk scores, user risk scores are calculated using a weighted sum on a scale of 0 (lowest) to 100 (highest). 
+Displays user risk score data for your environment, including the total number of users, and the five most recently recorded user risk scores, with their associated user names, risk data, and number of detection alerts. Like host risk scores, user risk scores are calculated using a weighted sum on a scale of 0 (lowest) to 100 (highest). 
 
 [role="screenshot"]
 image::images/user-score-data.png[User risk table]
 
 Interact with the table to filter data, view more details, and take action:
 
-* Select the *User risk classification* menu to filter the chart by the selected classification. 
-* Click a user name link to go to the User details page. 
+* Select the *User risk level* menu to filter the chart by the selected level. 
+* Click a user name link to open the user details flyout. 
 * Hover over a user name link to display inline actions: *Add to timeline*, which adds the selected value to Timeline, and *Copy to Clipboard*, which copies the user name value for you to paste later. 
 * Click *View all* in the upper-right to display all user risk information on the Users page. 
 * Click the number link in the *Alerts* column to view the alerts on the Alerts page. Hover over the number and select *Investigate in timeline* (image:images/timeline-button-osquery.png[Investigate in timeline icon,20,20]) to launch Timeline with a query that includes the associated user name value.

--- a/docs/getting-started/users-page.asciidoc
+++ b/docs/getting-started/users-page.asciidoc
@@ -54,6 +54,7 @@ image::images/users/user-details-pg.png[User details page]
 In addition to the user details page, relevant user information is also available in the user details flyout throughout the {elastic-sec} app. You can access this flyout from the following places:
 
 * The Alerts page, by clicking on a user name in the Alerts table
+* The Entity Analytics dashboard, by clicking on a user name in the User Risk Scores table
 * The **Events** tab on the Users and user details pages, by clicking on a user name in the Events table
 * The **User risk** tab on the user details page, by clicking on a user name in the Top risk score contributors table
 * The **Events** tab on the Hosts and host details pages, by clicking on a user name in the Events table

--- a/docs/management/hosts/hosts-overview.asciidoc
+++ b/docs/management/hosts/hosts-overview.asciidoc
@@ -56,7 +56,8 @@ image::images/hosts-detail-pg.png[Host's details page]
 
 In addition to the host details page, relevant host information is also available in the host details flyout throughout the {elastic-sec} app. You can access this flyout from the following places:
 
-* The Alerts page, by clicking on a host name in the Alerts table
+* The Alerts page, by clicking on a host name in the Alerts 
+* The Entity Analytics dashboard, by clicking on a host name in the Host Risk Scores table
 * The **Events** tab on the Users and user details pages, by clicking on a host name in the Events table
 * The **User risk** tab on the user details page, by clicking on a host name in the Top risk score contributors table
 * The **Events** tab on the Hosts and host details pages, by clicking on a host name in the Events table


### PR DESCRIPTION
Contributes to https://github.com/elastic/security-docs/issues/4902 by documenting that clicking on a host/user name in the EA dashboard now opens the host/user details flyout instead of the host/user details page.

Also includes a few minor terminology tweaks and typo fixes.

Twin serverless PR: https://github.com/elastic/staging-serverless-security-docs/pull/307

Previews:
* [Entity Analytics dashboard](https://security-docs_bk_4988.docs-preview.app.elstc.co/guide/en/security/master/detection-entity-dashboard.html)
* [Hosts page](https://security-docs_bk_4988.docs-preview.app.elstc.co/guide/en/security/master/hosts-overview.html)
* [Users page](https://security-docs_bk_4988.docs-preview.app.elstc.co/guide/en/security/master/users-page.html)