### PR TITLE
Max number of alerts per entity processed by risk scoring engine

### DIFF
--- a/docs/advanced-entity-analytics/entity-risk-scoring.asciidoc
+++ b/docs/advanced-entity-analytics/entity-risk-scoring.asciidoc
@@ -29,7 +29,7 @@ The resulting entity risk scores are stored in the `risk-score.risk-score-<space
 [[how-is-risk-score-calculated]]
 == How is risk score calculated?
 
-The risk scoring engine runs hourly to aggregate `Open` and `Acknowledged` alerts from the last 30 days. It groups alerts by `host.name` or `user.name`, and aggregates the individual alert risk scores (`kibana.alert.risk_score`) such that alerts with higher risk scores contribute more than alerts with lower risk scores. The resulting aggregated risk score is assigned to the **Alerts** category in the entity's <<host-risk-summary, risk summary>>.
+The risk scoring engine runs hourly to aggregate `Open` and `Acknowledged` alerts from the last 30 days. For each entity, the engine processes up to 10,000 alerts. It groups alerts by `host.name` or `user.name`, and aggregates the individual alert risk scores (`kibana.alert.risk_score`) such that alerts with higher risk scores contribute more than alerts with lower risk scores. The resulting aggregated risk score is assigned to the **Alerts** category in the entity's <<host-risk-summary, risk summary>>.
 
 The engine then verifies the entity's <<asset-criticality, asset criticality level>>. If there is no asset criticality assigned, the entity risk score remains equal to the aggregated score from the **Alerts** category. If a criticality level is assigned, the engine updates the risk score based on the default risk weight for each criticality level:
 


### PR DESCRIPTION
Contributes to https://github.com/elastic/security-docs/issues/4940 by documenting that the risk scoring engine takes into account up to 10K alerts per entity when calculating risk scores.

Twin serverless PR: https://github.com/elastic/staging-serverless-security-docs/pull/308

Preview: [Entity risk scoring](https://security-docs_bk_4989.docs-preview.app.elstc.co/guide/en/security/master/entity-risk-scoring.html)
 