### PR TITLE
[bugfix] Removes extra "the"s

### DIFF
--- a/docs/detections/prebuilt-rules/downloadable-packages/8-4-3/prebuilt-rule-8-4-3-host-files-system-changes-via-windows-subsystem-for-linux.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-4-3/prebuilt-rule-8-4-3-host-files-system-changes-via-windows-subsystem-for-linux.asciidoc
@@ -1,7 +1,7 @@
 [[prebuilt-rule-8-4-3-host-files-system-changes-via-windows-subsystem-for-linux]]
 === Host Files System Changes via Windows Subsystem for Linux
 
-Detects files creation and modification on the host system from the the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection.
+Detects files creation and modification on the host system from the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection.
 
 *Rule type*: eql
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-4-3/prebuilt-rule-8-4-3-suspicious-execution-via-windows-subsystem-for-linux.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-4-3/prebuilt-rule-8-4-3-suspicious-execution-via-windows-subsystem-for-linux.asciidoc
@@ -1,7 +1,7 @@
 [[prebuilt-rule-8-4-3-suspicious-execution-via-windows-subsystem-for-linux]]
 === Suspicious Execution via Windows Subsystem for Linux
 
-Detects Linux Bash commands from the the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection.
+Detects Linux Bash commands from the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection.
 
 *Rule type*: eql
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-4-3/prebuilt-rules-8-4-3-summary.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-4-3/prebuilt-rules-8-4-3-summary.asciidoc
@@ -41,13 +41,13 @@ This section lists all updates associated with version 8.4.3 of the Fleet integr
 
 |<<prebuilt-rule-8-4-3-untrusted-driver-loaded, Untrusted Driver Loaded>> | Identifies attempt to load an untrusted driver. Adversaries may modify code signing policies to enable execution of unsigned or self-signed code. | new | 1 
 
-|<<prebuilt-rule-8-4-3-suspicious-execution-via-windows-subsystem-for-linux, Suspicious Execution via Windows Subsystem for Linux>> | Detects Linux Bash commands from the the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection. | new | 1 
+|<<prebuilt-rule-8-4-3-suspicious-execution-via-windows-subsystem-for-linux, Suspicious Execution via Windows Subsystem for Linux>> | Detects Linux Bash commands from the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection. | new | 1 
 
 |<<prebuilt-rule-8-4-3-execution-via-windows-subsystem-for-linux, Execution via Windows Subsystem for Linux>> | Detects attempts to execute a program on the host from the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection. | new | 1 
 
 |<<prebuilt-rule-8-4-3-windows-subsystem-for-linux-enabled-via-dism-utility, Windows Subsystem for Linux Enabled via Dism Utility>> | Detects attempts to enable the Windows Subsystem for Linux using Microsoft Dism utility. Adversaries may enable and use WSL for Linux to avoid detection. | new | 1 
 
-|<<prebuilt-rule-8-4-3-host-files-system-changes-via-windows-subsystem-for-linux, Host Files System Changes via Windows Subsystem for Linux>> | Detects files creation and modification on the host system from the the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection. | new | 1 
+|<<prebuilt-rule-8-4-3-host-files-system-changes-via-windows-subsystem-for-linux, Host Files System Changes via Windows Subsystem for Linux>> | Detects files creation and modification on the host system from the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection. | new | 1 
 
 |<<prebuilt-rule-8-4-3-attempt-to-install-kali-linux-via-wsl, Attempt to Install Kali Linux via WSL>> | Detects attempts to install or use Kali Linux via Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection. | new | 1 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-5-1/prebuilt-rule-8-5-1-host-files-system-changes-via-windows-subsystem-for-linux.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-5-1/prebuilt-rule-8-5-1-host-files-system-changes-via-windows-subsystem-for-linux.asciidoc
@@ -1,7 +1,7 @@
 [[prebuilt-rule-8-5-1-host-files-system-changes-via-windows-subsystem-for-linux]]
 === Host Files System Changes via Windows Subsystem for Linux
 
-Detects files creation and modification on the host system from the the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection.
+Detects files creation and modification on the host system from the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection.
 
 *Rule type*: eql
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-5-1/prebuilt-rule-8-5-1-suspicious-execution-via-windows-subsystem-for-linux.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-5-1/prebuilt-rule-8-5-1-suspicious-execution-via-windows-subsystem-for-linux.asciidoc
@@ -1,7 +1,7 @@
 [[prebuilt-rule-8-5-1-suspicious-execution-via-windows-subsystem-for-linux]]
 === Suspicious Execution via Windows Subsystem for Linux
 
-Detects Linux Bash commands from the the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection.
+Detects Linux Bash commands from the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection.
 
 *Rule type*: eql
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-5-1/prebuilt-rules-8-5-1-summary.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-5-1/prebuilt-rules-8-5-1-summary.asciidoc
@@ -41,13 +41,13 @@ This section lists all updates associated with version 8.5.1 of the Fleet integr
 
 |<<prebuilt-rule-8-5-1-untrusted-driver-loaded, Untrusted Driver Loaded>> | Identifies attempt to load an untrusted driver. Adversaries may modify code signing policies to enable execution of unsigned or self-signed code. | new | 1 
 
-|<<prebuilt-rule-8-5-1-suspicious-execution-via-windows-subsystem-for-linux, Suspicious Execution via Windows Subsystem for Linux>> | Detects Linux Bash commands from the the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection. | new | 1 
+|<<prebuilt-rule-8-5-1-suspicious-execution-via-windows-subsystem-for-linux, Suspicious Execution via Windows Subsystem for Linux>> | Detects Linux Bash commands from the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection. | new | 1 
 
 |<<prebuilt-rule-8-5-1-execution-via-windows-subsystem-for-linux, Execution via Windows Subsystem for Linux>> | Detects attempts to execute a program on the host from the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection. | new | 1 
 
 |<<prebuilt-rule-8-5-1-windows-subsystem-for-linux-enabled-via-dism-utility, Windows Subsystem for Linux Enabled via Dism Utility>> | Detects attempts to enable the Windows Subsystem for Linux using Microsoft Dism utility. Adversaries may enable and use WSL for Linux to avoid detection. | new | 1 
 
-|<<prebuilt-rule-8-5-1-host-files-system-changes-via-windows-subsystem-for-linux, Host Files System Changes via Windows Subsystem for Linux>> | Detects files creation and modification on the host system from the the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection. | new | 1 
+|<<prebuilt-rule-8-5-1-host-files-system-changes-via-windows-subsystem-for-linux, Host Files System Changes via Windows Subsystem for Linux>> | Detects files creation and modification on the host system from the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection. | new | 1 
 
 |<<prebuilt-rule-8-5-1-attempt-to-install-kali-linux-via-wsl, Attempt to Install Kali Linux via WSL>> | Detects attempts to install or use Kali Linux via Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection. | new | 1 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-6-1/prebuilt-rule-8-6-1-host-files-system-changes-via-windows-subsystem-for-linux.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-6-1/prebuilt-rule-8-6-1-host-files-system-changes-via-windows-subsystem-for-linux.asciidoc
@@ -1,7 +1,7 @@
 [[prebuilt-rule-8-6-1-host-files-system-changes-via-windows-subsystem-for-linux]]
 === Host Files System Changes via Windows Subsystem for Linux
 
-Detects files creation and modification on the host system from the the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection.
+Detects files creation and modification on the host system from the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection.
 
 *Rule type*: eql
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-6-1/prebuilt-rule-8-6-1-suspicious-execution-via-windows-subsystem-for-linux.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-6-1/prebuilt-rule-8-6-1-suspicious-execution-via-windows-subsystem-for-linux.asciidoc
@@ -1,7 +1,7 @@
 [[prebuilt-rule-8-6-1-suspicious-execution-via-windows-subsystem-for-linux]]
 === Suspicious Execution via Windows Subsystem for Linux
 
-Detects Linux Bash commands from the the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection.
+Detects Linux Bash commands from the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection.
 
 *Rule type*: eql
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-6-1/prebuilt-rules-8-6-1-summary.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-6-1/prebuilt-rules-8-6-1-summary.asciidoc
@@ -41,13 +41,13 @@ This section lists all updates associated with version 8.6.1 of the Fleet integr
 
 |<<prebuilt-rule-8-6-1-untrusted-driver-loaded, Untrusted Driver Loaded>> | Identifies attempt to load an untrusted driver. Adversaries may modify code signing policies to enable execution of unsigned or self-signed code. | new | 1 
 
-|<<prebuilt-rule-8-6-1-suspicious-execution-via-windows-subsystem-for-linux, Suspicious Execution via Windows Subsystem for Linux>> | Detects Linux Bash commands from the the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection. | new | 1 
+|<<prebuilt-rule-8-6-1-suspicious-execution-via-windows-subsystem-for-linux, Suspicious Execution via Windows Subsystem for Linux>> | Detects Linux Bash commands from the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection. | new | 1 
 
 |<<prebuilt-rule-8-6-1-execution-via-windows-subsystem-for-linux, Execution via Windows Subsystem for Linux>> | Detects attempts to execute a program on the host from the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection. | new | 1 
 
 |<<prebuilt-rule-8-6-1-windows-subsystem-for-linux-enabled-via-dism-utility, Windows Subsystem for Linux Enabled via Dism Utility>> | Detects attempts to enable the Windows Subsystem for Linux using Microsoft Dism utility. Adversaries may enable and use WSL for Linux to avoid detection. | new | 1 
 
-|<<prebuilt-rule-8-6-1-host-files-system-changes-via-windows-subsystem-for-linux, Host Files System Changes via Windows Subsystem for Linux>> | Detects files creation and modification on the host system from the the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection. | new | 1 
+|<<prebuilt-rule-8-6-1-host-files-system-changes-via-windows-subsystem-for-linux, Host Files System Changes via Windows Subsystem for Linux>> | Detects files creation and modification on the host system from the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection. | new | 1 
 
 |<<prebuilt-rule-8-6-1-attempt-to-install-kali-linux-via-wsl, Attempt to Install Kali Linux via WSL>> | Detects attempts to install or use Kali Linux via Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection. | new | 1 
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-7-1/prebuilt-rule-8-7-1-host-files-system-changes-via-windows-subsystem-for-linux.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-7-1/prebuilt-rule-8-7-1-host-files-system-changes-via-windows-subsystem-for-linux.asciidoc
@@ -1,7 +1,7 @@
 [[prebuilt-rule-8-7-1-host-files-system-changes-via-windows-subsystem-for-linux]]
 === Host Files System Changes via Windows Subsystem for Linux
 
-Detects files creation and modification on the host system from the the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection.
+Detects files creation and modification on the host system from the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection.
 
 *Rule type*: eql
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-7-1/prebuilt-rule-8-7-1-suspicious-execution-via-windows-subsystem-for-linux.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-7-1/prebuilt-rule-8-7-1-suspicious-execution-via-windows-subsystem-for-linux.asciidoc
@@ -1,7 +1,7 @@
 [[prebuilt-rule-8-7-1-suspicious-execution-via-windows-subsystem-for-linux]]
 === Suspicious Execution via Windows Subsystem for Linux
 
-Detects Linux Bash commands from the the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection.
+Detects Linux Bash commands from the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection.
 
 *Rule type*: eql
 

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-7-1/prebuilt-rules-8-7-1-summary.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-7-1/prebuilt-rules-8-7-1-summary.asciidoc
@@ -43,13 +43,13 @@ This section lists all updates associated with version 8.7.1 of the Fleet integr
 
 |<<prebuilt-rule-8-7-1-untrusted-driver-loaded, Untrusted Driver Loaded>> | Identifies attempt to load an untrusted driver. Adversaries may modify code signing policies to enable execution of unsigned or self-signed code. | new | 1 
 
-|<<prebuilt-rule-8-7-1-suspicious-execution-via-windows-subsystem-for-linux, Suspicious Execution via Windows Subsystem for Linux>> | Detects Linux Bash commands from the the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection. | new | 1 
+|<<prebuilt-rule-8-7-1-suspicious-execution-via-windows-subsystem-for-linux, Suspicious Execution via Windows Subsystem for Linux>> | Detects Linux Bash commands from the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection. | new | 1 
 
 |<<prebuilt-rule-8-7-1-execution-via-windows-subsystem-for-linux, Execution via Windows Subsystem for Linux>> | Detects attempts to execute a program on the host from the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection. | new | 1 
 
 |<<prebuilt-rule-8-7-1-windows-subsystem-for-linux-enabled-via-dism-utility, Windows Subsystem for Linux Enabled via Dism Utility>> | Detects attempts to enable the Windows Subsystem for Linux using Microsoft Dism utility. Adversaries may enable and use WSL for Linux to avoid detection. | new | 1 
 
-|<<prebuilt-rule-8-7-1-host-files-system-changes-via-windows-subsystem-for-linux, Host Files System Changes via Windows Subsystem for Linux>> | Detects files creation and modification on the host system from the the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection. | new | 1 
+|<<prebuilt-rule-8-7-1-host-files-system-changes-via-windows-subsystem-for-linux, Host Files System Changes via Windows Subsystem for Linux>> | Detects files creation and modification on the host system from the Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection. | new | 1 
 
 |<<prebuilt-rule-8-7-1-attempt-to-install-kali-linux-via-wsl, Attempt to Install Kali Linux via WSL>> | Detects attempts to install or use Kali Linux via Windows Subsystem for Linux. Adversaries may enable and use WSL for Linux to avoid detection. | new | 1 
 

--- a/docs/release-notes/8.13.asciidoc
+++ b/docs/release-notes/8.13.asciidoc
@@ -22,7 +22,7 @@
 [[enhancements-8.13.0]]
 ==== Enhancements
 
-* Enables advanced sorting and customization options for the the Findings page's **Vulnerabilities** table ({kibana-pull}174413[#174413]).
+* Enables advanced sorting and customization options for the Findings page's **Vulnerabilities** table ({kibana-pull}174413[#174413]).
 * Adds the ability to analyze an event within a specific time range and data view ({kibana-pull}176364[#176364]).
 * Enables the newly expanded host and user details flyouts, which allow you to view host or user details, risk data and inputs, and asset criticality ({kibana-pull}175899[#175899]).
 * Improves the header layout in the alert details flyout so basic alert details are better organized ({kibana-pull}175075[#175075]).


### PR DESCRIPTION
Fixes #5014, resolving the problem identified in this PR: https://github.com/elastic/security-docs/pull/5011

Removes extra "the"s from docs. Found a number of places this double word is present.