### PR TITLE
Remove prebuilt rules changelog reference

### DIFF
--- a/docs/detections/detections-index.asciidoc
+++ b/docs/detections/detections-index.asciidoc
@@ -48,8 +48,6 @@ include::query-alert-indices.asciidoc[]
 
 include::prebuilt-rules/tune-rule-signals.asciidoc[]
 
-include::prebuilt-rules/prebuilt-rules-changelog.asciidoc[]
-
 include::prebuilt-rules/prebuilt-rules-reference.asciidoc[]
 
 include::prebuilt-rules/rule-desc-index.asciidoc[]


### PR DESCRIPTION
## Summary

- Remove the reference of prebuilt rules changelog which is no longer maintained. 
- Issue details https://github.com/elastic/ia-trade-team/issues/254
