### PR TITLE
Add limit for number of alerts per case

### DIFF
--- a/docs/cases/cases-manage.asciidoc
+++ b/docs/cases/cases-manage.asciidoc
@@ -173,6 +173,8 @@ To explore the alerts attached to a case, click the *Alerts* tab. In the table, 
 [role="screenshot"]
 image::images/cases-alert-tab.png[Shows you the Alerts tab]
 
+NOTE: Each case can have a maximum of 1,000 alerts.
+
 [float]
 [[cases-add-files]]
 === Add files

--- a/docs/detections/alerts-add-to-cases.asciidoc
+++ b/docs/detections/alerts-add-to-cases.asciidoc
@@ -7,7 +7,11 @@
 
 From the Alerts table, you can attach one or more alerts to a <<signals-to-new-cases,new case>> or <<signals-to-existing-cases,an existing one>>. Alerts from any rule type can be added to a case.
 
-NOTE: After you add an alert to a case, you can remove it from the case activity under the alert summary or by using the <<cases-api-overview,Elastic Security Cases API>>.
+[NOTE]
+===============================
+* After you add an alert to a case, you can remove it from the case activity under the alert summary or by using the <<cases-api-overview,Elastic Security Cases API>>.
+* Each case can have a maximum of 1,000 alerts.
+===============================
 
 [role="screenshot"]
 image::images/add-alert-to-case.gif[width=50%][height=50%][Animation of adding an alert to a case]


### PR DESCRIPTION
This PR updates https://www.elastic.co/guide/en/security/current/signals-to-cases.html and https://www.elastic.co/guide/en/security/current/cases-open-manage.html#cases-examine-alerts with details about the maximum number of alerts that can be attached to a case.