### PR TITLE
Updates docs for ability to unassign asset criticality

### DIFF
--- a/docs/advanced-entity-analytics/asset-criticality.asciidoc
+++ b/docs/advanced-entity-analytics/asset-criticality.asciidoc
@@ -26,7 +26,7 @@ For example, you can assign **Extreme impact** to business-critical entities, or
 [discrete]
 == View and assign asset criticality
 
-Entities do not have a default asset criticality level. You can view, assign, and change asset criticality from the following places in the {elastic-sec} app:
+Entities do not have a default asset criticality level. You can view, assign, change, or unassign asset criticality from the following places in the {elastic-sec} app:
 
 * The <<host-details-page, host details page>> and <<user-details-page, user details page>>:
 +

--- a/docs/getting-started/ers-req.asciidoc
+++ b/docs/getting-started/ers-req.asciidoc
@@ -52,11 +52,21 @@ To use the asset criticality feature, turn on the `securitySolution:enableAssetC
 [discrete]
 === Privileges
 
-* To view an entity's asset criticality, you need the `read` privilege for the `.asset-criticality.asset-criticality-<space-id>` index.
-
-* To view, assign, or change an entity's asset criticality, you need the `read` and `write` privileges for the `.asset-criticality.asset-criticality-<space-id>` index.
+To use asset criticality, you need the following privileges for the `.asset-criticality.asset-criticality-<space-id>` index: 
 
 [discrete]
-=== Known limitations
+[width="100%",options="header"]
+|==============================================
 
-* You cannot disable asset criticality as a risk input. Once assigned, an asset criticality level can be changed but not unassigned.
+| Action | Index privilege
+
+| View asset criticality
+| `read`
+
+| View, assign, or change asset criticality
+| `read` and `write`
+
+| Unassign asset criticality
+| `delete`
+
+|==============================================


### PR DESCRIPTION
Contributes to https://github.com/elastic/security-docs/issues/5084.

Previews:
* [Asset criticality](https://security-docs_bk_5096.docs-preview.app.elstc.co/guide/en/security/master/asset-criticality.html)
* [Entity risk scoring prerequisites](https://security-docs_bk_5096.docs-preview.app.elstc.co/guide/en/security/master/ers-requirements.html)

Twin serverless PR: https://github.com/elastic/staging-serverless-security-docs/pull/326