### PR TITLE
Creates new page detailing Bedrock connector setup

### DIFF
--- a/docs/assistant/connect-to-bedrock.asciidoc
+++ b/docs/assistant/connect-to-bedrock.asciidoc
@@ -158,8 +158,7 @@ Finally, configure the connector in {kib}:
 +
 Your LLM connector is now configured. For more information on using Elastic AI Assistant, refer to <<security-assistant, AI Assistant>>.
 
-IMPORTANT: If you're using https://docs.aws.amazon.com/bedrock/latest/userguide/prov-throughput.html[provisioned throughput], your ARN becomes the model ID, and the connector settings **URL** value must be https://www.urlencoder.org/[encoded] to work. 
-For example, if the non-encoded ARN is `arn:aws:bedrock:us-east-2:123456789102:provisioned-model/3Ztr7hbzmkrqy1`, the encoded ARN would be `arn%3Aaws%3Abedrock%3Aus-east-2%3A123456789102%3Aprovisioned-model%2F3Ztr7hbzmkrqy1`.
+IMPORTANT: If you're using https://docs.aws.amazon.com/bedrock/latest/userguide/prov-throughput.html[provisioned throughput], your ARN becomes the model ID, and the connector settings **URL** value must be https://www.urlencoder.org/[encoded] to work. For example, if the non-encoded ARN is `arn:aws:bedrock:us-east-2:123456789102:provisioned-model/3Ztr7hbzmkrqy1`, the encoded ARN would be `arn%3Aaws%3Abedrock%3Aus-east-2%3A123456789102%3Aprovisioned-model%2F3Ztr7hbzmkrqy1`.
 
 
 The following video demonstrates these steps.

--- a/docs/assistant/connect-to-bedrock.asciidoc
+++ b/docs/assistant/connect-to-bedrock.asciidoc
@@ -1,10 +1,9 @@
 [[assistant-connect-to-bedrock]]
-= Connect Elastic AI Assistant to Amazon Bedrock
+= Connect to Amazon Bedrock
 
-This page provides step-by-step instructions for connecting AI Assistant to an Amazon Bedrock large language model (LLM) for the first time. You'll need to configure AWS, then connect AI Assistant to your chosen model.
+This page provides step-by-step instructions for setting up an Amazon Bedrock connector for the first time. This connector type enables you to leverage large language models (LLMs) within {kib}. You'll first need to configure AWS, then configure the connector in {kib}.
 
 NOTE: Only Amazon Bedrock's `Anthropic` models are supported: `Claude` and `Claude instant`.
-
 
 [discrete]
 == Configure AWS
@@ -71,6 +70,7 @@ NOTE: These are the minimum required permissions. IAM policies with additional p
 . Log in to {kib}. 
 . Go to **Stack Management → Connectors → Create connector → Amazon Bedrock**. 
 . Name your connector. 
+. (Optional) Configure the Amazon Bedrock connector to use a different AWS region where Anthropic models are supported by editing the **URL** field, for example by changing `us-east-1` to `eu-central-1`.
 . (Optional) Add one of the following strings if you want to use a model other than the default:
 .. For Haiku: `anthropic.claude-3-haiku-20240307-v1:0`
 .. For Sonnet: `anthropic.claude-3-sonnet-20240229-v1:0`
@@ -78,3 +78,9 @@ NOTE: These are the minimum required permissions. IAM policies with additional p
 . Enter the **Access Key** and **Secret** that you generated earlier, then click **Save**.
 
 Your model is now configured. For more information on using Elastic AI Assistant, refer to <<security-assistant, AI Assistant>>.
+
+IMPORTANT: For customers using Provisioned Throughput, your ARN becomes the Model ID, and it must be be encoded for your Connector Settings URL to work. 
++
+For example, if the non-encoded ARN is: `arn:aws:bedrock:us-east-2:123456789102:provisioned-model/3Ztr7hbzmkrqy1`
++
+The encoded ARN would be: `arn%3Aaws%3Abedrock%3Aus-east-2%3A123456789102%3Aprovisioned-model%2F3Ztr7hbzmkrqy1`

--- a/docs/assistant/connect-to-bedrock.asciidoc
+++ b/docs/assistant/connect-to-bedrock.asciidoc
@@ -38,7 +38,22 @@ NOTE: These are the minimum required permissions. IAM policies with additional p
 +
 . Click **Next**. Name your policy.
 
-To see a video of these steps, refer to the following video.
+The following video demonstrates these steps.
+
+=======
+++++
+<script type="text/javascript" async src="https://play.vidyard.com/embed/v4.js"></script>
+<img
+  style="width: 100%; margin: auto; display: block;"
+  class="vidyard-player-embed"
+  src="https://play.vidyard.com/ek6NpHaj6u4keZyEjPWXcT.jpg"
+  data-uuid="ek6NpHaj6u4keZyEjPWXcT"
+  data-v="4"
+  data-type="inline"
+/>
+</br>
+++++
+=======
 
 
 [discrete]
@@ -52,6 +67,23 @@ Next, assign the policy you just created to a new user:
 . In the **Permissions policies** field, search for the policy you created earlier, select it, and click **Next**.
 . Review the configuration then click **Create user**.
 
+The following video demonstrates these steps.
+
+=======
+++++
+<script type="text/javascript" async src="https://play.vidyard.com/embed/v4.js"></script>
+<img
+  style="width: 100%; margin: auto; display: block;"
+  class="vidyard-player-embed"
+  src="https://play.vidyard.com/5BQb2P818SMddRo6gA79hd.jpg"
+  data-uuid="5BQb2P818SMddRo6gA79hd"
+  data-v="4"
+  data-type="inline"
+/>
+</br>
+++++
+=======
+
 [discrete]
 === Create an access key
 
@@ -64,6 +96,23 @@ Create the access keys that will authenticate your Elastic connector:
 . Select **Third-party service**, check the box under **Confirmation**, click **Next**, then click **Create access key**.
 . Click **Download .csv file** to download the key. Store it securely.
 
+The following video demonstrates these steps.
+
+=======
+++++
+<script type="text/javascript" async src="https://play.vidyard.com/embed/v4.js"></script>
+<img
+  style="width: 100%; margin: auto; display: block;"
+  class="vidyard-player-embed"
+  src="https://play.vidyard.com/8oXgP1fbaQCqjWUgncF9at.jpg"
+  data-uuid="8oXgP1fbaQCqjWUgncF9at"
+  data-v="4"
+  data-type="inline"
+/>
+</br>
+++++
+=======
+
 [discrete]
 === Enable model access
 
@@ -74,6 +123,23 @@ Make sure the supported Amazon Bedrock LLMs are enabled:
 . Select **Model access** from the left navigation menu, then click **Manage model access**.
 . Check the boxes for **Claude** and/or **Claude Instant**, depending which model or models you plan to use.
 . Click **Save changes**.
+
+The following video demonstrates these steps.
+
+=======
+++++
+<script type="text/javascript" async src="https://play.vidyard.com/embed/v4.js"></script>
+<img
+  style="width: 100%; margin: auto; display: block;"
+  class="vidyard-player-embed"
+  src="https://play.vidyard.com/Z7zpHq4N9uvUxegBUMbXDj.jpg"
+  data-uuid="Z7zpHq4N9uvUxegBUMbXDj"
+  data-v="4"
+  data-type="inline"
+/>
+</br>
+++++
+=======
 
 [discrete]
 == Configure Elastic AI Assistant
@@ -97,3 +163,21 @@ IMPORTANT: If you're using https://docs.aws.amazon.com/bedrock/latest/userguide/
 For example, if the non-encoded ARN is: `arn:aws:bedrock:us-east-2:123456789102:provisioned-model/3Ztr7hbzmkrqy1`
 +
 The encoded ARN would be: `arn%3Aaws%3Abedrock%3Aus-east-2%3A123456789102%3Aprovisioned-model%2F3Ztr7hbzmkrqy1`
+
+
+The following video demonstrates these steps.
+
+=======
+++++
+<script type="text/javascript" async src="https://play.vidyard.com/embed/v4.js"></script>
+<img
+  style="width: 100%; margin: auto; display: block;"
+  class="vidyard-player-embed"
+  src="https://play.vidyard.com/QJe4RcTJbp6S6m9CkReEXs.jpg"
+  data-uuid="QJe4RcTJbp6S6m9CkReEXs"
+  data-v="4"
+  data-type="inline"
+/>
+</br>
+++++
+=======

--- a/docs/assistant/connect-to-bedrock.asciidoc
+++ b/docs/assistant/connect-to-bedrock.asciidoc
@@ -1,0 +1,80 @@
+[[assistant-connect-to-bedrock]]
+= Connect Elastic AI Assistant to Amazon Bedrock
+
+This page provides step-by-step instructions for connecting AI Assistant to an Amazon Bedrock large language model (LLM) for the first time. You'll need to configure AWS, then connect AI Assistant to your chosen model.
+
+NOTE: Only Amazon Bedrock's `Anthropic` models are supported: `Claude` and `Claude instant`.
+
+
+[discrete]
+== Configure AWS
+
+[discrete]
+=== Configure an IAM policy 
+
+. Log into the AWS console and search for Identity and Access Management (IAM).
+. From the **IAM** menu, select **Policies**, then click **Create policy**.
+. To provide the necessary permissions, paste the following JSON into the **Specify permissions** menu.
++
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": [
+                "bedrock:InvokeModel",
+                "bedrock:InvokeModelWithResponseStream"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
++
+NOTE: These are the minimum required permissions. IAM policies with additional permissions are also supported.
++
+. Click **Next**. Name your policy.
+
+[discrete]
+=== Configure an IAM User
+
+. Return to the **IAM** menu. Select **Users** from the navigation menu, then click **Create User**. 
+. Name the user, then click **Next**.
+. Select **Attach policies directly**. 
+. In the **Permissions policies** field, search for the policy you created earlier, select it, and click **Next**.
+. Review the configuration then click **Create user**.
+
+[discrete]
+=== Create an access key
+
+. Return to the **IAM** menu. Select **Users** from the navigation menu. 
+. Search for the user you just created, and click it's name.
+. Go to the **Security credentials** tab.
+. Under **Access keys**, click **Create access key**.
+. Select **Third-party service**, check the box under **Confirmation**, click **Next**, then click **Create access key**.
+. Click **Download .csv file**, to download the key. Store it securely.
+
+[discrete]
+=== Enable model access
+
+. Search the AWS console for Amazon Bedrock. 
+. From the Amazon Bedrock page, click **Get started**.
+. Select **Model access** from the left navigation menu, then click **Manage model access**.
+. Check the boxes for **Claude** and **Claude Instant**, depending which model or models you plan to use.
+. Click **Save changes**.
+
+[discrete]
+== Configure Elastic AI Assistant
+
+. Log in to {kib}. 
+. Go to **Stack Management > Connectors > Create connector > Amazon Bedrock**. 
+. Name your connector. 
+. (Optional) Add one of the following strings if you want to use a model other than the default:
+.. For Haiku: `anthropic.claude-3-haiku-20240307-v1:0`
+.. For Sonnet: `anthropic.claude-3-sonnet-20240229-v1:0`
+.. For Opus: `anthropic.claude-3-opus-20240229-v1:0`
+. Enter the **Access Key** and **Secret** that you generated earlier, then click **Save**.
+
+Your model is now configured. For more information on using Elastic AI Assistant, refer to <<security-assistant, AI Assistant>>.

--- a/docs/assistant/connect-to-bedrock.asciidoc
+++ b/docs/assistant/connect-to-bedrock.asciidoc
@@ -13,7 +13,7 @@ NOTE: Only Amazon Bedrock's `Anthropic` models are supported: `Claude` and `Clau
 === Configure an IAM policy 
 
 . Log into the AWS console and search for Identity and Access Management (IAM).
-. From the **IAM** menu, select **Policies**, then click **Create policy**.
+. From the **IAM** menu, select **Policies** → **Create policy**.
 . To provide the necessary permissions, paste the following JSON into the **Specify permissions** menu.
 +
 ```json

--- a/docs/assistant/connect-to-bedrock.asciidoc
+++ b/docs/assistant/connect-to-bedrock.asciidoc
@@ -11,6 +11,8 @@ NOTE: Only Amazon Bedrock's `Anthropic` models are supported: `Claude` and `Clau
 [discrete]
 === Configure an IAM policy 
 
+First, configure an IAM policy with the necessary permissions:
+
 . Log into the AWS console and search for Identity and Access Management (IAM).
 . From the **IAM** menu, select **Policies** → **Create policy**.
 . To provide the necessary permissions, paste the following JSON into the **Specify permissions** menu.
@@ -36,8 +38,13 @@ NOTE: These are the minimum required permissions. IAM policies with additional p
 +
 . Click **Next**. Name your policy.
 
+To see a video of these steps, refer to the following video.
+
+
 [discrete]
 === Configure an IAM User
+
+Next, assign the policy you just created to a new user:
 
 . Return to the **IAM** menu. Select **Users** from the navigation menu, then click **Create User**. 
 . Name the user, then click **Next**.
@@ -47,6 +54,8 @@ NOTE: These are the minimum required permissions. IAM policies with additional p
 
 [discrete]
 === Create an access key
+
+Create the access keys that will authenticate your Elastic connector:
 
 . Return to the **IAM** menu. Select **Users** from the navigation menu. 
 . Search for the user you just created, and click its name.
@@ -58,6 +67,8 @@ NOTE: These are the minimum required permissions. IAM policies with additional p
 [discrete]
 === Enable model access
 
+Make sure the supported Amazon Bedrock LLMs are enabled:
+
 . Search the AWS console for Amazon Bedrock. 
 . From the Amazon Bedrock page, click **Get started**.
 . Select **Model access** from the left navigation menu, then click **Manage model access**.
@@ -66,6 +77,8 @@ NOTE: These are the minimum required permissions. IAM policies with additional p
 
 [discrete]
 == Configure Elastic AI Assistant
+
+Finally, configure the connector in {kib}:
 
 . Log in to {kib}. 
 . Go to **Stack Management → Connectors → Create connector → Amazon Bedrock**. 
@@ -77,7 +90,7 @@ NOTE: These are the minimum required permissions. IAM policies with additional p
 .. For Opus: `anthropic.claude-3-opus-20240229-v1:0`
 . Enter the **Access Key** and **Secret** that you generated earlier, then click **Save**.
 
-Your model is now configured. For more information on using Elastic AI Assistant, refer to <<security-assistant, AI Assistant>>.
+Your LLM connector is now configured. For more information on using Elastic AI Assistant, refer to <<security-assistant, AI Assistant>>.
 
 IMPORTANT: If you're using https://docs.aws.amazon.com/bedrock/latest/userguide/prov-throughput.html[provisioned throughput], your ARN becomes the model ID, and the connector settings **URL** value must be https://www.urlencoder.org/[encoded] to work. 
 +

--- a/docs/assistant/connect-to-bedrock.asciidoc
+++ b/docs/assistant/connect-to-bedrock.asciidoc
@@ -50,7 +50,7 @@ NOTE: These are the minimum required permissions. IAM policies with additional p
 === Create an access key
 
 . Return to the **IAM** menu. Select **Users** from the navigation menu. 
-. Search for the user you just created, and click it's name.
+. Search for the user you just created, and click its name.
 . Go to the **Security credentials** tab.
 . Under **Access keys**, click **Create access key**.
 . Select **Third-party service**, check the box under **Confirmation**, click **Next**, then click **Create access key**.

--- a/docs/assistant/connect-to-bedrock.asciidoc
+++ b/docs/assistant/connect-to-bedrock.asciidoc
@@ -61,7 +61,7 @@ NOTE: These are the minimum required permissions. IAM policies with additional p
 . Search the AWS console for Amazon Bedrock. 
 . From the Amazon Bedrock page, click **Get started**.
 . Select **Model access** from the left navigation menu, then click **Manage model access**.
-. Check the boxes for **Claude** and **Claude Instant**, depending which model or models you plan to use.
+. Check the boxes for **Claude** and/or **Claude Instant**, depending which model or models you plan to use.
 . Click **Save changes**.
 
 [discrete]
@@ -79,7 +79,7 @@ NOTE: These are the minimum required permissions. IAM policies with additional p
 
 Your model is now configured. For more information on using Elastic AI Assistant, refer to <<security-assistant, AI Assistant>>.
 
-IMPORTANT: If you're using provisioned throughput, your ARN becomes the model ID, and the connector settings **URL** value must be https://www.urlencoder.org/[encoded] to work. 
+IMPORTANT: If you're using https://docs.aws.amazon.com/bedrock/latest/userguide/prov-throughput.html[provisioned throughput], your ARN becomes the model ID, and the connector settings **URL** value must be https://www.urlencoder.org/[encoded] to work. 
 +
 For example, if the non-encoded ARN is: `arn:aws:bedrock:us-east-2:123456789102:provisioned-model/3Ztr7hbzmkrqy1`
 +

--- a/docs/assistant/connect-to-bedrock.asciidoc
+++ b/docs/assistant/connect-to-bedrock.asciidoc
@@ -160,9 +160,7 @@ Your LLM connector is now configured. For more information on using Elastic AI A
 
 IMPORTANT: If you're using https://docs.aws.amazon.com/bedrock/latest/userguide/prov-throughput.html[provisioned throughput], your ARN becomes the model ID, and the connector settings **URL** value must be https://www.urlencoder.org/[encoded] to work. 
 +
-For example, if the non-encoded ARN is: `arn:aws:bedrock:us-east-2:123456789102:provisioned-model/3Ztr7hbzmkrqy1`
-+
-The encoded ARN would be: `arn%3Aaws%3Abedrock%3Aus-east-2%3A123456789102%3Aprovisioned-model%2F3Ztr7hbzmkrqy1`
+For example, if the non-encoded ARN is `arn:aws:bedrock:us-east-2:123456789102:provisioned-model/3Ztr7hbzmkrqy1`, the encoded ARN would be `arn%3Aaws%3Abedrock%3Aus-east-2%3A123456789102%3Aprovisioned-model%2F3Ztr7hbzmkrqy1`.
 
 
 The following video demonstrates these steps.

--- a/docs/assistant/connect-to-bedrock.asciidoc
+++ b/docs/assistant/connect-to-bedrock.asciidoc
@@ -142,7 +142,7 @@ The following video demonstrates these steps.
 =======
 
 [discrete]
-== Configure Elastic AI Assistant
+== Configure the Amazon Bedrock connector
 
 Finally, configure the connector in {kib}:
 

--- a/docs/assistant/connect-to-bedrock.asciidoc
+++ b/docs/assistant/connect-to-bedrock.asciidoc
@@ -54,7 +54,7 @@ NOTE: These are the minimum required permissions. IAM policies with additional p
 . Go to the **Security credentials** tab.
 . Under **Access keys**, click **Create access key**.
 . Select **Third-party service**, check the box under **Confirmation**, click **Next**, then click **Create access key**.
-. Click **Download .csv file**, to download the key. Store it securely.
+. Click **Download .csv file** to download the key. Store it securely.
 
 [discrete]
 === Enable model access

--- a/docs/assistant/connect-to-bedrock.asciidoc
+++ b/docs/assistant/connect-to-bedrock.asciidoc
@@ -157,6 +157,7 @@ Finally, configure the connector in {kib}:
 . Enter the **Access Key** and **Secret** that you generated earlier, then click **Save**.
 +
 Your LLM connector is now configured. For more information on using Elastic AI Assistant, refer to <<security-assistant, AI Assistant>>.
+
 IMPORTANT: If you're using https://docs.aws.amazon.com/bedrock/latest/userguide/prov-throughput.html[provisioned throughput], your ARN becomes the model ID, and the connector settings **URL** value must be https://www.urlencoder.org/[encoded] to work. 
 +
 For example, if the non-encoded ARN is: `arn:aws:bedrock:us-east-2:123456789102:provisioned-model/3Ztr7hbzmkrqy1`

--- a/docs/assistant/connect-to-bedrock.asciidoc
+++ b/docs/assistant/connect-to-bedrock.asciidoc
@@ -155,7 +155,7 @@ Finally, configure the connector in {kib}:
 .. For Sonnet: `anthropic.claude-3-sonnet-20240229-v1:0`
 .. For Opus: `anthropic.claude-3-opus-20240229-v1:0`
 . Enter the **Access Key** and **Secret** that you generated earlier, then click **Save**.
-
++
 Your LLM connector is now configured. For more information on using Elastic AI Assistant, refer to <<security-assistant, AI Assistant>>.
 
 IMPORTANT: If you're using https://docs.aws.amazon.com/bedrock/latest/userguide/prov-throughput.html[provisioned throughput], your ARN becomes the model ID, and the connector settings **URL** value must be https://www.urlencoder.org/[encoded] to work. 

--- a/docs/assistant/connect-to-bedrock.asciidoc
+++ b/docs/assistant/connect-to-bedrock.asciidoc
@@ -79,7 +79,7 @@ NOTE: These are the minimum required permissions. IAM policies with additional p
 
 Your model is now configured. For more information on using Elastic AI Assistant, refer to <<security-assistant, AI Assistant>>.
 
-IMPORTANT: For customers using Provisioned Throughput, your ARN becomes the Model ID, and it must be be encoded for your Connector Settings URL to work. 
+IMPORTANT: If you're using provisioned throughput, your ARN becomes the model ID, and the connector settings **URL** value must be https://www.urlencoder.org/[encoded] to work. 
 +
 For example, if the non-encoded ARN is: `arn:aws:bedrock:us-east-2:123456789102:provisioned-model/3Ztr7hbzmkrqy1`
 +

--- a/docs/assistant/connect-to-bedrock.asciidoc
+++ b/docs/assistant/connect-to-bedrock.asciidoc
@@ -159,7 +159,6 @@ Finally, configure the connector in {kib}:
 Your LLM connector is now configured. For more information on using Elastic AI Assistant, refer to <<security-assistant, AI Assistant>>.
 
 IMPORTANT: If you're using https://docs.aws.amazon.com/bedrock/latest/userguide/prov-throughput.html[provisioned throughput], your ARN becomes the model ID, and the connector settings **URL** value must be https://www.urlencoder.org/[encoded] to work. 
-+
 For example, if the non-encoded ARN is `arn:aws:bedrock:us-east-2:123456789102:provisioned-model/3Ztr7hbzmkrqy1`, the encoded ARN would be `arn%3Aaws%3Abedrock%3Aus-east-2%3A123456789102%3Aprovisioned-model%2F3Ztr7hbzmkrqy1`.
 
 

--- a/docs/assistant/connect-to-bedrock.asciidoc
+++ b/docs/assistant/connect-to-bedrock.asciidoc
@@ -69,7 +69,7 @@ NOTE: These are the minimum required permissions. IAM policies with additional p
 == Configure Elastic AI Assistant
 
 . Log in to {kib}. 
-. Go to **Stack Management > Connectors > Create connector > Amazon Bedrock**. 
+. Go to **Stack Management → Connectors → Create connector → Amazon Bedrock**. 
 . Name your connector. 
 . (Optional) Add one of the following strings if you want to use a model other than the default:
 .. For Haiku: `anthropic.claude-3-haiku-20240307-v1:0`

--- a/docs/assistant/connect-to-bedrock.asciidoc
+++ b/docs/assistant/connect-to-bedrock.asciidoc
@@ -157,7 +157,6 @@ Finally, configure the connector in {kib}:
 . Enter the **Access Key** and **Secret** that you generated earlier, then click **Save**.
 +
 Your LLM connector is now configured. For more information on using Elastic AI Assistant, refer to <<security-assistant, AI Assistant>>.
-+
 IMPORTANT: If you're using https://docs.aws.amazon.com/bedrock/latest/userguide/prov-throughput.html[provisioned throughput], your ARN becomes the model ID, and the connector settings **URL** value must be https://www.urlencoder.org/[encoded] to work. 
 +
 For example, if the non-encoded ARN is: `arn:aws:bedrock:us-east-2:123456789102:provisioned-model/3Ztr7hbzmkrqy1`

--- a/docs/assistant/connect-to-bedrock.asciidoc
+++ b/docs/assistant/connect-to-bedrock.asciidoc
@@ -157,7 +157,7 @@ Finally, configure the connector in {kib}:
 . Enter the **Access Key** and **Secret** that you generated earlier, then click **Save**.
 +
 Your LLM connector is now configured. For more information on using Elastic AI Assistant, refer to <<security-assistant, AI Assistant>>.
-
++
 IMPORTANT: If you're using https://docs.aws.amazon.com/bedrock/latest/userguide/prov-throughput.html[provisioned throughput], your ARN becomes the model ID, and the connector settings **URL** value must be https://www.urlencoder.org/[encoded] to work. 
 +
 For example, if the non-encoded ARN is: `arn:aws:bedrock:us-east-2:123456789102:provisioned-model/3Ztr7hbzmkrqy1`

--- a/docs/assistant/security-assistant.asciidoc
+++ b/docs/assistant/security-assistant.asciidoc
@@ -223,3 +223,4 @@ In addition to practical advice, AI Assistant can offer conceptual advice, tips,
 
 
 include::ai-alert-triage.asciidoc[leveloffset=+1]
+include::connect-to-bedrock.asciidoc[leveloffset=+1]


### PR DESCRIPTION
Fixes #5113 by adding a page with step by step details for how to set up an Amazon Bedrock connector.

Preview:[Set up an Amazon Bedrock connector](https://security-docs_bk_5148.docs-preview.app.elstc.co/guide/en/security/master/assistant-connect-to-bedrock.html)