### PR TITLE
[Detection Rules] Adding Documents for v8.10.18 Pre-Built Detection Rules

### DIFF
--- a/docs/detections/prebuilt-rules/downloadable-packages/8-10-18/prebuilt-rules-8-10-18-appendix.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-10-18/prebuilt-rules-8-10-18-appendix.asciidoc
@@ -1,0 +1,6 @@
+["appendix",role="exclude",id="prebuilt-rule-8-10-18-prebuilt-rules-8-10-18-appendix"]
+= Downloadable rule update v8.10.18
+
+This section lists all updates associated with version 8.10.18 of the Fleet integration *Prebuilt Security Detection Rules*.
+
+

--- a/docs/detections/prebuilt-rules/downloadable-packages/8-10-18/prebuilt-rules-8-10-18-summary.asciidoc
+++ b/docs/detections/prebuilt-rules/downloadable-packages/8-10-18/prebuilt-rules-8-10-18-summary.asciidoc
@@ -1,0 +1,12 @@
+[[prebuilt-rule-8-10-18-prebuilt-rules-8-10-18-summary]]
+[role="xpack"]
+== Update v8.10.18
+
+This section lists all updates associated with version 8.10.18 of the Fleet integration *Prebuilt Security Detection Rules*.
+
+
+[width="100%",options="header"]
+|==============================================
+|Rule |Description |Status |Version
+
+|==============================================

--- a/docs/detections/prebuilt-rules/prebuilt-rules-downloadable-updates.asciidoc
+++ b/docs/detections/prebuilt-rules/prebuilt-rules-downloadable-updates.asciidoc
@@ -14,7 +14,8 @@ For previous rule updates, please navigate to the https://www.elastic.co/guide/e
 
 
 |<<prebuilt-rule-8-10-18-prebuilt-rules-8-10-18-summary, 8.10.18>> | 06 May 2024 | 0 | 0 | 
-This update bump is a result of an out of band update. This contains no new or modified rules required to update to this version.
+This version bump is a result of an out of band update.
+No rules require an update to this version.
 
 
 |<<prebuilt-rule-8-10-17-prebuilt-rules-8-10-17-summary, 8.10.17>> | 30 Apr 2024 | 2 | 2 | 

--- a/docs/detections/prebuilt-rules/prebuilt-rules-downloadable-updates.asciidoc
+++ b/docs/detections/prebuilt-rules/prebuilt-rules-downloadable-updates.asciidoc
@@ -13,6 +13,10 @@ For previous rule updates, please navigate to the https://www.elastic.co/guide/e
 |Update version |Date | New rules | Updated rules | Notes
 
 
+|<<prebuilt-rule-8-10-18-prebuilt-rules-8-10-18-summary, 8.10.18>> | 06 May 2024 | 0 | 0 | 
+update rules for 8.10 release
+
+
 |<<prebuilt-rule-8-10-17-prebuilt-rules-8-10-17-summary, 8.10.17>> | 30 Apr 2024 | 2 | 2 | 
 This release includes new rules for Linux and Windows and tuned rules for Linux. 
 New rules for Linux include detection for persistence. 
@@ -143,3 +147,4 @@ include::downloadable-packages/8-10-14/prebuilt-rules-8-10-14-summary.asciidoc[l
 include::downloadable-packages/8-10-15/prebuilt-rules-8-10-15-summary.asciidoc[leveloffset=+1]
 include::downloadable-packages/8-10-16/prebuilt-rules-8-10-16-summary.asciidoc[leveloffset=+1]
 include::downloadable-packages/8-10-17/prebuilt-rules-8-10-17-summary.asciidoc[leveloffset=+1]
+include::downloadable-packages/8-10-18/prebuilt-rules-8-10-18-summary.asciidoc[leveloffset=+1]

--- a/docs/detections/prebuilt-rules/prebuilt-rules-downloadable-updates.asciidoc
+++ b/docs/detections/prebuilt-rules/prebuilt-rules-downloadable-updates.asciidoc
@@ -14,8 +14,7 @@ For previous rule updates, please navigate to the https://www.elastic.co/guide/e
 
 
 |<<prebuilt-rule-8-10-18-prebuilt-rules-8-10-18-summary, 8.10.18>> | 06 May 2024 | 0 | 0 | 
-This out of band update is a result of an update for a more recent stack version.
-This contains no new or modified rules and there is no reason to update to this version.
+This update bump is a result of an out of band update. This contains no new or modified rules required to update to this version.
 
 
 |<<prebuilt-rule-8-10-17-prebuilt-rules-8-10-17-summary, 8.10.17>> | 30 Apr 2024 | 2 | 2 | 

--- a/docs/detections/prebuilt-rules/prebuilt-rules-downloadable-updates.asciidoc
+++ b/docs/detections/prebuilt-rules/prebuilt-rules-downloadable-updates.asciidoc
@@ -14,7 +14,8 @@ For previous rule updates, please navigate to the https://www.elastic.co/guide/e
 
 
 |<<prebuilt-rule-8-10-18-prebuilt-rules-8-10-18-summary, 8.10.18>> | 06 May 2024 | 0 | 0 | 
-update rules for 8.10 release
+This out of band update is a result of an update for a more recent stack version.
+This contains no new or modified rules and there is no reason to update to this version.
 
 
 |<<prebuilt-rule-8-10-17-prebuilt-rules-8-10-17-summary, 8.10.17>> | 30 Apr 2024 | 2 | 2 | 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -117,3 +117,5 @@ include::detections/prebuilt-rules/downloadable-packages/8-10-15/prebuilt-rules-
 include::detections/prebuilt-rules/downloadable-packages/8-10-16/prebuilt-rules-8-10-16-appendix.asciidoc[]
 
 include::detections/prebuilt-rules/downloadable-packages/8-10-17/prebuilt-rules-8-10-17-appendix.asciidoc[]
+
+include::detections/prebuilt-rules/downloadable-packages/8-10-18/prebuilt-rules-8-10-18-appendix.asciidoc[]


### PR DESCRIPTION
Security Doc updates for prebuilt security rule integration package version v8.10.18. Please note these are meant to merge into 8.10 only and not backport.