### PR TITLE
Deletes extraneous setup guide notes

### DIFF
--- a/docs/detections/api/rules/rules-api-bulk-actions.asciidoc
+++ b/docs/detections/api/rules/rules-api-bulk-actions.asciidoc
@@ -585,7 +585,7 @@ A rule can only be `skipped` when the bulk action to be performed on it results 
                "immutable":false,
                "related_integrations": [],       <1>
                "required_fields": [],            <1>
-               "setup": "",                      <1>
+               "setup": "",
                "type":"machine_learning",
                "anomaly_threshold":50,
                "machine_learning_job_id":[
@@ -626,7 +626,7 @@ A rule can only be `skipped` when the bulk action to be performed on it results 
 }
 --------------------------------------------------
 
-<1> dev:[] These fields are under development and their usage or schema may change: `related_integrations`, `required_fields`, `setup`, and `execution_summary`.
+<1> dev:[] These fields are under development and their usage or schema may change: `related_integrations`, `required_fields`, and `execution_summary`.
 
 
 For an `export` action, an `.ndjson` file containing exported rules.
@@ -753,7 +753,7 @@ If processing of any rule fails, a partial error outputs the ID and/or name of t
                     "immutable": false,
                     "related_integrations": [],       <1>
                     "required_fields": [],            <1>
-                    "setup": "",                      <1>
+                    "setup": "",
                     "type": "query",
                     "language": "kuery",
                     "index": [
@@ -797,7 +797,7 @@ If processing of any rule fails, a partial error outputs the ID and/or name of t
 }
 --------------------------------------------------
 
-<1> dev:[] These fields are under development and their usage or schema may change: `related_integrations`, `required_fields`, `setup`, and `execution_summary`.
+<1> dev:[] These fields are under development and their usage or schema may change: `related_integrations`, `required_fields`, and `execution_summary`.
 
 *Example 3, Dry run*
 

--- a/docs/detections/api/rules/rules-api-find.asciidoc
+++ b/docs/detections/api/rules/rules-api-find.asciidoc
@@ -98,7 +98,7 @@ Example response:
       "to": "now",
       "related_integrations": [],       <1>
       "required_fields": [],            <1>
-      "setup": "",                      <1>
+      "setup": "",
       "type": "query",
       "threat": [
         {
@@ -138,4 +138,4 @@ Example response:
 
 --------------------------------------------------
 
-<1> dev:[] These fields are under development and their usage or schema may change: `related_integrations`, `required_fields`, `setup`, and `execution_summary`.
+<1> dev:[] These fields are under development and their usage or schema may change: `related_integrations`, `required_fields`, and `execution_summary`.

--- a/docs/detections/api/rules/rules-api-get.asciidoc
+++ b/docs/detections/api/rules/rules-api-get.asciidoc
@@ -63,7 +63,7 @@ Example response:
   "rule_id": "process_started_by_ms_office_user_folder",
   "related_integrations": [],       <1>
   "required_fields": [],            <1>
-  "setup": "",                      <1>
+  "setup": "",
   "language": "kuery",
   "max_signals": 100,
   "risk_score": 21,
@@ -113,4 +113,4 @@ Example response:
 
 --------------------------------------------------
 
-<1> dev:[] These fields are under development and their usage or schema may change: `related_integrations`, `required_fields`, `setup`, and `execution_summary`.
+<1> dev:[] These fields are under development and their usage or schema may change: `related_integrations`, `required_fields`, and `execution_summary`.


### PR DESCRIPTION
Removes remaining setup guide notes and labels that were accidentally not included in https://github.com/elastic/security-docs/pull/5095