### PR TITLE
Adds note to legacy risk scoring docs

### DIFF
--- a/docs/experimental-features/host-risk-score.asciidoc
+++ b/docs/experimental-features/host-risk-score.asciidoc
@@ -1,6 +1,9 @@
 [[host-risk-score]]
 == Host risk score
 
+NOTE: This page refers to the original user and host risk score modules. If you have the original modules installed, and you're running {stack} version 8.11 or newer, you can <<upgrade-risk-engine, upgrade to the latest risk scoring engine>>.
+For information about the latest risk engine, refer to <<entity-risk-scoring, Entity risk scoring>>.
+
 NOTE: This feature is available for {stack} versions 7.16.0 and newer and requires a https://www.elastic.co/pricing[Platinum subscription] or higher.
 
 The host risk score feature highlights risky hosts from within your environment. It utilizes a transform with a scripted metric aggregation to calculate host risk scores based on alerts that were generated within the past five days. The transform runs hourly to update the score as new alerts are generated.

--- a/docs/experimental-features/user-risk-score.asciidoc
+++ b/docs/experimental-features/user-risk-score.asciidoc
@@ -1,6 +1,9 @@
 [[user-risk-score]]
 == User risk score
 
+NOTE: This page refers to the original user and host risk score modules. If you have the original modules installed, and you're running {stack} version 8.11 or newer, you can <<upgrade-risk-engine, upgrade to the latest risk scoring engine>>.
+For information about the latest risk engine, refer to <<entity-risk-scoring, Entity risk scoring>>.
+
 NOTE: This feature is available for {stack} versions 8.3.0 and newer and requires a https://www.elastic.co/pricing[Platinum subscription] or higher.
 
 The user risk score feature highlights risky usernames in your environment. It utilizes a transform with a scripted metric aggregation to calculate user risk scores based on alerts generated within the past 90 days. The transform runs hourly to update scores as new alerts are generated.


### PR DESCRIPTION
Resolves https://github.com/elastic/security-docs/issues/5191.

Previews:
* [Host risk score](https://security-docs_bk_5209.docs-preview.app.elstc.co/guide/en/security/master/host-risk-score.html)
* [User risk score](https://security-docs_bk_5209.docs-preview.app.elstc.co/guide/en/security/master/user-risk-score.html)

No twin serverless PR since these docs don't exist in serverless.