### PR TITLE
[8.14] Introduces AWS GovCloud support for CSPM

### DIFF
--- a/docs/cloud-native-security/cspm-get-started-aws.asciidoc
+++ b/docs/cloud-native-security/cspm-get-started-aws.asciidoc
@@ -12,7 +12,7 @@ This page explains how to get started monitoring the security posture of your cl
 --
 * The CSPM integration is available to all {ecloud} users. On-premise deployments require an https://www.elastic.co/pricing[Enterprise subscription].
 * CSPM only works in the `Default` {kib} space. Installing the CSPM integration on a different {kib} space will not work. 
-* CSPM is supported on commercial cloud only. Government cloud is not supported (https://github.com/elastic/enhancements[request support]).
+* CSPM is supported only on AWS, GCP, and Azure commercial cloud platforms, and AWS GovCloud. Other government cloud platforms are not supported (https://github.com/elastic/kibana/issues/new/choose[request support]).
 * To view posture data, you need `read` privileges for the following {es} indices:
 ** `logs-cloud_security_posture.findings_latest-*`
 ** `logs-cloud_security_posture.scores-*`

--- a/docs/cloud-native-security/cspm-get-started-aws.asciidoc
+++ b/docs/cloud-native-security/cspm-get-started-aws.asciidoc
@@ -12,7 +12,7 @@ This page explains how to get started monitoring the security posture of your cl
 --
 * The CSPM integration is available to all {ecloud} users. On-premise deployments require an https://www.elastic.co/pricing[Enterprise subscription].
 * CSPM only works in the `Default` {kib} space. Installing the CSPM integration on a different {kib} space will not work. 
-* CSPM is supported only on AWS, GCP, and Azure commercial cloud platforms, and AWS GovCloud. Other government cloud platforms are not supported (https://github.com/elastic/kibana/issues/new/choose[request support]).
+* CSPM is supported only on AWS, GCP, and Azure commercial cloud platforms, and AWS GovCloud. Other government cloud platforms are not supported. https://github.com/elastic/kibana/issues/new/choose[Click here to request support].
 * To view posture data, you need `read` privileges for the following {es} indices:
 ** `logs-cloud_security_posture.findings_latest-*`
 ** `logs-cloud_security_posture.scores-*`

--- a/docs/cloud-native-security/cspm-get-started-azure.asciidoc
+++ b/docs/cloud-native-security/cspm-get-started-azure.asciidoc
@@ -12,7 +12,7 @@ This page explains how to get started monitoring the security posture of your cl
 --
 * The CSPM integration is available to all {ecloud} users. On-premise deployments require an https://www.elastic.co/pricing[Enterprise subscription].
 * CSPM only works in the `Default` {kib} space. Installing the CSPM integration on a different {kib} space will not work. 
-* CSPM is supported on commercial cloud only. Government cloud is not supported (https://github.com/elastic/enhancements[request support]).
+* CSPM is supported only on AWS, GCP, and Azure commercial cloud platforms, and AWS GovCloud. Other government cloud platforms are not supported (https://github.com/elastic/kibana/issues/new/choose[request support]).
 * To view posture data, you need `read` privileges for the following {es} indices:
 ** `logs-cloud_security_posture.findings_latest-*`
 ** `logs-cloud_security_posture.scores-*`

--- a/docs/cloud-native-security/cspm-get-started-azure.asciidoc
+++ b/docs/cloud-native-security/cspm-get-started-azure.asciidoc
@@ -12,7 +12,7 @@ This page explains how to get started monitoring the security posture of your cl
 --
 * The CSPM integration is available to all {ecloud} users. On-premise deployments require an https://www.elastic.co/pricing[Enterprise subscription].
 * CSPM only works in the `Default` {kib} space. Installing the CSPM integration on a different {kib} space will not work. 
-* CSPM is supported only on AWS, GCP, and Azure commercial cloud platforms, and AWS GovCloud. Other government cloud platforms are not supported (https://github.com/elastic/kibana/issues/new/choose[request support]).
+* CSPM is supported only on AWS, GCP, and Azure commercial cloud platforms, and AWS GovCloud. Other government cloud platforms are not supported. https://github.com/elastic/kibana/issues/new/choose[Click here to request support].
 * To view posture data, you need `read` privileges for the following {es} indices:
 ** `logs-cloud_security_posture.findings_latest-*`
 ** `logs-cloud_security_posture.scores-*`

--- a/docs/cloud-native-security/cspm-get-started-gcp.asciidoc
+++ b/docs/cloud-native-security/cspm-get-started-gcp.asciidoc
@@ -12,7 +12,7 @@ This page explains how to get started monitoring the security posture of your GC
 --
 * The CSPM integration is available to all {ecloud} users. On-premise deployments require an https://www.elastic.co/pricing[Enterprise subscription].
 * CSPM only works in the `Default` {kib} space. Installing the CSPM integration on a different {kib} space will not work. 
-* CSPM is supported only on AWS, GCP, and Azure commercial cloud platforms, and AWS GovCloud. Other government cloud platforms are not supported (https://github.com/elastic/kibana/issues/new/choose[request support]).
+* CSPM is supported only on AWS, GCP, and Azure commercial cloud platforms, and AWS GovCloud. Other government cloud platforms are not supported. https://github.com/elastic/kibana/issues/new/choose[Click here to request support].
 * To view posture data, you need `read` privileges for the following {es} indices:
 ** `logs-cloud_security_posture.findings_latest-*`
 ** `logs-cloud_security_posture.scores-*`

--- a/docs/cloud-native-security/cspm-get-started-gcp.asciidoc
+++ b/docs/cloud-native-security/cspm-get-started-gcp.asciidoc
@@ -12,7 +12,7 @@ This page explains how to get started monitoring the security posture of your GC
 --
 * The CSPM integration is available to all {ecloud} users. On-premise deployments require an https://www.elastic.co/pricing[Enterprise subscription].
 * CSPM only works in the `Default` {kib} space. Installing the CSPM integration on a different {kib} space will not work. 
-* CSPM is supported on commercial cloud only. Government cloud is not supported (https://github.com/elastic/enhancements[request support]).
+* CSPM is supported only on AWS, GCP, and Azure commercial cloud platforms, and AWS GovCloud. Other government cloud platforms are not supported (https://github.com/elastic/kibana/issues/new/choose[request support]).
 * To view posture data, you need `read` privileges for the following {es} indices:
 ** `logs-cloud_security_posture.findings_latest-*`
 ** `logs-cloud_security_posture.scores-*`

--- a/docs/cloud-native-security/cspm.asciidoc
+++ b/docs/cloud-native-security/cspm.asciidoc
@@ -11,7 +11,7 @@ This feature currently supports Amazon Web Services (AWS), Google Cloud Platform
 * CSPM is available to all {ecloud} users. On-premise deployments require an https://www.elastic.co/pricing[Enterprise subscription].
 * {stack} version 8.10 or greater.
 * CSPM only works in the `Default` {kib} space. Installing the CSPM integration on a different {kib} space will not work. 
-* CSPM is supported only on AWS, GCP, and Azure commercial cloud platforms, and AWS GovCloud. Other government cloud platforms are not supported (https://github.com/elastic/kibana/issues/new/choose[request support]).
+* CSPM is supported only on AWS, GCP, and Azure commercial cloud platforms, and AWS GovCloud. Other government cloud platforms are not supported. https://github.com/elastic/kibana/issues/new/choose[Click here to request support].
 --
 
 [discrete]

--- a/docs/cloud-native-security/cspm.asciidoc
+++ b/docs/cloud-native-security/cspm.asciidoc
@@ -11,7 +11,7 @@ This feature currently supports Amazon Web Services (AWS), Google Cloud Platform
 * CSPM is available to all {ecloud} users. On-premise deployments require an https://www.elastic.co/pricing[Enterprise subscription].
 * {stack} version 8.10 or greater.
 * CSPM only works in the `Default` {kib} space. Installing the CSPM integration on a different {kib} space will not work. 
-* CSPM is supported on commercial cloud only. Government cloud is not supported (https://github.com/elastic/enhancements[request support]).
+* CSPM is supported only on AWS, GCP, and Azure commercial cloud platforms, and AWS GovCloud. Other government cloud platforms are not supported (https://github.com/elastic/kibana/issues/new/choose[request support]).
 --
 
 [discrete]

--- a/docs/cloud-native-security/kspm-get-started.asciidoc
+++ b/docs/cloud-native-security/kspm-get-started.asciidoc
@@ -7,7 +7,7 @@ This page explains how to configure the Kubernetes Security Posture Management (
 --
 * The KSPM integration is available to all Elastic Cloud users. For on-prem deployments, it requires an https://www.elastic.co/pricing[Enterprise subscription].
 * The KSPM integration only works in the `Default` Kibana space. Installing the KSPM integration on a different Kibana space will not work.
-* KSPM is not supported on EKS clusters in AWS GovCloud (https://github.com/elastic/kibana/issues/new/choose[request support]).
+* KSPM is not supported on EKS clusters in AWS GovCloud. https://github.com/elastic/kibana/issues/new/choose[Click here to request support].
 * To view posture data, ensure you have the `read` privilege for the following {es} indices:
 
 - `logs-cloud_security_posture.findings_latest-*`

--- a/docs/cloud-native-security/kspm-get-started.asciidoc
+++ b/docs/cloud-native-security/kspm-get-started.asciidoc
@@ -7,7 +7,7 @@ This page explains how to configure the Kubernetes Security Posture Management (
 --
 * The KSPM integration is available to all Elastic Cloud users. For on-prem deployments, it requires an https://www.elastic.co/pricing[Enterprise subscription].
 * The KSPM integration only works in the `Default` Kibana space. Installing the KSPM integration on a different Kibana space will not work.
-* KSPM is not supported on EKS clusters in AWS Government Cloud (https://github.com/elastic/enhancements[request support for government cloud]).
+* KSPM is not supported on EKS clusters in AWS GovCloud (https://github.com/elastic/kibana/issues/new/choose[request support]).
 * To view posture data, ensure you have the `read` privilege for the following {es} indices:
 
 - `logs-cloud_security_posture.findings_latest-*`

--- a/docs/cloud-native-security/kspm.asciidoc
+++ b/docs/cloud-native-security/kspm.asciidoc
@@ -13,7 +13,7 @@ This integration supports Amazon EKS and unmanaged Kubernetes clusters. For setu
 [sidebar]
 --
 * The KSPM integration is available to all Elastic Cloud users. For on-prem deployments, it requires an https://www.elastic.co/pricing[Enterprise subscription].
-* KSPM is not supported on EKS clusters in AWS Government Cloud (https://github.com/elastic/enhancements[request support for government cloud]).
+* KSPM is not supported on EKS clusters in AWS GovCloud (https://github.com/elastic/kibana/issues/new/choose[request support]).
 --
 
 [discrete]

--- a/docs/cloud-native-security/kspm.asciidoc
+++ b/docs/cloud-native-security/kspm.asciidoc
@@ -13,7 +13,7 @@ This integration supports Amazon EKS and unmanaged Kubernetes clusters. For setu
 [sidebar]
 --
 * The KSPM integration is available to all Elastic Cloud users. For on-prem deployments, it requires an https://www.elastic.co/pricing[Enterprise subscription].
-* KSPM is not supported on EKS clusters in AWS GovCloud (https://github.com/elastic/kibana/issues/new/choose[request support]).
+* KSPM is not supported on EKS clusters in AWS GovCloud. https://github.com/elastic/kibana/issues/new/choose[Click here to request support].
 --
 
 [discrete]


### PR DESCRIPTION
Fixes #5102. Twin PR of [353](https://github.com/elastic/staging-serverless-security-docs/pull/353)

Minor changes, directly ported from the twin PR with no differences other than asciidoc / MDX syntax.