### PR TITLE
[DO NOT MERGE] Update publish_docs_co.yml to point to elastic.co/docs

### DIFF
--- a/.github/workflows/co-docs-builder.yml
+++ b/.github/workflows/co-docs-builder.yml
@@ -21,11 +21,16 @@ on:
 jobs:
   publish:
     if: contains(github.event.pull_request.labels.*.name, 'ci:doc-build')
-    uses: elastic/workflows/.github/workflows/docs-elastic-co-publish.yml@main
+    uses: elastic/workflows/.github/workflows/docs-versioned-publish.yml@main
     with:
-      subdirectory: 'docs/serverless/'
+      # Refers to Vercel project
+      project-name: elastic-dot-co-docs-preview-docs
+      # Which prebuild step (dev or not)
+      prebuild: wordlake-docs
+      # Docsmobile project dir
+      site-repo: docs-site    
     secrets:
       VERCEL_GITHUB_TOKEN: ${{ secrets.VERCEL_GITHUB_TOKEN_PUBLIC }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PUBLIC }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID_PUBLIC }}
-      VERCEL_PROJECT_ID_DOCS_CO: ${{ secrets.VERCEL_PROJECT_ID_DOCS_CO_PUBLIC }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_ELASTIC_DOT_CO_DOCS_PRODUCTION_PUBLIC }}


### PR DESCRIPTION
We are migrating the content from docs.elastic.co to elastic.co/docs on Wednesday, June 12, 2024. As a part of this, will be having a content freeze while we switch out hosting providers. 

This PR will need to be merged during the freeze to facilitate that move.