### PR TITLE
Adds a video demo to the AD docs

### DIFF
--- a/docs/attack-discovery/attack-discovery.asciidoc
+++ b/docs/attack-discovery/attack-discovery.asciidoc
@@ -9,9 +9,23 @@
 
 preview::["This feature is in technical preview. It may change in the future, and you should exercise caution when using it in production environments. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of GA features."]
 
-NOTE: This feature is available starting with {elastic-sec} version 8.14.0.
-
 Attack discovery leverages large language models (LLMs) to analyze alerts in your environment and identify threats. Each "discovery" represents a potential attack and describes relationships among multiple alerts to tell you which users and hosts are involved, how alerts correspond to the MITRE ATT&CK matrix, and which threat actor might be responsible. This can help make the most of each security analyst's time, fight alert fatigue, and reduce your mean time to respond.
+
+For a demo, refer to the following video.
+=======
+++++
+<script type="text/javascript" async src="https://play.vidyard.com/embed/v4.js"></script>
+<img
+  style="width: 100%; margin: auto; display: block;"
+  class="vidyard-player-embed"
+  src="https://play.vidyard.com/eT92arEbpRddmSM4JeyzdX.jpg"
+  data-uuid="eT92arEbpRddmSM4JeyzdX"
+  data-v="4"
+  data-type="inline"
+/>
+</br>
+++++
+=======
 
 This page describes:
 

--- a/docs/attack-discovery/attack-discovery.asciidoc
+++ b/docs/attack-discovery/attack-discovery.asciidoc
@@ -52,7 +52,7 @@ image::images/select-model-empty-state.png[]
 +
 . Once you've selected a connector, click **Generate** to start the analysis.
 
-It may take from a few seconds up to several minutes to generate discoveries, depending on the number of alerts and the model you selected. Note that Attack discovery only analyzes alerts from the past 24 hours.
+It may take from a few seconds up to several minutes to generate discoveries, depending on the number of alerts and the model you selected. Note that Attack discovery is in technical preview and will only analyze opened and acknowleged alerts from the past 24 hours.
 
 IMPORTANT: Attack discovery uses the same data anonymization settings as <<security-assistant, Elastic AI Assistant>>. To configure which alert fields are sent to the LLM and which of those fields are obfuscated, use the Elastic AI Assistant settings. Consider the privacy policies of third-party LLMs before sending them sensitive data.
 

--- a/docs/serverless/attack-discovery/attack-discovery.mdx
+++ b/docs/serverless/attack-discovery/attack-discovery.mdx
@@ -42,7 +42,7 @@ While Attack discovery is compatible with many different models, our testing fou
 
 3. Once you've selected a connector, click **Generate** to start the analysis. 
 
-It may take from a few seconds up to several minutes to generate discoveries, depending on the number of alerts and the model you selected. Note that Attack discovery only analyzes alerts from the past 24 hours.
+It may take from a few seconds up to several minutes to generate discoveries, depending on the number of alerts and the model you selected. Note that Attack discovery is in technical preview and will only analyze opened and acknowleged alerts from the past 24 hours.
 
 
 <DocCallOut title="Important">

--- a/docs/serverless/attack-discovery/attack-discovery.mdx
+++ b/docs/serverless/attack-discovery/attack-discovery.mdx
@@ -15,6 +15,9 @@ This feature is in technical preview. It may change in the future, and you shoul
 
 Attack discovery leverages large language models (LLMs) to analyze alerts in your environment and identify threats. Each "discovery" represents a potential attack and describes relationships among multiple alerts to tell you which users and hosts are involved, how alerts correspond to the MITRE ATT&CK matrix, and which threat actor might be responsible. This can help make the most of each security analyst's time, fight alert fatigue, and reduce your mean time to respond.
 
+For a demo, refer to the following video.
+<DocVideo id="eT92arEbpRddmSM4JeyzdX" source="vidyard"/>
+
 This page describes:
 
 - <DocLink id="attackDiscovery" section="generate-discoveries">How to start generating discoveries</DocLink>


### PR DESCRIPTION
Fixes #5336 by adding a video demo to the AD docs as requested by James S. The video gives an overview of how AD works and shows it in action. I added it at the top of the page. This update affects both ESS and serverless docs.

Also fixes #5361 by making a minor change to how we discuss AD's 24-hour lookback window for alerts.

Preview: [ESS](https://security-docs_bk_5362.docs-preview.app.elstc.co/guide/en/security/master/attack-discovery.html), [Serverless](https://docs-elastic-8f8lv4mbt-elastic-dev.vercel.app/serverless/security/attack-discovery)