### PR TITLE
[7.9] fix: remove ndjson.org (#5376)

### DIFF
--- a/docs/events/timeline-templates.asciidoc
+++ b/docs/events/timeline-templates.asciidoc
@@ -125,8 +125,7 @@ NOTE: You cannot delete prebuilt templates.
 === Export and import Timeline templates
 
 You can import and export Timeline templates, which enables importing templates
-from one {kib} space or instance to another. Exported templates are saved in an
-http://ndjson.org[`ndjson`] file.
+from one {kib} space or instance to another. Exported templates are saved in an `ndjson` file.
 
 . Go to *Security* -> *Timelines*.
 . Click the *Templates* tab.

--- a/docs/events/timeline-ui-overview.asciidoc
+++ b/docs/events/timeline-ui-overview.asciidoc
@@ -145,9 +145,8 @@ then the required action from the _Bulk actions_ menu.
 [[import-export-timelines]]
 == Export and import Timelines
 
-You can import and export Timelines, which enables importing Timelines from one
-{kib} space or instance to another. Exported Timelines are saved in an
-http://ndjson.org[`ndjson`] file.
+You can export and import Timelines, which enables you to share Timelines from one
+{kib} space or instance to another. Exported Timelines are saved as `.ndjson` files.
 
 . Go to *Security* -> *Timelines*.
 . To export Timelines, do one of the following:

--- a/docs/getting-started/siem-ui.asciidoc
+++ b/docs/getting-started/siem-ui.asciidoc
@@ -299,8 +299,7 @@ drop area for further introspection.
 ==== Export and import timelines
 
 You can import and export timelines, which enables importing timelines from one
-{kib} space or instance to another. Exported timelines are saved in an
-http://ndjson.org[`ndjson`] file.
+{kib} space or instance to another. Exported Timelines are saved in an `ndjson` file.
 
 . Go to *SIEM* -> *Timelines*.
 . To export timelines, do one of the following:


### PR DESCRIPTION
Backports the following commits to 7.9:
 - fix: remove ndjson.org (#5376)