### PR TITLE
Fix backport config file in 7.17 branch

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,5 +1,5 @@
 {
   "upstream": "elastic/security-docs",
-  "branches": [{ "name": "7.16", "checked": true }, "7.15", "7.14", "7.13", "7.12", "7.11", "7.10", "7.8"],
+  "branches": [{ "name": "7.17", "checked": true }, "7.16", "7.15", "7.14", "7.13", "7.12", "7.11", "7.10", "7.9", "7.8"],
   "labels": ["backport"]
 }

--- a/docs/es-overview.asciidoc
+++ b/docs/es-overview.asciidoc
@@ -6,7 +6,7 @@ Elastic Security combines SIEM threat detection features with endpoint
 prevention and response capabilities in one solution. These analytical and
 protection capabilities, leveraged by the speed and extensibility of
 Elasticsearch, enable analysts to defend their organization from threats before
-damage and loss occur.
+damage and loss occur. 
 
 Elastic Security provides the following security benefits and capabilities:
 


### PR DESCRIPTION
This PR updates the backport tool's config file (`.backportrc.json`) with these fixes:
- Adds missing 7.9 branch
- Makes 7.17 the default/checked branch

(I accidentally called this the .gitignore file in the commit message 🙃 )