### PR TITLE
[7.12] Fixes `comments` description in Update exception item API (#5365)

### DIFF
--- a/docs/detections/api/exceptions/api-update-exception-item.asciidoc
+++ b/docs/detections/api/exceptions/api-update-exception-item.asciidoc
@@ -15,11 +15,11 @@ NOTE: The {kib} Console supports only Elasticsearch APIs. You cannot interact wi
 |==============================================
 |Name |Type |Description |Required
 
-|`comments` |comments[] a|Array of `comment` fields:
+|`comments` |comments[] a|Array of comments to be appended:
 
 * `comment` (string): Comments about the exception item.
-* `id` (string): Existing comment ID, required for updating existing comments.
-When unspecified, a new comment is created.
+
+NOTE: Comments cannot be modified—they can only be appended.
 
 |No, defaults to empty array.
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.12`:
 - [Fixes &#x60;comments&#x60; description in Update exception item API (#5365)](https://github.com/elastic/security-docs/pull/5365)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)