### PR TITLE
Update .gitignore to `7.8` branch 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .DS_Store
+docs/html_docs
+/html_docs
+.vscode/
+.vs/


### PR DESCRIPTION
Updates the `.gitignore` file ...just in case we ever need to backport to the SIEM guide, though unlikely. :-)