### PR TITLE
[7.11] Fixes `comments` description in Update exception item API (#5365)

### DIFF
--- a/docs/detections/api/exceptions/api-update-exception-item.asciidoc
+++ b/docs/detections/api/exceptions/api-update-exception-item.asciidoc
@@ -13,11 +13,11 @@ Updates an existing exception item.
 |==============================================
 |Name |Type |Description |Required
 
-|`comments` |comments[] a|Array of `comment` fields:
+|`comments` |comments[] a|Array of comments to be appended:
 
 * `comment` (string): Comments about the exception item.
-* `id` (string): Existing comment ID, required for updating existing comments.
-When unspecified, a new comment is created.  
+
+NOTE: Comments cannot be modified—they can only be appended.
 
 |No, defaults to empty array.
 


### PR DESCRIPTION
Backports the following PR to 7.11:

* https://github.com/elastic/security-docs/pull/5365