### PR TITLE
Update link in 8.8 release notes

### DIFF
--- a/docs/release-notes/8.8.asciidoc
+++ b/docs/release-notes/8.8.asciidoc
@@ -485,7 +485,7 @@ NOTE: To avoid further issues, _do not_ re-add the `file.name` field to the tabl
 * Session view: Makes the row representing the session leader remain visible when you scroll past it, and adds a button to this row that allows you to collapse child processes ({kibana-pull}154982[#154982]).
 * Reduces Linux process event volume by about 50% by combining `fork`, `exec`, and `end` events when they occur around the same time (does not affect queries of this data) ({kibana-pull}153213[#153213]).
 * Updates where the technical preview tags appear for host risk score features ({kibana-pull}156659[#156659], {kibana-pull}156514[#156514]).
-* Allows you to use fully qualified domain names (FQDNs) for hosts. To learn how to enable the FQDN feature flag, refer to {fleet-guide}/elastic-agent-standalone-feature-flags.html[Configure feature flags for standalone {agents}]. To learn how to set host names in {fleet}, refer to {fleet-guide}/fleet-settings.html#fleet-agent-hostname-format-settings[Agent Binary Download {fleet} settings]. 
+* Allows you to use fully qualified domain names (FQDNs) for hosts. To learn how to set a host name format in {fleet}, refer to {fleet-guide}/agent-policy.html[Elastic Agent policies]. 
 
 [discrete]
 [[bug-fixes-8.8.0]]


### PR DESCRIPTION
This link points to a setting that I accidently put into the wrong area of the Fleet & Agent docs. I plan to [fix that](https://github.com/elastic/ingest-docs/pull/1092), but before I can, I need to update this link in order not to bust up our docs build.

This link originates in version 8.8 so I hope it's okay to backport to there.