### PR TITLE
Adds callout to legacy risk score troubleshooting docs

### DIFF
--- a/docs/experimental-features/host-risk-score.asciidoc
+++ b/docs/experimental-features/host-risk-score.asciidoc
@@ -164,6 +164,11 @@ image::images/data-tables.png[]
 [discrete]
 === Troubleshooting
 
+[sidebar]
+--
+These steps refer to the original host risk score module.
+--
+
 During the installation or upgrade process, you may receive the following error messages:
 
 * `Saved object already exists`

--- a/docs/experimental-features/user-risk-score.asciidoc
+++ b/docs/experimental-features/user-risk-score.asciidoc
@@ -147,6 +147,11 @@ image::images/dashboard.gif[User risk score dashboard]
 [discrete]
 === Troubleshooting
 
+[sidebar]
+--
+These steps refer to the original user risk score module.
+--
+
 During the installation or upgrade process, you may receive the following error messages:
 
 * `Saved object already exists`


### PR DESCRIPTION
Contributes to https://github.com/elastic/security-docs/issues/5489.

Per [this comment](https://github.com/elastic/security-docs/issues/5489#issuecomment-2206066166), adds a callout to the legacy host and user risk score troubleshooting docs to explicitly state that those steps apply to the legacy modules. 

Previews:

ESS only – these pages don't exist in serverless docs.