### PR TITLE
SentinelOne `get-file` response action [classic]

### DIFF
--- a/docs/management/admin/response-actions.asciidoc
+++ b/docs/management/admin/response-actions.asciidoc
@@ -106,9 +106,17 @@ Required privilege: *Process Operations*
 Example: `suspend-process --pid 123 --comment "Suspend suspicious process"`
 
 [discrete]
+[[get-file]]
 === `get-file`
 
 Retrieve a file from a host. Files are downloaded in a password-protected `.zip` archive to prevent the file from running. Use password `elastic` to open the `.zip` in a safe environment.
+
+[NOTE]
+====
+Files retrieved from third-party-protected hosts require a different password. Refer to the following:
+
+* <<sentinelone-response-actions>>
+====
 
 You must include the following parameter to specify the file's location on the host:
 

--- a/docs/management/admin/third-party-actions.asciidoc
+++ b/docs/management/admin/third-party-actions.asciidoc
@@ -14,6 +14,12 @@ preview::[]
 
 You can direct SentinelOne to perform response actions on protected hosts without leaving the {elastic-sec} UI. Prior <<response-actions-config,configuration>> is required to connect {elastic-sec} with SentinelOne.
 
+.Requirements
+[sidebar]
+--
+Third-party response actions require an https://www.elastic.co/pricing[Enterprise subscription], and each response action type has its own user role privilege requirements. Refer to <<response-actions>> for more information.
+--
+
 The following response actions and related features are supported for SentinelOne-protected hosts:
 
 * **Isolate and release a host** using any of these methods:
@@ -24,5 +30,9 @@ The following response actions and related features are supported for SentinelOn
 --
 +
 Refer to the instructions on <<isolate-a-host,isolating>> and <<release-a-host,releasing>> hosts for more details.
+
+* **Retrieve a file from a host** with the <<get-file,`get-file` response action>>.
++
+NOTE: For SentinelOne-protected hosts, you must use the password `Elastic@123` to open the retrieved file.
 
 * **View past response action activity** in the <<response-actions-history,response actions history>> log.


### PR DESCRIPTION
Contributes to https://github.com/elastic/security-docs/issues/5359.

Not looking for any further changes, just code owner approval to unblock. This is a twin of the serverless PR: https://github.com/elastic/security-docs/pull/5444, which has already been approved and merged.

