### PR TITLE
Updates note about number of alerts AD can analyze

### DIFF
--- a/docs/AI-for-security/attack-discovery.asciidoc
+++ b/docs/AI-for-security/attack-discovery.asciidoc
@@ -52,7 +52,11 @@ image::images/select-model-empty-state.png[]
 +
 . Once you've selected a connector, click **Generate** to start the analysis.
 
-It may take from a few seconds up to several minutes to generate discoveries, depending on the number of alerts and the model you selected. Note that Attack discovery is in technical preview and will only analyze opened and acknowleged alerts from the past 24 hours.
+It may take from a few seconds up to several minutes to generate discoveries, depending on the number of alerts and the model you selected. 
+
+IMPORTANT: Attack discovery is in technical preview and will only analyze opened and acknowleged alerts from the past 24 hours. By default it only analyzes up to 20 alerts within this timeframe, but you can expand this up to 100 by going to **AI Assistant → Settings (image:images/icon-settings.png[Settings icon,17,17]) → Knowledge Base** and updating the **Alerts** setting.
+
+image::images/knowledge-base-settings.png["AI Assistant's settings menu open to the Knowledge Base tab",75%]
 
 IMPORTANT: Attack discovery uses the same data anonymization settings as <<security-assistant, Elastic AI Assistant>>. To configure which alert fields are sent to the LLM and which of those fields are obfuscated, use the Elastic AI Assistant settings. Consider the privacy policies of third-party LLMs before sending them sensitive data.
 


### PR DESCRIPTION
Fixes #5481 by updating the note about how many alerts AD can analyze to add instructions for adjusting that number.

Preview: 