### PR TITLE
[Serverless] Updates D4C badge from tech preview to beta 

### DIFF
--- a/docs/serverless/cloud-native-security/d4c-get-started.mdx
+++ b/docs/serverless/cloud-native-security/d4c-get-started.mdx
@@ -8,7 +8,8 @@ status: in review
 
 <DocBadge template="technical preview" />
 
-<DocCallOut template="beta" />
+<DocBadge template="beta" />
+
 <div id="d4c-get-started"></div>
 
 This page describes how to set up Cloud Workload Protection (CWP) for Kubernetes.

--- a/docs/serverless/cloud-native-security/d4c-get-started.mdx
+++ b/docs/serverless/cloud-native-security/d4c-get-started.mdx
@@ -6,7 +6,7 @@ tags: ["security","how-to","get-started", "cloud security"]
 status: in review
 ---
 
-<DocBadge template="technical preview" />
+<DocBadge template="beta" />
 <div id="d4c-get-started"></div>
 
 This page describes how to set up Cloud Workload Protection (CWP) for Kubernetes.

--- a/docs/serverless/cloud-native-security/d4c-get-started.mdx
+++ b/docs/serverless/cloud-native-security/d4c-get-started.mdx
@@ -6,7 +6,9 @@ tags: ["security","how-to","get-started", "cloud security"]
 status: in review
 ---
 
-<DocBadge template="beta" />
+<DocBadge template="technical preview" />
+
+<DocCallOut template="beta" />
 <div id="d4c-get-started"></div>
 
 This page describes how to set up Cloud Workload Protection (CWP) for Kubernetes.

--- a/docs/serverless/cloud-native-security/d4c-overview.mdx
+++ b/docs/serverless/cloud-native-security/d4c-overview.mdx
@@ -6,7 +6,7 @@ tags: ["security","cloud","reference","manage"]
 status: in review
 ---
 
-<DocBadge template="technical preview" />
+<DocBadge template="beta" />
 <div id="d4c-overview"></div>
 
 Elastic Cloud Workload Protection (CWP) for Kubernetes provides cloud-native runtime protections for containerized environments by identifying and optionally blocking unexpected system behavior in Kubernetes containers.

--- a/docs/serverless/cloud-native-security/d4c-overview.mdx
+++ b/docs/serverless/cloud-native-security/d4c-overview.mdx
@@ -8,7 +8,8 @@ status: in review
 
 <DocBadge template="technical preview" />
 
-<DocCallOut template="beta" />
+<DocBadge template="beta" />
+
 <div id="d4c-overview"></div>
 
 Elastic Cloud Workload Protection (CWP) for Kubernetes provides cloud-native runtime protections for containerized environments by identifying and optionally blocking unexpected system behavior in Kubernetes containers.

--- a/docs/serverless/cloud-native-security/d4c-overview.mdx
+++ b/docs/serverless/cloud-native-security/d4c-overview.mdx
@@ -6,7 +6,9 @@ tags: ["security","cloud","reference","manage"]
 status: in review
 ---
 
-<DocBadge template="beta" />
+<DocBadge template="technical preview" />
+
+<DocCallOut template="beta" />
 <div id="d4c-overview"></div>
 
 Elastic Cloud Workload Protection (CWP) for Kubernetes provides cloud-native runtime protections for containerized environments by identifying and optionally blocking unexpected system behavior in Kubernetes containers.


### PR DESCRIPTION
Fixes #5454 by updating the tech preview badge to beta for D4C docs (serverless)

Previews: [D4C overview](https://elastic-dot-co-docs-production-3icqoy3dk-elastic-dev.vercel.app/current/serverless/security/d4c-overview), [get started with D4C](https://elastic-dot-co-docs-production-3icqoy3dk-elastic-dev.vercel.app/current/serverless/security/d4c-get-started)