### PR TITLE
Remove cloud shell editor deprecation notification

### DIFF
--- a/docs/cloud-native-security/cspm-get-started-gcp.asciidoc
+++ b/docs/cloud-native-security/cspm-get-started-gcp.asciidoc
@@ -59,13 +59,6 @@ For most users, the simplest option is to use a Google Cloud Shell script to aut
 . Check the box to trust Elastic's `cloudbeat` repo, then click **Confirm**
 +
 image::images/cspm-cloudshell-trust.png[The cloud shell confirmation popup]
-+
-NOTE: Google has deprecated its old Cloud Shell editor. If you continue to use it, you may encounter the following message:
-+
-image::images/cspm-cloudshell-old-editor.png[The cloud shell switch editor popup]
-+
-If the message appears, click **X** or **Try the new Editor** and follow the next steps. When you switch to the new editor, your context should remain unchanged.
-. In Google Cloud Shell, execute the command you copied. Once it finishes, return to {kib} and wait for the confirmation of data received from your new integration. Then you can click **View Assets** to see your data.
 
 NOTE: If you encounter any issues running the command, return to {kib} and navigate again to Google Cloud Shell.
 

--- a/docs/cloud-native-security/cspm-get-started-gcp.asciidoc
+++ b/docs/cloud-native-security/cspm-get-started-gcp.asciidoc
@@ -59,6 +59,8 @@ For most users, the simplest option is to use a Google Cloud Shell script to aut
 . Check the box to trust Elastic's `cloudbeat` repo, then click **Confirm**
 +
 image::images/cspm-cloudshell-trust.png[The cloud shell confirmation popup]
++
+. In Google Cloud Shell, execute the command you copied. Once it finishes, return to {kib} and wait for the confirmation of data received from your new integration. Then you can click **View Assets** to see your data.
 
 NOTE: If you encounter any issues running the command, return to {kib} and navigate again to Google Cloud Shell.
 


### PR DESCRIPTION
It's not needed anymore, GCP has removed it.
Can be removed from all versions.