### PR TITLE
Serverless twin PR - adds CNVM requirement

### DIFF
--- a/docs/serverless/cloud-native-security/vuln-management-faq.mdx
+++ b/docs/serverless/cloud-native-security/vuln-management-faq.mdx
@@ -19,6 +19,10 @@ The CNVM integration uses various security data sources. The complete list can b
 
 CNVM uses the open source scanner [Trivy](https://github.com/aquasecurity/trivy) v0.35.
 
+**What system architectures are supported?**
+
+Because of Trivy's limitations, CNVM can only be deployed on ARM-based VMs. However, it can scan hosts regardless of system architecture.
+
 **How often are the security data sources synchronized?**
 
 The CNVM integration fetches the latest data sources at the beginning of every scan cycle to ensure up-to-date vulnerability information.

--- a/docs/serverless/cloud-native-security/vuln-management-get-started.mdx
+++ b/docs/serverless/cloud-native-security/vuln-management-get-started.mdx
@@ -15,6 +15,7 @@ This page explains how to set up Cloud Native Vulnerability Management (CNVM).
 
 * CNVM only works in the `Default` ((kib)) space. Installing the CNVM integration on a different ((kib)) space will not work. 
 * Requires ((agent)) version 8.8 or higher.
+* CNVM can only be deployed on ARM-based VMs. 
 * To view vulnerability scan findings, you need the appropriate user role to read the following indices:
     * `logs-cloud_security_posture.vulnerabilities-*`
     * `logs-cloud_security_posture.vulnerabilities_latest-*`


### PR DESCRIPTION
Fixes #5304. Adds a requirement to the CNVM serverless docs. The language was already approved for the ESS version.

Previews: 
[Get started with CNVM](https://elastic-dot-co-docs-production-h60pov5n9-elastic-dev.vercel.app/current/serverless/security/vuln-management-get-started)
[CNVM FAQ](https://elastic-dot-co-docs-production-h60pov5n9-elastic-dev.vercel.app/current/serverless/security/vuln-management-faq)