### PR TITLE
(Doc+) Alerts UI cannot be CCS [serverless] + bonus fixes

### DIFF
--- a/docs/getting-started/data-views-in-sec.asciidoc
+++ b/docs/getting-started/data-views-in-sec.asciidoc
@@ -20,7 +20,7 @@ image::images/dataview-button-highlighted.png[image highlighting how to open the
 
 To learn how to modify the default **Security Default Data View**, refer to <<update-sec-indices, Update default {elastic-sec} indices>>.
 
-To learn how to modify, create, or delete another {data-source} refer to {apm-app-ref}/data-views.html[{kib} {data-sources-cap}].
+To learn how to modify, create, or delete another {data-source} refer to {kibana-ref}/data-views.html[{kib} {data-sources-cap}].
 
 You can also temporarily modify the active {data-source} from the *{data-source-cap}* menu by clicking *Advanced options*, then adding or removing index patterns.
 
@@ -36,6 +36,6 @@ NOTE: You cannot update the data view for the Alerts page. This includes referen
 
 The default {data-source} is defined by the `securitySolution:defaultIndex` setting, which you can modify in {kib}'s advanced settings (**Stack Management** > **Advanced Settings** > **Security Solution**). To learn more about this setting, including its default value, refer to {security-guide}/advanced-settings.html#update-sec-indices[Advanced settings].
 
-The first time a user visits {elastic-sec} within a given {kib} {apm-app-ref}/xpack-spaces.html[space], the default {data-source} generates in that space and becomes active.
+The first time a user visits {elastic-sec} within a given {kib} {kibana-ref}/xpack-spaces.html[space], the default {data-source} generates in that space and becomes active.
 
 If you delete the active {data-source} when there are no other defined {data-sources}, the default {data-source} will regenerate and become active upon refreshing any {elastic-sec} page in the space.

--- a/docs/getting-started/data-views-in-sec.asciidoc
+++ b/docs/getting-started/data-views-in-sec.asciidoc
@@ -10,8 +10,7 @@ IMPORTANT: Custom indices are not included in the <<default-data-view-security, 
 [discrete]
 == Switch to another {data-source}
 
-You can tell which {data-source} is active by clicking the *{data-source-cap}* menu at the upper right of {elastic-sec} pages that display event or alert data, such as Overview, Alerts, Timelines, or Hosts.
-To switch to another {data-source}, click **Choose {data-source}**, select one of the options, and click **Save**.
+You can tell which {data-source} is active by clicking the *{data-source-cap}* menu at the upper right of {elastic-sec} pages that display event or alert data, such as Overview, Alerts, Timelines, or Hosts. To switch to another {data-source}, click **Choose {data-source}**, select one of the options, and click **Save**.
 
 image::images/dataview-button-highlighted.png[image highlighting how to open the data view selection menu]
 

--- a/docs/serverless/explore/data-views-in-sec.mdx
+++ b/docs/serverless/explore/data-views-in-sec.mdx
@@ -26,7 +26,11 @@ To switch to another ((data-source)), click **Choose ((data-source))**, select o
 
 ## Create or modify a ((data-source))
 
-You can temporarily modify the active ((data-source)) from the **((data-source-cap))** menu by clicking **Advanced options**, then adding or removing index patterns.
+To learn how to modify the default **Security Default Data View**, refer to <DocLink slug="/serverless/security/advanced-settings" section="update-sec-indices" />.
+
+To learn how to modify, create, or delete another ((data-source)) refer to [((data-sources-cap))](((kibana-ref))/data-views.html).
+
+You can also temporarily modify the active ((data-source)) from the **((data-source-cap))** menu by clicking **Advanced options**, then adding or removing index patterns.
 
 ![video showing how to filter the active data view](../images/data-views-in-sec/-getting-started-dataview-filter-example.gif)
 

--- a/docs/serverless/explore/data-views-in-sec.mdx
+++ b/docs/serverless/explore/data-views-in-sec.mdx
@@ -46,6 +46,6 @@ This only allows you to add index patterns that match indices that currently con
 
 The default ((data-source)) is defined by the `securitySolution:defaultIndex` setting, which you can modify in your project's advanced settings{/* path to be updated: (**Stack Management** → **Advanced Settings** → **Security Solution**) */}. To learn more about this setting, including its default value, refer to <DocLink slug="/serverless/security/advanced-settings" />).
 
-The first time a user visits ((elastic-sec)){/* within a given ((kib)) [space](((apm-app-ref))/xpack-spaces.html)*/}, the default ((data-source)) generates{/* in that space*/} and becomes active.
+The first time a user visits ((elastic-sec)){/* within a given ((kib)) [space](((kibana-ref))/xpack-spaces.html)*/}, the default ((data-source)) generates{/* in that space*/} and becomes active.
 
 If you delete the active ((data-source)) when there are no other defined ((data-sources)), the default ((data-source)) will regenerate and become active upon refreshing any ((elastic-sec)) page{/* in the space*/}.

--- a/docs/serverless/explore/data-views-in-sec.mdx
+++ b/docs/serverless/explore/data-views-in-sec.mdx
@@ -32,8 +32,9 @@ You can temporarily modify the active ((data-source)) from the **((data-source-c
 
 This only allows you to add index patterns that match indices that currently contain data (other index patterns are unavailable). Note that any changes made are saved in the current browser window and won't persist if you open a new tab.
 
-To permanently modify a ((data-source)), delete an existing ((data-source)) or create a new one, you need the required permissions.
-To learn more, refer to [((data-sources-cap))](((apm-app-ref))/data-views.html).
+<DocCallOut title="Note">
+    You cannot update the data view for the Alerts page. This includes referencing a cross-cluster search (CCS) data view or any other data view. The Alerts page always shows data from `.alerts-security.alerts-default`.
+</DocCallOut>
 
 <div id="default-data-view-security"></div>
 


### PR DESCRIPTION
### Fixes included

* Serverless twin follow-up to https://github.com/elastic/security-docs/pull/5513
   Adds admonition about data view picker in the Alerts page.

* Updates the **Data views in Elastic Security** serverless page to match its ESS counterpart. It appears the serverless page was never updated to match ESS changes in https://github.com/elastic/security-docs/pull/4695, so this gets ESS + serverless back in sync.

* Fixes URL variable/attribute usage: a few links used `apm-app-ref` instead of `kibana-ref` to point to Kibana docs. Currently the two variables have the same value, so _technically_ the links still go to the right place, but I think that in itself is an error. We should just use the Kibana variable if we want to point to Kibana docs.

* Backports: The errant `apm-app-ref` attribute appears back to 8.0, but I think we can get by with fixing the current version (8.14) and moving on.

### Previews

ESS:
- [Data views in Elastic Security](https://security-docs_bk_5582.docs-preview.app.elstc.co/guide/en/security/master/data-views-in-sec.html)

Serverless:
- Click the [link below](https://github.com/elastic/security-docs/pull/5582#issuecomment-2234237565), then in the Security card click **View serverless docs**. 
- Navigate to: **Explore your data → Data views in Elastic Security**.