### PR TITLE
Add link to region docs

### DIFF
--- a/docs/serverless/projects-create/create-project.mdx
+++ b/docs/serverless/projects-create/create-project.mdx
@@ -27,7 +27,7 @@ Use your ((ecloud)) account to create a fully-managed ((elastic-sec)) project:
 
     * **Cloud provider**: The cloud platform where you’ll deploy your project. We currently support Amazon Web Services (AWS).
 
-    * **Region**: The cloud platform’s <DocLink slug="/serverless/region" text="region"/> where your project will live. The region should be as close as possible to the location of your data.
+    * **Region**: The cloud platform’s <DocLink slug="/serverless/regions" text="region"/> where your project will live. The region should be as close as possible to the location of your data.
 
     You can also check [the pricing details](https://cloud.elastic.co/pricing) to see how you consume ((serverless-short)) ((elastic-sec)).
 

--- a/docs/serverless/projects-create/create-project.mdx
+++ b/docs/serverless/projects-create/create-project.mdx
@@ -27,7 +27,7 @@ Use your ((ecloud)) account to create a fully-managed ((elastic-sec)) project:
 
     * **Cloud provider**: The cloud platform where you’ll deploy your project. We currently support Amazon Web Services (AWS).
 
-    * **Region**: The cloud platform’s <DocLink slug="/serverless/region">region</DocLink> where your project will live. The region should be as close as possible to the location of your data.
+    * **Region**: The cloud platform’s <DocLink slug="/serverless/region" text="region"/> where your project will live. The region should be as close as possible to the location of your data.
 
     You can also check [the pricing details](https://cloud.elastic.co/pricing) to see how you consume ((serverless-short)) ((elastic-sec)).
 

--- a/docs/serverless/projects-create/create-project.mdx
+++ b/docs/serverless/projects-create/create-project.mdx
@@ -27,7 +27,7 @@ Use your ((ecloud)) account to create a fully-managed ((elastic-sec)) project:
 
     * **Cloud provider**: The cloud platform where you’ll deploy your project. We currently support Amazon Web Services (AWS).
 
-    * **Region**: The cloud platform’s region where your project will live. The region should be as close as possible to the location of your data.
+    * **Region**: The cloud platform’s <DocLink slug="/serverless/region">region</DocLink> where your project will live. The region should be as close as possible to the location of your data.
 
     You can also check [the pricing details](https://cloud.elastic.co/pricing) to see how you consume ((serverless-short)) ((elastic-sec)).
 

--- a/docs/serverless/projects-create/create-project.mdx
+++ b/docs/serverless/projects-create/create-project.mdx
@@ -27,7 +27,7 @@ Use your ((ecloud)) account to create a fully-managed ((elastic-sec)) project:
 
     * **Cloud provider**: The cloud platform where you’ll deploy your project. We currently support Amazon Web Services (AWS).
 
-    * **Region**: The cloud platform’s <DocLink slug="/serverless/regions" text="region"/> where your project will live. The region should be as close as possible to the location of your data.
+    * **Region**: The cloud platform’s <DocLink slug="/serverless/regions" text="region"/> where your project will live.
 
     You can also check [the pricing details](https://cloud.elastic.co/pricing) to see how you consume ((serverless-short)) ((elastic-sec)).
 


### PR DESCRIPTION
Added docs for serverless cloud regions [here](https://github.com/elastic/docs-content/pull/47) - this PR adds an informational link for regions to the security project creation doc. 

I also removed the region proximity guidance from this [on request](https://github.com/elastic/docs-content/pull/47#issuecomment-2250601601). the linked region page provides some similar guidance, just a little less prescriptive

Won't merge until the core doc is merged