### PR TITLE
[Enhancement][Serverless, 8.14, & 8.15]: add note to highlight that internal indices aren't suggested in the Timeline ES|QL tab

### DIFF
--- a/docs/events/timeline-ui-overview.asciidoc
+++ b/docs/events/timeline-ui-overview.asciidoc
@@ -233,7 +233,13 @@ This query does the following:
 +
 TIP: When querying indices that tend to be large (for example, `logs-*`), performance can be impacted by the number of fields returned in the output. To optimize performance, we recommend using the {ref}/esql-commands.html#esql-keep[`KEEP`] command to specify fields that you want returned. For example, add the clause `KEEP @timestamp, user.name` to the end of your query to specify that you only want the `@timestamp` and `user.name` fields returned.
 
-NOTE: An error message displays when the query bar is empty. 
+[NOTE]
+======
+
+* An error message displays when the query bar is empty. 
+* When specifying data sources for an ((esql)) query, autocomplete doesn't suggest hidden indices, such as `.alerts-*`. You must manually enter the index name or pattern. 
+
+======
 
 - Click the help icon (image:images/esql-help-ref-button.png[Click the ES|QL reference button,20,20]) on the far right side of the query editor to open the in-product reference documentation for all {esql} commands and functions.  
 - Visualize query results using {kibana-ref}/discover.html[Discover] functionality.

--- a/docs/serverless/investigate/timelines-ui.mdx
+++ b/docs/serverless/investigate/timelines-ui.mdx
@@ -236,7 +236,8 @@ You can use ((esql)) in Timeline by opening the **((esql))** tab. From there, yo
             </DocCallOut>
 
         <DocCallOut title="Note">
-        An error message displays when the query bar is empty. 
+        * An error message displays when the query bar is empty. 
+        *  When specifying data sources for an ((esql)) query, autocomplete doesn't suggest hidden indices, such as `.alerts-*`. You must manually enter the index name or pattern. 
         </DocCallOut> 
 
 - Click the help icon (<DocIcon type="iInCircle" title="Click the ES|QL help icon" />) on the far right side of the query editor to open the in-product reference documentation for all ((esql)) commands and functions.  


### PR DESCRIPTION
Fixes https://github.com/elastic/security-docs/issues/5200

Previews:
- ESS: TBD
- Serverless 