### PR TITLE
Adds Allowlist Elastic Endpoint in third-party antivirus apps page to serverless docs

### DIFF
--- a/docs/management/admin/allowlist-endpoint-3rd-party-av.asciidoc
+++ b/docs/management/admin/allowlist-endpoint-3rd-party-av.asciidoc
@@ -1,6 +1,8 @@
 [[allowlist-endpoint-3rd-party-av-apps]]
 = Allowlist Elastic Endpoint in third-party antivirus apps
 
+NOTE: If you use other antivirus (AV) software along with {elastic-defend}, you may need to add the other system as a trusted application in the {security-app}. Refer to <<trusted-apps-ov>> for more information.
+
 Third-party antivirus (AV) applications may identify the expected behavior of {elastic-endpoint} as a potential threat. Add {elastic-endpoint}'s digital signatures and file paths to your AV software's allowlist to ensure {elastic-endpoint} continues to function as intended. We recommend you allowlist both the file paths and digital signatures, if applicable. 
 
 NOTE: Your AV software may refer to allowlisted processes as process exclusions, ignored processes, or trusted processes. It is important to note that file, folder, and path-based exclusions/exceptions are distinct from trusted applications and will not achieve the same result. This page explains how to ignore actions taken by processes, not how to ignore the files that spawned those processes.

--- a/docs/management/admin/trusted-apps.asciidoc
+++ b/docs/management/admin/trusted-apps.asciidoc
@@ -2,6 +2,8 @@
 [chapter, role="xpack"]
 = Trusted applications
 
+NOTE: To add Elastic Endpoint as a trusted application in your other antivirus (AV) software, refer to <<allowlist-endpoint-3rd-party-av-apps>>.
+
 You can add Windows, macOS, and Linux applications that should be trusted, such as other antivirus or endpoint security applications. Trusted applications are designed to help mitigate performance issues and incompatibilities with other endpoint software installed on your hosts. Trusted applications apply only to hosts running the {elastic-defend} integration.
 
 .Requirements

--- a/docs/management/admin/trusted-apps.asciidoc
+++ b/docs/management/admin/trusted-apps.asciidoc
@@ -2,7 +2,7 @@
 [chapter, role="xpack"]
 = Trusted applications
 
-NOTE: To add Elastic Endpoint as a trusted application in your other antivirus (AV) software, refer to <<allowlist-endpoint-3rd-party-av-apps>>.
+NOTE: If you use {elastic-defend} along with other antivirus (AV) software, you might need to configure the other system to trust {elastic-endpoint}. Refer to <<allowlist-endpoint-3rd-party-av-apps>> for more information.
 
 You can add Windows, macOS, and Linux applications that should be trusted, such as other antivirus or endpoint security applications. Trusted applications are designed to help mitigate performance issues and incompatibilities with other endpoint software installed on your hosts. Trusted applications apply only to hosts running the {elastic-defend} integration.
 

--- a/docs/serverless/edr-manage/allowlist-endpoint-3rd-party-av.mdx
+++ b/docs/serverless/edr-manage/allowlist-endpoint-3rd-party-av.mdx
@@ -1,7 +1,7 @@
 ---
 slug: /serverless/security/allowlist-endpoint
-title: Allowlist Elastic Endpoint in third-party antivirus apps
-description: Add Elastic Endpoint as a trusted application in third-party antivirus (AV) software.
+title: Allowlist ((elastic-endpoint)) in third-party antivirus apps
+description: Add ((elastic-endpoint)) as a trusted application in third-party antivirus (AV) software.
 tags: [ 'serverless', 'security', 'overview' ]
 status: in review
 ---

--- a/docs/serverless/edr-manage/allowlist-endpoint-3rd-party-av.mdx
+++ b/docs/serverless/edr-manage/allowlist-endpoint-3rd-party-av.mdx
@@ -1,7 +1,7 @@
 ---
 slug: /serverless/security/allowlist-endpoint
 title: Allowlist Elastic Endpoint in third-party antivirus apps
-# description: Description to be written
+description: Add Elastic Endpoint as a trusted application in third-party antivirus (AV) software.
 tags: [ 'serverless', 'security', 'overview' ]
 status: in review
 ---

--- a/docs/serverless/edr-manage/allowlist-endpoint-3rd-party-av.mdx
+++ b/docs/serverless/edr-manage/allowlist-endpoint-3rd-party-av.mdx
@@ -8,6 +8,10 @@ status: in review
 
 <DocBadge template="technical preview" />
 
+<DocCallOut title="Note">
+If you use other antivirus (AV) software along with ((elastic-defend)), you may need to add the other system as a trusted application in the ((security-app)). Refer to <DocLink slug="/serverless/security/trusted-applications" /> for more information.
+</DocCallOut>
+
 Third-party antivirus (AV) applications may identify the expected behavior of ((elastic-endpoint)) as a potential threat. Add ((elastic-endpoint))'s digital signatures and file paths to your AV software's allowlist to ensure ((elastic-endpoint)) continues to function as intended. We recommend you allowlist both the file paths and digital signatures, if applicable. 
 
 <DocCallOut title="Note">

--- a/docs/serverless/edr-manage/allowlist-endpoint-3rd-party-av.mdx
+++ b/docs/serverless/edr-manage/allowlist-endpoint-3rd-party-av.mdx
@@ -1,0 +1,66 @@
+---
+slug: /serverless/security/allowlist-endpoint
+title: Allowlist Elastic Endpoint in third-party antivirus apps
+# description: Description to be written
+tags: [ 'serverless', 'security', 'overview' ]
+status: in review
+---
+
+<DocBadge template="technical preview" />
+<div id="blocklist"></div>
+
+Third-party antivirus (AV) applications may identify the expected behavior of ((elastic-endpoint)) as a potential threat. Add ((elastic-endpoint))'s digital signatures and file paths to your AV software's allowlist to ensure ((elastic-endpoint)) continues to function as intended. We recommend you allowlist both the file paths and digital signatures, if applicable. 
+
+<DocCallOut title="Note">
+Your AV software may refer to allowlisted processes as process exclusions, ignored processes, or trusted processes. It is important to note that file, folder, and path-based exclusions/exceptions are distinct from trusted applications and will not achieve the same result. This page explains how to ignore actions taken by processes, not how to ignore the files that spawned those processes.
+</DocCallOut>
+
+## Allowlist ((elastic-endpoint)) on Windows
+
+File paths:
+
+* ELAM driver: `c:\Windows\system32\drivers\elastic-endpoint-driver.sys`
+* Driver: `c:\Windows\system32\drivers\ElasticElam.sys`
+* Executable: `c:\Program Files\Elastic\Endpoint\elastic-endpoint.exe`
+
+    <DocCallOut title="Note">
+    The executable runs as `elastic-endpoint.exe`.
+    </DocCallOut>
+
+Digital signatures:
+
+* `Elasticsearch, Inc.`
+* `Elasticsearch B.V.`
+
+For additional information about allowlisting on Windows, refer to [Trusting Elastic Defend in other software](https://github.com/elastic/endpoint/blob/main/PerformanceIssues-Windows.md#trusting-elastic-defend-in-other-software).
+
+## Allowlist ((elastic-endpoint)) on macOS
+
+File paths:
+
+* System extension (recursive directory structure): `/Applications/ElasticEndpoint.app/`
+
+    <DocCallOut title="Note">
+    The system extension runs as `co.elastic.systemextension`.
+    </DocCallOut>
+
+* Executable: `/Library/Elastic/Endpoint/elastic-endpoint.app/Contents/MacOS/elastic-endpoint`
+
+    <DocCallOut title="Note">
+    The executable runs as `elastic-endpoint`.
+    </DocCallOut>
+
+Digital signatures:
+
+* Authority/Developer ID Application: `Elasticsearch, Inc (2BT3HPN62Z)`
+* Team ID: `2BT3HPN62Z`
+
+## Allowlist ((elastic-endpoint)) on Linux
+
+File path:
+
+* Executable: `/opt/Elastic/Endpoint/elastic-endpoint`
+
+    <DocCallOut title="Note">
+    The executable runs as `elastic-endpoint`.
+    </DocCallOut>

--- a/docs/serverless/edr-manage/allowlist-endpoint-3rd-party-av.mdx
+++ b/docs/serverless/edr-manage/allowlist-endpoint-3rd-party-av.mdx
@@ -7,7 +7,6 @@ status: in review
 ---
 
 <DocBadge template="technical preview" />
-<div id="blocklist"></div>
 
 Third-party antivirus (AV) applications may identify the expected behavior of ((elastic-endpoint)) as a potential threat. Add ((elastic-endpoint))'s digital signatures and file paths to your AV software's allowlist to ensure ((elastic-endpoint)) continues to function as intended. We recommend you allowlist both the file paths and digital signatures, if applicable. 
 

--- a/docs/serverless/edr-manage/trusted-apps-ov.mdx
+++ b/docs/serverless/edr-manage/trusted-apps-ov.mdx
@@ -10,7 +10,7 @@ status: in review
 <div id="trusted-apps-ov"></div>
 
 <DocCallOut title="Note">
-To add Elastic Endpoint as a trusted application in your other antivirus (AV) software, refer to <DocLink slug="/serverless/security/allowlist-endpoint">Allowlist Elastic Endpoint in third-party antivirus apps</DocLink>.
+If you use ((elastic-defend)) along with other antivirus (AV) software, you might need to configure the other system to trust ((elastic-endpoint)). Refer to <DocLink slug="/serverless/security/allowlist-endpoint" /> for more information.
 </DocCallOut>
 
 On the **Trusted applications** page (**Assets** → **Trusted applications**), you can add Windows, macOS, and Linux applications that should be trusted, such as other antivirus or endpoint security applications. Trusted applications are designed to help mitigate performance issues and incompatibilities with other endpoint software installed on your hosts. Trusted applications apply only to hosts running the ((elastic-defend)) integration.

--- a/docs/serverless/edr-manage/trusted-apps-ov.mdx
+++ b/docs/serverless/edr-manage/trusted-apps-ov.mdx
@@ -9,6 +9,10 @@ status: in review
 <DocBadge template="technical preview" />
 <div id="trusted-apps-ov"></div>
 
+<DocCallOut title="Note">
+To add Elastic Endpoint as a trusted application in your other antivirus (AV) software, refer to <DocLink slug="/serverless/security/allowlist-endpoint">Allowlist Elastic Endpoint in third-party antivirus apps</DocLink>.
+</DocCallOut>
+
 On the **Trusted applications** page (**Assets** → **Trusted applications**), you can add Windows, macOS, and Linux applications that should be trusted, such as other antivirus or endpoint security applications. Trusted applications are designed to help mitigate performance issues and incompatibilities with other endpoint software installed on your hosts. Trusted applications apply only to hosts running the ((elastic-defend)) integration.
 
 <DocCallOut title="Requirements">

--- a/docs/serverless/serverless-security.docnav.json
+++ b/docs/serverless/serverless-security.docnav.json
@@ -629,6 +629,9 @@
           "classic-sources": [ "enSecurityEndpointArtifacts" ]
         },
         {
+          "slug": "/serverless/security/allowlist-endpoint"
+        },
+        {
           "slug": "/serverless/security/troubleshoot-endpoints",
           "classic-sources": [ "enSecurityTsManagement" ]
         }


### PR DESCRIPTION
Resolves https://github.com/elastic/security-docs/issues/3433, which is a duplicate of https://github.com/elastic/security-docs/issues/3535.

This PR adds the [Allowlist Elastic Endpoint in third-party antivirus apps](https://www.elastic.co/guide/en/security/master/allowlist-endpoint-3rd-party-av-apps.html) page to serverless docs and a disambiguation note to the [Trusted applications](https://www.elastic.co/guide/en/security/master/trusted-apps-ov.html) page.

Previews:
* ESS: 
  * [Allowlist Elastic Endpoint in third-party antivirus apps](https://security-docs_bk_5639.docs-preview.app.elstc.co/guide/en/security/master/allowlist-endpoint-3rd-party-av-apps.html)
  * [Trusted applications](https://security-docs_bk_5639.docs-preview.app.elstc.co/guide/en/security/master/trusted-apps-ov.html)
* serverless: Click the preview link in [this comment](https://github.com/elastic/security-docs/pull/5639#issuecomment-2263481983) and navigate to:
   *  **Elastic Security** -> **Manage endpoint protection** -> **Allowlist Elastic Endpoint in third-party antivirus apps**
   *  **Elastic Security** -> **Manage endpoint protection** -> **Trusted applications**

