### PR TITLE
Adds AI Assistant APIs link to release highlights

### DIFF
--- a/docs/whats-new.asciidoc
+++ b/docs/whats-new.asciidoc
@@ -16,8 +16,7 @@ Other versions: {security-guide-all}/8.14/whats-new.html[8.14] | {security-guide
 [float]
 === Manage Elastic AI Assistant using API
 
-You can now interact with and manage {security-guide}/security-assistant.html[Elastic AI Assistant] using the Elastic AI Assistant API.
-// add link to Elastic AI Assistant API page when available: {security-guide}/assistant-api-overview.html[Elastic AI Assistant API]
+You can now interact with and manage {security-guide}/security-assistant.html[Elastic AI Assistant] using the {security-guide}/assistant-api-overview.html[Elastic AI Assistant API]. 
 
 [float]
 === Create new third-party data integrations using Automatic Import


### PR DESCRIPTION
Contributes to https://github.com/elastic/security-docs/issues/5508.

Adds a link to the Elastic AI Assistant API page in the release highlights now that https://github.com/elastic/security-docs/pull/5620 is merged.

Preview: [What’s new in 8.15](https://security-docs_bk_5690.docs-preview.app.elstc.co/guide/en/security/master/whats-new.html)