### PR TITLE
[Response Actions][kill-process] Update API docs for `kill-process` to include `process_name` parameter for SentinelOne

### DIFF
--- a/docs/management/api/kill-process-api.asciidoc
+++ b/docs/management/api/kill-process-api.asciidoc
@@ -1,7 +1,7 @@
 [[kill-process-api]]
 === Terminate a process
 
-Terminates a process on a host running {elastic-defend} or a supported agent type.
+Terminates a process on a host running {elastic-defend} or a supported third-party agent type.
 
 You must have the *Process Operations* <<endpoint-management-req,privilege>> and an Enterprise license to perform this action.
 
@@ -19,7 +19,7 @@ include::_response-actions-api-reusable-content.asciidoc[tags=create-response-ac
 
 |`parameters.pid` |Number |The process ID (PID) of the process to terminate. |Yes, must provide either `parameters.pid` or `parameters.entity_id`, but not both
 |`parameters.entity_id` |String |The entity ID of the process to terminate. |Yes, must provide either `parameters.pid` or `parameters.entity_id`, but not both
-|`parameters.process_name` |String |SentinelOne `agent_type` only. The process name to terminate. |Yes. This is the only parameter accepted for SentinelOne
+|`parameters.process_name` |String |SentinelOne `agent_type` only. The name of the process to terminate. |Yes. This is the only parameter accepted for SentinelOne
 |==============================================
 
 

--- a/docs/management/api/kill-process-api.asciidoc
+++ b/docs/management/api/kill-process-api.asciidoc
@@ -1,7 +1,7 @@
 [[kill-process-api]]
 === Terminate a process
 
-Terminates a process on a host running {elastic-defend}.
+Terminates a process on a host running {elastic-defend} or a supported agent type.
 
 You must have the *Process Operations* <<endpoint-management-req,privilege>> and an Enterprise license to perform this action.
 
@@ -19,6 +19,7 @@ include::_response-actions-api-reusable-content.asciidoc[tags=create-response-ac
 
 |`parameters.pid` |Number |The process ID (PID) of the process to terminate. |Yes, must provide either `parameters.pid` or `parameters.entity_id`, but not both
 |`parameters.entity_id` |String |The entity ID of the process to terminate. |Yes, must provide either `parameters.pid` or `parameters.entity_id`, but not both
+|`parameters.process_name` |String |SentinelOne `agent_type` only. The process name to terminate. |Yes. This is the only parameter accepted for SentinelOne
 |==============================================
 
 
@@ -53,7 +54,7 @@ POST /api/endpoint/action/kill_process
 
 ==== Response payload
 
-A JSON object with an `id` that refers to the submitted action.
+A JSON object with the details of the response action created.
 
 ===== Example response
 


### PR DESCRIPTION
## Description

- Updates the `kill-process` response action API to include `parameters.process_name` for use only with SentinelOne `agent_type`





