### PR TITLE
[DE Team][8.16] Case system action being added for rules

### DIFF
--- a/docs/detections/rules-ui-create.asciidoc
+++ b/docs/detections/rules-ui-create.asciidoc
@@ -13,7 +13,7 @@ To create a new detection rule, follow these steps:
 . Configure basic rule settings.
 . Configure advanced rule settings (optional).
 . Set the rule's schedule.
-. Set up alert notifications (optional).
+. Set up rule actions (optional).
 . Set up response actions (optional).
 
 .Requirements
@@ -616,9 +616,6 @@ run exactly at its scheduled time.
 `Additional look-back time` are _not_ created.
 ==============
 . Click *Continue*. The *Rule actions* pane is displayed.
-+
-[role="screenshot"]
-image::images/available-action-types.png[Available connector types]
 
 . Do either of the following:
 
@@ -627,23 +624,26 @@ image::images/available-action-types.png[Available connector types]
 
 [float]
 [[rule-notifications]]
-=== Set up alert notifications (optional)
+=== Set up rule actions (optional)
 
-Use {kib} Actions to set up notifications sent via other systems when alerts
+Use {kib} actions to set up notifications sent via other systems when alerts
 are generated.
 
-NOTE: To use {kib} Actions for alert notifications, you need the
+NOTE: To use {kib} actions for alert notifications, you need the
 https://www.elastic.co/subscriptions[appropriate license] and your role needs *All* privileges for the *Action and Connectors* feature. For more information, see <<case-permissions>>.
 
 . Select a connector type to determine how notifications are sent. For example, if you select the {jira} connector, notifications are sent to your {jira} system.
 +
-NOTE: Each action type requires a connector. Connectors store the
+[NOTE] 
+=====
+Each action type requires a connector. Connectors store the
 information required to send the notification from the external system. You can
 configure connectors while creating the rule or in *{stack-manage-app}* -> *{connectors-ui}*. For more
 information, see {kibana-ref}/action-types.html[Action and connector types].
-+
-[role="screenshot"]
-image::images/available-action-types.png[Available connector types]
+
+Some connectors that perform actions require less configuration. For example, you do not need to set the action frequency or variables for the {kibana-ref}/cases-action-type.html[Cases connector]
+
+=====
 
 . After you select a connector, set its action frequency to define when notifications are sent:
 
@@ -776,16 +776,13 @@ Example using the mustache "current element" notation `{{.}}` to output all the 
 [float]
 [[rule-response-action]]
 === Set up response actions (optional)
-Use Response Actions to set up additional functionality that will run whenever a rule executes:
+Use response actions to set up additional functionality that will run whenever a rule executes:
 
 * **Osquery**: Include live Osquery queries with a custom query rule. When an alert is generated, Osquery automatically collects data on the system related to the alert. Refer to <<osquery-response-action>> to learn more.
 
 * **{elastic-defend}**: Automatically run response actions on an endpoint when rule conditions are met. For example, you can automatically isolate a host or terminate a process when specific activities or events are detected on the host. Refer to <<automated-response-actions>> to learn more.
 
 IMPORTANT: Host isolation involves quarantining a host from the network to prevent further spread of threats and limit potential damage. Be aware that automatic host isolation can cause unintended consequences, such as disrupting legitimate user activities or blocking critical business processes.
-
-[role="screenshot"]
-image::images/available-response-actions.png[Shows available response actions]
 
 [discrete]
 [[preview-rules]]

--- a/docs/serverless/rules/rules-ui-create.mdx
+++ b/docs/serverless/rules/rules-ui-create.mdx
@@ -662,8 +662,6 @@ When configuring an ((esql)) rule's **<DocLink slug="/serverless/security/rules-
 
 1. Click **Continue**. The **Rule actions** pane is displayed.
 
-    ![Available connector types](../images/rules-ui-create/-detections-available-action-types.png)
-
 1. Do either of the following:
 
     * Continue onto <DocLink slug="/serverless/security/rules-create" section="set-up-alert-notifications-optional">setting up alert notifications</DocLink> and <DocLink slug="/serverless/security/rules-create" section="set-up-response-actions-optional">Response Actions</DocLink> (optional).
@@ -689,8 +687,6 @@ To use actions for alert notifications, you need the appropriate user role. For 
 
     Some connectors that perform actions require less configuration. For example, you do not need to set the action frequency or variables for the [Cases connector](((kibana-ref))/cases-action-type.html).
     </DocCallOut>
-
-    ![Available connector types](../images/rules-ui-create/-detections-available-action-types.png)
 
 1. After you select a connector, set its action frequency to define when notifications are sent:
 
@@ -844,8 +840,6 @@ Use response actions to set up additional functionality that will run whenever a
 <DocCallOut title="Important" color="warning">
 Host isolation involves quarantining a host from the network to prevent further spread of threats and limit potential damage. Be aware that automatic host isolation can cause unintended consequences, such as disrupting legitimate user activities or blocking critical business processes.
 </DocCallOut>
-
-![Shows available response actions](../images/rules-ui-create/-detections-available-response-actions.png)
 
 <div id="preview-rules"></div>
 


### PR DESCRIPTION
Made the following changes to the [Create a detection rule](https://elastic-dot-co-docs-production-7m7ozw1rh-elastic-dev.vercel.app/current/serverless/security/rules-create) page:
- Revised step 5 at the start of the page so it reflects that users can set up actions for the rule
- Changed the title of the alert notifications section from "Set up alert notifications (optional)" to "Set up rule actions (optional)" and refreshed outdated images 
- Added a blurb about the case connector and linked to the connector docs
- Moved the response actions section one more level down so it's under the "Set up rule actions (optional)" section. This seemed appropriate, seeing that response actions are considered a sub-type of rule actions.