### PR TITLE
[Known Issue] In bulk action menu we show manual rule run, but it's not available 

### DIFF
--- a/docs/release-notes/8.15.asciidoc
+++ b/docs/release-notes/8.15.asciidoc
@@ -21,6 +21,18 @@ On August 1, 2024, it was discovered that Elastic AI Assistant's responses when 
 ====
 // end::known-issue-189676[]
 
+// tag::known-issue-5713[]
+[discrete]
+.The option to manually run multiple rules is available in the bulk actions menu on the Rules page
+[%collapsible]
+====
+*Details* +
+On August 20, 2024, it was discovered that the bulk actions menu on the Rules page erroneously had the option to manually run multiple rules.  
+
+*Workaround* +
+To resolve this issue, upgrade to 8.15.1 or later.
+====
+// end::known-issue-5713[]
 
 [discrete]
 [[breaking-changes-8.15.0]]

--- a/docs/release-notes/8.15.asciidoc
+++ b/docs/release-notes/8.15.asciidoc
@@ -29,8 +29,6 @@ On August 1, 2024, it was discovered that Elastic AI Assistant's responses when 
 *Details* +
 On August 20, 2024, it was discovered that the bulk actions menu on the Rules page erroneously had the option to manually run multiple rules.  
 
-*Workaround* +
-To resolve this issue, upgrade to 8.15.1 or later.
 ====
 // end::known-issue-5713[]
 


### PR DESCRIPTION
Fixes https://github.com/elastic/security-docs/issues/5713

Preview: https://security-docs_bk_5714.docs-preview.app.elstc.co/guide/en/security/master/release-notes-header-8.15.0.html#known-issue-8.15.0