### PR TITLE
Serverless changes to rework main overview landing page

### DIFF
--- a/docs/es-overview.asciidoc
+++ b/docs/es-overview.asciidoc
@@ -1,10 +1,10 @@
 [[es-overview]]
 [chapter, role="xpack"]
-= Elastic Security overview
+= {elastic-sec} overview
 
 {elastic-sec} combines threat detection analytics, cloud native security, and endpoint protection capabilities in a single solution, so you can quickly detect, investigate, and respond to threats and vulnerabilities across your environment.
 
-Elastic Security provides:
+{elastic-sec} provides:
 
 * A detection engine that identifies a wide range of threats
 * A workspace for event triage, investigation, and case management
@@ -16,7 +16,7 @@ Elastic Security provides:
 === Learn more
 
 * <<getting-started, Get started>>: Learn about system requirements, workspaces, configuration, and data ingestion.
-* <<es-ui-overview, Elastic Security UI overview>>: Navigate {elastic-sec}'s various tools and interfaces.
+* <<es-ui-overview, {elastic-sec} UI overview>>: Navigate {elastic-sec}'s various tools and interfaces.
 * <<about-rules, Detection rules>>: Use {elastic-sec}'s detection engine with custom and prebuilt rules.
 * <<cloud-native-security-overview, Cloud native security>>: Enable cloud native security capabilities such as Cloud and Kubernetes security posture management, cloud native vulnerability management, and cloud workload protection for Kubernetes and VMs.
 * <<install-endpoint, Install {elastic-defend}>>: Enable key endpoint protection capabilities like event collection and malicious activity prevention.

--- a/docs/serverless/rules/rules-ui-create.mdx
+++ b/docs/serverless/rules/rules-ui-create.mdx
@@ -251,7 +251,7 @@ To create or edit ((ml)) rules, you need an appropriate user role. Additionally,
     1. **Indicator index patterns**: The indicator index patterns containing field values for which you want to generate alerts. This field is automatically populated with indices specified in the `securitySolution:defaultThreatIndex` advanced setting. For more information, see <DocLink slug="/serverless/security/advanced-settings" section="update-default-elastic-security-threat-intelligence-indices">Update default Elastic Security threat intelligence indices</DocLink>.
 
         <DocCallOut title="Important" color="warning">
-        Data in indicator indices must be <DocLink slug="/serverless/security/overview" section="ecs-compliance-data-requirements">ECS compatible</DocLink>, and so it must contain a `@timestamp` field.
+        Data in indicator indices must be <DocLink slug="/serverless/security/siem-field-reference">ECS compatible</DocLink>, and so it must contain a `@timestamp` field.
         </DocCallOut>
 
     1. **Indicator index query**: The query and filters used to filter the fields from

--- a/docs/serverless/security-overview.mdx
+++ b/docs/serverless/security-overview.mdx
@@ -3,125 +3,46 @@ slug: /serverless/security/overview
 title: ((elastic-sec)) overview
 # description: Description to be written
 tags: [ 'serverless', 'security', 'reference' ]
-status: in review
 ---
  
 <DocBadge template="technical preview" />
 <div id="es-overview"></div>
 
-((elastic-sec)) combines SIEM threat detection features with endpoint
-prevention and response capabilities in one solution. These analytical and
-protection capabilities, leveraged by the speed and extensibility of
-Elasticsearch, enable analysts to defend their organization from threats before
-damage and loss occur.
+((elastic-sec)) combines threat detection analytics, cloud native security, and endpoint protection capabilities in a single solution, so you can quickly detect, investigate, and respond to threats and vulnerabilities across your environment.
 
-((elastic-sec)) provides the following security benefits and capabilities:
+((elastic-sec)) provides:
 
-* A detection engine to identify attacks and system misconfigurations
-* A workspace for event triage and investigations
-* Interactive visualizations to investigate process relationships
-* Inbuilt case management with automated actions
-* Detection of signatureless attacks with prebuilt machine learning anomaly jobs and detection rules
+* A detection engine that identifies a wide range of threats
+* A workspace for event triage, investigation, and case management
+* Interactive data visualization tools 
+* Integrations for collecting data from various sources
 
-## ((elastic-sec)) components and workflow
+<div id="siem-integration"></div>
 
-The following diagram provides a comprehensive illustration of the ((elastic-sec)) workflow.
+## Learn more
 
-![((elastic-sec)) workflow](images/es-overview/-getting-started-workflow.png)
+* <DocLink slug="/serverless/security/security-ui">((elastic-sec)) UI overview</DocLink>: Navigate ((elastic-sec))'s various tools and interfaces.
+* <DocLink slug="/serverless/security/about-rules">Detection rules</DocLink>: Use ((elastic-sec))'s detection engine with custom and prebuilt rules.
+* <DocLink slug="/serverless/security/cloud-native-security-overview">Cloud native security</DocLink>: Enable cloud native security capabilities such as Cloud and Kubernetes security posture management, cloud native vulnerability management, and cloud workload protection for Kubernetes and VMs.
+* <DocLink slug="/serverless/security/install-edr">Install ((elastic-defend))</DocLink>: Enable key endpoint protection capabilities like event collection and malicious activity prevention.
+* [((ml-cap))](https://www.elastic.co/products/stack/machine-learning): Enable built-in ((ml)) tools to help you identify malicious behavior.
+* <DocLink slug="/serverless/security/advanced-entity-analytics">Advanced entity analytics</DocLink>: Leverage ((elastic-sec))'s detection engine and ((ml)) capabilities to generate comprehensive risk analytics for hosts and users.
+* <DocLink slug="/serverless/security/ai-assistant">Elastic AI Assistant</DocLink>: Ask AI Assistant questions about how to use ((elastic-sec)), how to understand particular alerts and other documents, and how to write ((esql)) queries.
 
-Here's an overview of the flow and its components:
+<div id="elastic-search-and-kibana"></div>
 
-* Data is shipped from your hosts to ((elastic-sec)) in the following ways:
-    * <DocLink slug="/serverless/security/install-edr">((elastic-defend))</DocLink>: ((agent)) integration that
-        protects your hosts <DocLink slug="/serverless/security/detection-engine-overview" section="malware-prevention">against malware</DocLink> and ships these data sets:
+## ((es)) and ((kib))
 
-        *  **Windows**: Process, network, file, DNS, registry, DLL and driver loads,
-            malware security detections, API
+((elastic-sec)) uses ((es)) for data storage, management, and search, and ((kib)) is its main user interface. Learn more:
 
-        * **Linux/macOS**: Process, network, file
-    * [((integrations))](((integrations-docs))): Integrations are a streamlined way to ship your data. Integrations are available for popular services and platforms, like Nginx, AWS, and MongoDB, as well as many generic input types like log files.
-    * [Beat modules](https://www.elastic.co/integrations?solution=security): ((beats))
-        are lightweight data shippers. Beat modules provide a way of collecting and
-        parsing specific data sets from common sources, such as cloud and OS events,
-        logs, and metrics. Common security-related modules are listed
-        <DocLink slug="/serverless/security/ingest-data" section="enable-modules-and-configuration-options">here</DocLink>.
-
-* The ((security-app)) is used to manage the **Detection engine**,
-    **Cases**, and **Timeline**, as well as administer hosts running ((elastic-defend)):
-
-    * Detection engine: Automatically searches for suspicious host and network
-        activity via the following:
-
-        * <DocLink slug="/serverless/security/detection-engine-overview">Detection rules</DocLink>: Periodically search the data
-            (((es)) indices) sent from your hosts for suspicious events. When a suspicious
-            event is discovered, an alert is generated. External systems, such as
-            Slack and email, can be used to send notifications when alerts are generated.
-            You can create your own rules and make use of our <DocLink slug="/serverless/security/prebuilt-rules">prebuilt ones</DocLink>.
-
-        * <DocLink slug="/serverless/security/rule-exceptions">Exceptions</DocLink>: Reduce noise and the number of
-            false positives. Exceptions are associated with rules and prevent alerts when
-            an exception's conditions are met. **Value lists** contain source event
-            values that can be used as part of an exception's conditions. When
-            ((elastic-defend)) is installed on your hosts, you can add malware exceptions
-            directly to the endpoint from the Security app.
-
-        * <DocLink slug="/serverless/security/machine-learning" section="prebuilt-jobs">((ml-cap)) jobs</DocLink>: Automatic anomaly detection of host and network events. Anomaly scores are provided per host and can be used with detection rules.
-    * <DocLink slug="/serverless/security/timelines-ui">Timeline</DocLink>: Workspace for investigating alerts and events.
-        Timelines use queries and filters to drill down into events related to
-        a specific incident. Timeline templates are attached to rules and use predefined
-        queries when alerts are investigated. Timelines can be saved and shared with
-        others, as well as attached to Cases.
-
-    * <DocLink slug="/serverless/security/cases-overview">Cases</DocLink>: An internal system for opening, tracking, and sharing
-        security issues directly in the ((security-app)). Cases can be integrated with
-        external ticketing systems.
-
-    * <DocLink slug="/serverless/security/endpoints-page">Administration</DocLink>: View and manage hosts running ((elastic-defend)).
-
-<DocLink slug="/serverless/security/ingest-data">Ingest data to ((elastic-sec))</DocLink> and <DocLink slug="/serverless/security/install-edr">Install and configure the ((elastic-defend)) integration</DocLink> describe how to ship security-related data.
-
-### Additional ((elastic-defend)) information
-
-The [((elastic-defend)) integration](https://www.elastic.co/endpoint-security/)
-for ((agent)) provides capabilities such as collecting events, detecting and preventing
-malicious activity, exceptions, and artifact delivery. 
-[((fleet))](((fleet-guide))/fleet-overview.html) is used to
-install and manage ((agents)) and integrations on your hosts.
+* [((es))](https://www.elastic.co/products/elasticsearch): A real-time,
+distributed storage, search, and analytics engine. ((elastic-sec)) stores your data using ((es)).
+* [((kib))](https://www.elastic.co/products/kibana): An open-source analytics and
+visualization platform designed to work with ((es)) and ((elastic-sec)). ((kib)) allows you to search,
+view, analyze and visualize data stored in ((es)) indices.
 
 <div id="self-protection"></div>
 
 ### ((elastic-endpoint)) self-protection
 
 For information about ((elastic-endpoint))'s tamper-protection features, refer to <DocLink slug="/serverless/security/endpoint-self-protection" />.
-
-<div id="siem-integration"></div>
-
-### Integration with other Elastic products
-
-You can use ((elastic-sec)) with other Elastic products and features to help you
-identify and investigate suspicious activity:
-
-* [((ml-cap))](https://www.elastic.co/products/stack/machine-learning)
-* [Alerting](https://www.elastic.co/products/stack/alerting)
-
-<div id="data-sources"></div>
-
-### APM transaction data sources
-
-By default, ((elastic-sec)) monitors [APM](((apm-app-ref))/apm-getting-started.html)
-`apm-*-transaction*` indices. To add additional APM indices, update the
-index patterns in the `securitySolution:defaultIndex` setting in **Advanced Settings**.
-
-<div id="ecs-compliant-reqs"></div>
-
-### ECS compliance data requirements
-
-The [Elastic Common Schema (ECS)](((ecs-ref))) defines a common set of fields to be used for
-storing event data in Elasticsearch. ECS helps users normalize their event data
-to better analyze, visualize, and correlate the data represented in their
-events. ((elastic-sec)) supports events and indicator index data from any ECS-compliant data source.
-
-<DocCallOut title="Important" color="warning">
-((elastic-sec)) requires [ECS-compliant data](((ecs-ref))). If you use third-party data collectors to ship data to ((es)), the data must be mapped to ECS.
-<DocLink slug="/serverless/security/siem-field-reference" /> lists ECS fields used in ((elastic-sec)).
-</DocCallOut>

--- a/docs/serverless/serverless-security.docnav.json
+++ b/docs/serverless/serverless-security.docnav.json
@@ -174,19 +174,9 @@
         {
           "slug": "/serverless/security/allowlist-endpoint"
         },
-
-
-
         {
           "slug": "/serverless/security/endpoint-self-protection"
         },
-
-
-
-
-
-
-
         {
           "slug": "/serverless/security/troubleshoot-endpoints",
           "classic-sources": [ "enSecurityTsManagement" ]


### PR DESCRIPTION
Resolves https://github.com/elastic/security-docs/issues/5716, by updating the serverless docs with the changes started in ESS in https://github.com/elastic/security-docs/pull/4528. The serverless overview page now matches the [ESS overview page](https://www.elastic.co/guide/en/security/master/es-overview.html).

## Preview
Click [the link below](https://github.com/elastic/security-docs/pull/5738#issuecomment-2307242302), then navigate to the **Elastic Security overview** page in the serverless docs (not the landing page).

## Notable differences
These two bullets were omitted from the "Learn more" section, because the target pages don't exist in serverless docs:

- [Get started](https://www.elastic.co/guide/en/security/8.15/getting-started.html): Learn about system requirements, workspaces, configuration, and data ingestion.
- [Elastic Security fields and object schemas](https://www.elastic.co/guide/en/security/8.15/security-ref-intro.html): Learn how to structure data for use with Elastic Security.

Maybe eventually we'll add back in, or remove from ESS, once the two docsets are more fully aligned. But for now OK to just omit.