### PR TITLE
Adds Elastic Endpoint command reference

### DIFF
--- a/docs/management/admin/endpoint-command-ref.asciidoc
+++ b/docs/management/admin/endpoint-command-ref.asciidoc
@@ -5,12 +5,12 @@ This page lists the commands for management and troubleshooting of {elastic-endp
 
 [NOTE]
 ====
-* The service is not added to the `PATH` system variable, so you must prepend the commands with the full OS-dependent path:
+* {elastic-endpoint} is not added to the `PATH` system variable, so you must prepend the commands with the full OS-dependent path:
 ** On Windows: `"C:\Program Files\Elastic\Endpoint\elastic-endpoint.exe"`
 ** On macOS: `/Library/Elastic/Endpoint/elastic-endpoint`
 ** On Linux: `/opt/Elastic/Endpoint/elastic-endpoint`
 
-* You must run the commands with elevated privileges—as the root user on POSIX systems, or as Administrator on Windows.
+* You must run the commands with elevated privileges—as the root user on Linux and macOS, or as Administrator on Windows.
 ====
 
 The following {elastic-endpoint} commands are available:
@@ -232,7 +232,7 @@ Fleet server: https://fleet.example.elastic.co:443
 [[elastic-endpoint-top-command]]
 == elastic-endpoint top
 
-Show a breakdown of the executables that triggered {elastic-endpoint} CPU usage within the last interval. This utility displays which {elastic-endpoint} features are resource-intensive for a particular executable.
+Show a breakdown of the executables that triggered {elastic-endpoint} CPU usage within the last interval. This displays which {elastic-endpoint} features are resource-intensive for a particular executable.
 
 NOTE: The meaning and output of this command are similar, but not identical, to the POSIX `top` command. The `elastic-endpoint top` command aggregates multiple processes by executable. The utilization values aren't measured by the OS scheduler but by a wall clock in user mode. The output helps identify outliers causing excessive CPU utilization, allowing you to fine-tune the {elastic-defend} policy and exception lists in your deployment.
 

--- a/docs/management/admin/endpoint-command-ref.asciidoc
+++ b/docs/management/admin/endpoint-command-ref.asciidoc
@@ -48,16 +48,40 @@ Gather diagnostics information from {elastic-endpoint}. This command produces an
 - `logs` directory: Copy of {elastic-endpoint} log files
 
 [discrete]
+=== Example
+
+[source,shell]
+------
+sudo /Library/Elastic/Endpoint/elastic-endpoint diagnostics
+------
+
+[discrete]
 [[elastic-endpoint-help-command]]
 == elastic-endpoint help
 
 Show help for the available commands.
 
 [discrete]
+=== Example
+
+[source,shell]
+------
+sudo /Library/Elastic/Endpoint/elastic-endpoint help
+------
+
+[discrete]
 [[elastic-endpoint-inspect-command]]
 == elastic-endpoint inspect
 
 Show the current {elastic-endpoint} configuration.
+
+[discrete]
+=== Example
+
+[source,shell]
+------
+sudo /Library/Elastic/Endpoint/elastic-endpoint inspect
+------
 
 [discrete]
 [[elastic-endpoint-install-command]]
@@ -77,6 +101,14 @@ Specify a resources `.zip` file to be used during the installation.
 Upgrade the existing installation.
 
 [discrete]
+=== Example
+
+[source,shell]
+------
+sudo /Library/Elastic/Endpoint/elastic-endpoint install --upgrade
+------
+
+[discrete]
 [[elastic-endpoint-memorydump-command]]
 == elastic-endpoint memorydump
 
@@ -92,10 +124,26 @@ Compress the saved memory dump.
 Specify the memory collection timeout, in seconds; the default is 60 seconds.
 
 [discrete]
+=== Example
+
+[source,shell]
+------
+sudo /Library/Elastic/Endpoint/elastic-endpoint memorydump --timeout 120
+------
+
+[discrete]
 [[elastic-endpoint-run-command]]
 == elastic-endpoint run
 
 Run `elastic-endpoint` as a foreground process if no other instance is already running.
+
+[discrete]
+=== Example
+
+[source,shell]
+------
+sudo /Library/Elastic/Endpoint/elastic-endpoint run
+------
 
 [discrete]
 [[elastic-endpoint-send-command]]
@@ -108,6 +156,14 @@ Send the requested document to the {stack}.
 
 `metadata`::
 Send an off-schedule metrics document to the {stack}.
+
+[discrete]
+=== Example
+
+[source,shell]
+------
+sudo /Library/Elastic/Endpoint/elastic-endpoint send metadata
+------
 
 [discrete]
 [[elastic-endpoint-status-command]]
@@ -126,6 +182,14 @@ Control the level of detail and formatting of the information. Valid values are:
 * `json`: Always returns the full status information.
 
 [discrete]
+=== Example
+
+[source,shell]
+------
+sudo /Library/Elastic/Endpoint/elastic-endpoint status --output json
+------
+
+[discrete]
 [[elastic-endpoint-test-command]]
 == elastic-endpoint test
 
@@ -139,6 +203,14 @@ Test whether {elastic-endpoint} can connect to remote resources.
 
 [discrete]
 === Example
+
+[source,shell]
+------
+sudo /Library/Elastic/Endpoint/elastic-endpoint test output
+------
+
+[discrete]
+=== Example output
 
 [source,txt]
 ----
@@ -178,6 +250,14 @@ Normalize CPU usage values to a total of 100% across all CPUs on multi-CPU syste
 
 [discrete]
 === Example
+
+[source,shell]
+------
+sudo /Library/Elastic/Endpoint/elastic-endpoint top --interval 10 --limit 5
+------
+
+[discrete]
+=== Example output
 
 [source,txt]
 ----
@@ -240,8 +320,24 @@ NOTE: {elastic-endpoint} is managed by {agent}. To remove {elastic-endpoint} fro
 Provide the uninstall token. The token is required if <<agent-tamper-protection,agent tamper protection>> is enabled.
 
 [discrete]
+=== Example
+
+[source,shell]
+------
+sudo /Library/Elastic/Endpoint/elastic-endpoint uninstall --uninstall-token 12345678901234567890123456789012
+------
+
+[discrete]
 [[elastic-endpoint-version-command]]
 == elastic-endpoint version
 
 Show the version of {elastic-endpoint}.
+
+[discrete]
+=== Example
+
+[source,shell]
+------
+sudo /Library/Elastic/Endpoint/elastic-endpoint version
+------
 

--- a/docs/management/admin/endpoint-command-ref.asciidoc
+++ b/docs/management/admin/endpoint-command-ref.asciidoc
@@ -88,8 +88,8 @@ Save a memory dump of the {elastic-endpoint} service.
 `--compress`::
 Compress the saved memory dump.
 
-`--timeout`::
-The memory collection timeout; the default is 60 seconds.
+`--timeout <duration>`::
+Specify the memory collection timeout; the default is 60 seconds.
 
 [discrete]
 [[elastic-endpoint-run-command]]
@@ -167,11 +167,11 @@ NOTE: The meaning and output of this command are similar, but not identical, to 
 [discrete]
 === Options
 
-`--interval`::
-The data collection interval; the default is 5 seconds.
+`--interval <duration>`::
+Specify the data collection interval; the default is 5 seconds.
 
-`--limit`::
-The number of updates to collect; by default, data is collected until interrupted by **Ctrl+C**.
+`--limit <number>`::
+Specify the number of updates to collect; by default, data is collected until interrupted by **Ctrl+C**.
 
 `--normalized`::
 Normalize values to 100% on multi-CPU systems.
@@ -236,8 +236,8 @@ NOTE: {elastic-endpoint} is managed by {agent}. To remove {elastic-endpoint} fro
 [discrete]
 === Options
 
-`--uninstall-token`::
-The uninstall token. This is required if <<agent-tamper-protection,agent tamper protection>> is enabled.
+`--uninstall-token <string>`::
+Provide the uninstall token. The token is required if <<agent-tamper-protection,agent tamper protection>> is enabled.
 
 [discrete]
 [[elastic-endpoint-version-command]]

--- a/docs/management/admin/endpoint-command-ref.asciidoc
+++ b/docs/management/admin/endpoint-command-ref.asciidoc
@@ -1,0 +1,247 @@
+[[endpoint-command-ref]]
+= {elastic-endpoint} command reference
+
+This page lists the commands for management and troubleshooting of {elastic-endpoint}, the installed component that performs {elastic-defend}'s threat monitoring and prevention.
+
+[NOTE]
+====
+* The service is not added to the `PATH` system variable, so you must prepend the commands with the full OS-dependent path:
+** On Windows: `"C:\Program Files\Elastic\Endpoint\elastic-endpoint.exe"`
+** On macOS: `/Library/Elastic/Endpoint/elastic-endpoint`
+** On Linux: `/opt/Elastic/Endpoint/elastic-endpoint`
+
+* You must run the commands from an elevated command prompt—as the root user on POSIX, or Administrator on Windows.
+====
+
+The following {elastic-endpoint} commands are available:
+
+* <<elastic-endpoint-diagnostics-command, diagnostics>>
+* <<elastic-endpoint-help-command, help>>
+* <<elastic-endpoint-inspect-command, inspect>>
+* <<elastic-endpoint-install-command, install>>
+* <<elastic-endpoint-memorydump-command, memorydump>>
+* <<elastic-endpoint-run-command, run>>
+* <<elastic-endpoint-send-command, send>>
+* <<elastic-endpoint-status-command, status>>
+* <<elastic-endpoint-test-command, test>>
+* <<elastic-endpoint-top-command, top>>
+* <<elastic-endpoint-uninstall-command, uninstall>>
+* <<elastic-endpoint-version-command, version>>
+
+Each of the commands accepts logging options:
+
+* `--log [stdout,stderr,debugview,file]`
+* `--log-level [error,info,debug]`
+
+[discrete]
+[[elastic-endpoint-diagnostics-command]]
+== elastic-endpoint diagnostics
+
+Gather diagnostics information from {elastic-endpoint}. This command produces an archive that contains:
+
+- `version.txt`: Version information
+- `elastic-endpoint.yaml`: Current policy
+- `metrics.json`: Metrics document
+- `policy_response.json`: Last policy response
+- `system_info.txt`: System information
+- `analysis.txt`: Diagnostic analysis report
+- `logs` directory: Copy of {elastic-endpoint} log files
+
+[discrete]
+[[elastic-endpoint-help-command]]
+== elastic-endpoint help
+
+Show help for the available commands.
+
+[discrete]
+[[elastic-endpoint-inspect-command]]
+== elastic-endpoint inspect
+
+Show the current {elastic-endpoint} configuration.
+
+[discrete]
+[[elastic-endpoint-install-command]]
+== elastic-endpoint install
+
+Install {elastic-endpoint} as a system service.
+
+NOTE: Elastic doesn't publish independent {elastic-endpoint} packages since {elastic-endpoint} is managed by {agent}.
+
+[discrete]
+=== Options
+
+`--resources`::
+Install the resources `.zip` file.
+
+`--upgrade`::
+Upgrade the existing installation.
+
+[discrete]
+[[elastic-endpoint-memorydump-command]]
+== elastic-endpoint memorydump
+
+Save a memory dump of the {elastic-endpoint} service.
+
+[discrete]
+=== Options
+
+`--compress`::
+Compress the saved memory dump.
+
+`--timeout`::
+The memory collection timeout; the default is 60 seconds.
+
+[discrete]
+[[elastic-endpoint-run-command]]
+== elastic-endpoint run
+
+Run `elastic-endpoint` as a foreground process if no other instance is already running.
+
+[discrete]
+[[elastic-endpoint-send-command]]
+== elastic-endpoint send
+
+Send the requested document to the {stack}.
+
+[discrete]
+=== Subcommands
+
+`metadata`::
+Send an off-schedule metrics document to the {stack}.
+
+[discrete]
+[[elastic-endpoint-status-command]]
+== elastic-endpoint status
+
+Retrieve the current status of the running {elastic-endpoint} service. The command also returns the last known status of {agent}.
+
+[discrete]
+=== Options
+
+`--output`::
+Control the level of detail and formatting of the information. Valid values are:
+
+* `human`: Returns limited information when {elastic-endpoint}'s status is `Healthy`. If any policy actions weren't successfully applied, the relevant details are displayed.
+* `full`: Always returns the full status information.
+* `json`: Always returns the full status information.
+
+[discrete]
+[[elastic-endpoint-test-command]]
+== elastic-endpoint test
+
+Perform the requested test.
+
+[discrete]
+=== Subcommands
+
+`output`::
+Test whether {elastic-endpoint} can connect to remote resources.
+
+[discrete]
+=== Example
+
+[source,txt]
+----
+Testing output connections using config file: [C:\Program Files\Elastic\Endpoint\elastic-endpoint.yaml]
+
+Using proxy:
+
+Elasticsearch server: https://example.elastic.co:443
+        Status: Success
+
+Global artifact server: https://artifacts.security.elastic.co
+        Status: Success
+
+Fleet server: https://fleet.example.elastic.co:443
+        Status: Success
+----
+
+[discrete]
+[[elastic-endpoint-top-command]]
+== elastic-endpoint top
+
+Show a breakdown of the executables that triggered {elastic-endpoint} CPU usage within the last interval. This utility displays which {elastic-endpoint} features are resource-intensive for a particular executable.
+
+NOTE: The meaning and output of this command are similar, but not identical, to the POSIX `top` command. The `elastic-endpoint top` command aggregates multiple processes by executable. The utilization values aren't measured by the OS scheduler but by a wall clock in user mode. The output helps identify outliers causing excessive CPU utilization, allowing you to fine-tune the {elastic-defend} policy and exception lists in your deployment.
+
+[discrete]
+=== Options
+
+`--interval`::
+The data collection interval; the default is 5 seconds.
+
+`--limit`::
+The number of updates to collect; by default, data is collected until interrupted by **Ctrl+C**.
+
+`--normalized`::
+Normalize values to 100% on multi-CPU systems.
+
+[discrete]
+=== Example
+
+[source,txt]
+----
+| PROCESS                                            | OVERALL | API | BHVR | DIAG BHVR | DNS | FILE   | LIB | MEM SCAN | MLWR  | NET | PROC | RANSOM | REG |
+=============================================================================================================================================================
+| MSBuild.exe                                        |  3146.0 | 0.0 |  0.8 |       0.7 | 0.0 | 2330.9 | 0.0 |    226.2 | 586.9 | 0.0 |  0.0 |    0.4 | 0.0 |
+| Microsoft.Management.Services.IntuneWindowsAgen... |    30.0 | 0.0 |  0.0 |       0.0 | 0.0 |    0.0 | 0.2 |     29.8 |   0.0 | 0.0 |  0.0 |    0.0 | 0.0 |
+| svchost.exe                                        |    27.3 | 0.0 |  0.1 |       0.1 | 0.0 |    0.4 | 0.2 |      0.0 |  26.6 | 0.0 |  0.0 |    0.0 | 0.0 |
+| LenovoVantage-(LenovoServiceBridgeAddin).exe       |     0.1 | 0.0 |  0.0 |       0.0 | 0.0 |    0.0 | 0.1 |      0.0 |   0.0 | 0.0 |  0.0 |    0.0 | 0.0 |
+| Lenovo.Modern.ImController.PluginHost.Device.exe   |     0.0 | 0.0 |  0.0 |       0.0 | 0.0 |    0.0 | 0.0 |      0.0 |   0.0 | 0.0 |  0.0 |    0.0 | 0.0 |
+| msedgewebview2.exe                                 |     0.0 | 0.0 |  0.0 |       0.0 | 0.0 |    0.0 | 0.0 |      0.0 |   0.0 | 0.0 |  0.0 |    0.0 | 0.0 |
+| msedge.exe                                         |     0.0 | 0.0 |  0.0 |       0.0 | 0.0 |    0.0 | 0.0 |      0.0 |   0.0 | 0.0 |  0.0 |    0.0 | 0.0 |
+| powershell.exe                                     |     0.0 | 0.0 |  0.0 |       0.0 | 0.0 |    0.0 | 0.0 |      0.0 |   0.0 | 0.0 |  0.0 |    0.0 | 0.0 |
+| WmiPrvSE.exe                                       |     0.0 | 0.0 |  0.0 |       0.0 | 0.0 |    0.0 | 0.0 |      0.0 |   0.0 | 0.0 |  0.0 |    0.0 | 0.0 |
+| Lenovo.Modern.ImController.PluginHost.Device.exe   |     0.0 | 0.0 |  0.0 |       0.0 | 0.0 |    0.0 | 0.0 |      0.0 |   0.0 | 0.0 |  0.0 |    0.0 | 0.0 |
+| Slack.exe                                          |     0.0 | 0.0 |  0.0 |       0.0 | 0.0 |    0.0 | 0.0 |      0.0 |   0.0 | 0.0 |  0.0 |    0.0 | 0.0 |
+| uhssvc.exe                                         |     0.0 | 0.0 |  0.0 |       0.0 | 0.0 |    0.0 | 0.0 |      0.0 |   0.0 | 0.0 |  0.0 |    0.0 | 0.0 |
+| explorer.exe                                       |     0.0 | 0.0 |  0.0 |       0.0 | 0.0 |    0.0 | 0.0 |      0.0 |   0.0 | 0.0 |  0.0 |    0.0 | 0.0 |
+| taskhostw.exe                                      |     0.0 | 0.0 |  0.0 |       0.0 | 0.0 |    0.0 | 0.0 |      0.0 |   0.0 | 0.0 |  0.0 |    0.0 | 0.0 |
+| Widgets.exe                                        |     0.0 | 0.0 |  0.0 |       0.0 | 0.0 |    0.0 | 0.0 |      0.0 |   0.0 | 0.0 |  0.0 |    0.0 | 0.0 |
+| elastic-endpoint.exe                               |     0.0 | 0.0 |  0.0 |       0.0 | 0.0 |    0.0 | 0.0 |      0.0 |   0.0 | 0.0 |  0.0 |    0.0 | 0.0 |
+| sppsvc.exe                                         |     0.0 | 0.0 |  0.0 |       0.0 | 0.0 |    0.0 | 0.0 |      0.0 |   0.0 | 0.0 |  0.0 |    0.0 | 0.0 |
+
+Endpoint service (16 CPU): 113.0% out of 1600%
+
+Collecting data.  Press Ctrl-C to cancel
+----
+
+[discrete]
+==== Column abbreviations
+
+* `API`: ETW API events
+* `AUTH`: Authentication events
+* `BHVR`: Malicious behavior protection
+* `CRED`: Credential access events
+* `DIAG BHVR`: Diagnostic malicious behavior protection
+* `DNS`: DNS events
+* `FILE`: File events
+* `LIB`: Library load events
+* `MEM SCAN`: Memory scanning
+* `MLWR`: Malware protection
+* `NET`: Network events
+* `PROC`: Process events
+* `PROC INJ`: Process injection
+* `RANSOM`: Ransomware protection
+* `REG`: Registry events
+
+[discrete]
+[[elastic-endpoint-uninstall-command]]
+== elastic-endpoint uninstall
+
+Uninstall {elastic-endpoint}.
+
+NOTE: {elastic-endpoint} is managed by {agent}. To remove {elastic-endpoint} from the target machine permanently, remove the {elastic-defend} integration from the {fleet} policy. The <<uninstall-agent,elastic-agent uninstall>> command also uninstalls {elastic-endpoint}; therefore, in practice, the `elastic-endpoint uninstall` command is used only to troubleshoot broken installations.
+
+[discrete]
+=== Options
+
+`--uninstall-token`::
+The uninstall token. This is required if <<agent-tamper-protection,agent tamper protection>> is enabled.
+
+[discrete]
+[[elastic-endpoint-version-command]]
+== elastic-endpoint version
+
+Show the version of {elastic-endpoint}.
+

--- a/docs/management/admin/endpoint-command-ref.asciidoc
+++ b/docs/management/admin/endpoint-command-ref.asciidoc
@@ -10,7 +10,7 @@ This page lists the commands for management and troubleshooting of {elastic-endp
 ** On macOS: `/Library/Elastic/Endpoint/elastic-endpoint`
 ** On Linux: `/opt/Elastic/Endpoint/elastic-endpoint`
 
-* You must run the commands from an elevated command prompt—as the root user on POSIX, or Administrator on Windows.
+* You must run the commands with elevated privileges—as the root user on POSIX systems, or as Administrator on Windows.
 ====
 
 The following {elastic-endpoint} commands are available:
@@ -28,7 +28,7 @@ The following {elastic-endpoint} commands are available:
 * <<elastic-endpoint-uninstall-command, uninstall>>
 * <<elastic-endpoint-version-command, version>>
 
-Each of the commands accepts logging options:
+Each of the commands accepts the following logging options:
 
 * `--log [stdout,stderr,debugview,file]`
 * `--log-level [error,info,debug]`
@@ -70,8 +70,8 @@ NOTE: Elastic doesn't publish independent {elastic-endpoint} packages since {ela
 [discrete]
 === Options
 
-`--resources`::
-Install the resources `.zip` file.
+`--resources <string>`::
+Specify a resources `.zip` file to be used during the installation.
 
 `--upgrade`::
 Upgrade the existing installation.
@@ -89,7 +89,7 @@ Save a memory dump of the {elastic-endpoint} service.
 Compress the saved memory dump.
 
 `--timeout <duration>`::
-Specify the memory collection timeout; the default is 60 seconds.
+Specify the memory collection timeout, in seconds; the default is 60 seconds.
 
 [discrete]
 [[elastic-endpoint-run-command]]
@@ -168,13 +168,13 @@ NOTE: The meaning and output of this command are similar, but not identical, to 
 === Options
 
 `--interval <duration>`::
-Specify the data collection interval; the default is 5 seconds.
+Specify the data collection interval, in seconds; the default is 5 seconds.
 
 `--limit <number>`::
 Specify the number of updates to collect; by default, data is collected until interrupted by **Ctrl+C**.
 
 `--normalized`::
-Normalize values to 100% on multi-CPU systems.
+Normalize CPU usage values to a total of 100% across all CPUs on multi-CPU systems.
 
 [discrete]
 === Example
@@ -209,7 +209,7 @@ Collecting data.  Press Ctrl-C to cancel
 [discrete]
 ==== Column abbreviations
 
-* `API`: ETW API events
+* `API`: Event Tracing for Windows (ETW) API events
 * `AUTH`: Authentication events
 * `BHVR`: Malicious behavior protection
 * `CRED`: Credential access events

--- a/docs/management/admin/endpoint-command-ref.asciidoc
+++ b/docs/management/admin/endpoint-command-ref.asciidoc
@@ -95,7 +95,7 @@ NOTE: Elastic doesn't publish independent {elastic-endpoint} packages since {ela
 === Options
 
 `--resources <string>`::
-Specify a resources `.zip` file to be used during the installation.
+Specify a resources `.zip` file to be used during the installation. This option is required.
 
 `--upgrade`::
 Upgrade the existing installation.
@@ -105,7 +105,7 @@ Upgrade the existing installation.
 
 [source,shell]
 ------
-sudo /Library/Elastic/Endpoint/elastic-endpoint install --upgrade
+sudo /Library/Elastic/Endpoint/elastic-endpoint install --upgrade --resources endpoint-security-resources.zip
 ------
 
 [discrete]
@@ -214,7 +214,7 @@ sudo /Library/Elastic/Endpoint/elastic-endpoint test output
 
 [source,txt]
 ----
-Testing output connections using config file: [C:\Program Files\Elastic\Endpoint\elastic-endpoint.yaml]
+Testing output connections
 
 Using proxy:
 

--- a/docs/management/admin/endpoint-command-ref.asciidoc
+++ b/docs/management/admin/endpoint-command-ref.asciidoc
@@ -10,7 +10,7 @@ This page lists the commands for management and troubleshooting of {elastic-endp
 ** On macOS: `/Library/Elastic/Endpoint/elastic-endpoint`
 ** On Linux: `/opt/Elastic/Endpoint/elastic-endpoint`
 
-* You must run the commands with elevated privileges—as the root user on Linux and macOS, or as Administrator on Windows.
+* You must run the commands with elevated privileges—using `sudo` to run as the root user on Linux and macOS, or running as Administrator on Windows.
 ====
 
 The following {elastic-endpoint} commands are available:
@@ -52,7 +52,7 @@ Gather diagnostics information from {elastic-endpoint}. This command produces an
 
 [source,shell]
 ------
-sudo /Library/Elastic/Endpoint/elastic-endpoint diagnostics
+elastic-endpoint diagnostics
 ------
 
 [discrete]
@@ -66,7 +66,7 @@ Show help for the available commands.
 
 [source,shell]
 ------
-sudo /Library/Elastic/Endpoint/elastic-endpoint help
+elastic-endpoint help
 ------
 
 [discrete]
@@ -80,7 +80,7 @@ Show the current {elastic-endpoint} configuration.
 
 [source,shell]
 ------
-sudo /Library/Elastic/Endpoint/elastic-endpoint inspect
+elastic-endpoint inspect
 ------
 
 [discrete]
@@ -89,7 +89,7 @@ sudo /Library/Elastic/Endpoint/elastic-endpoint inspect
 
 Install {elastic-endpoint} as a system service.
 
-NOTE: Elastic doesn't publish independent {elastic-endpoint} packages since {elastic-endpoint} is managed by {agent}.
+NOTE: We do not recommend installing {elastic-endpoint} using this command. {elastic-endpoint} is managed by {agent} and cannot function as a standalone service. Therefore, there is no separate installation package for {elastic-endpoint}, and it should not be installed independently.
 
 [discrete]
 === Options
@@ -105,7 +105,7 @@ Upgrade the existing installation.
 
 [source,shell]
 ------
-sudo /Library/Elastic/Endpoint/elastic-endpoint install --upgrade --resources endpoint-security-resources.zip
+elastic-endpoint install --upgrade --resources endpoint-security-resources.zip
 ------
 
 [discrete]
@@ -128,7 +128,7 @@ Specify the memory collection timeout, in seconds; the default is 60 seconds.
 
 [source,shell]
 ------
-sudo /Library/Elastic/Endpoint/elastic-endpoint memorydump --timeout 120
+elastic-endpoint memorydump --timeout 120
 ------
 
 [discrete]
@@ -142,7 +142,7 @@ Run `elastic-endpoint` as a foreground process if no other instance is already r
 
 [source,shell]
 ------
-sudo /Library/Elastic/Endpoint/elastic-endpoint run
+elastic-endpoint run
 ------
 
 [discrete]
@@ -162,7 +162,7 @@ Send an off-schedule metrics document to the {stack}.
 
 [source,shell]
 ------
-sudo /Library/Elastic/Endpoint/elastic-endpoint send metadata
+elastic-endpoint send metadata
 ------
 
 [discrete]
@@ -186,7 +186,7 @@ Control the level of detail and formatting of the information. Valid values are:
 
 [source,shell]
 ------
-sudo /Library/Elastic/Endpoint/elastic-endpoint status --output json
+elastic-endpoint status --output json
 ------
 
 [discrete]
@@ -206,7 +206,7 @@ Test whether {elastic-endpoint} can connect to remote resources.
 
 [source,shell]
 ------
-sudo /Library/Elastic/Endpoint/elastic-endpoint test output
+elastic-endpoint test output
 ------
 
 [discrete]
@@ -253,7 +253,7 @@ Normalize CPU usage values to a total of 100% across all CPUs on multi-CPU syste
 
 [source,shell]
 ------
-sudo /Library/Elastic/Endpoint/elastic-endpoint top --interval 10 --limit 5
+elastic-endpoint top --interval 10 --limit 5
 ------
 
 [discrete]
@@ -324,7 +324,7 @@ Provide the uninstall token. The token is required if <<agent-tamper-protection,
 
 [source,shell]
 ------
-sudo /Library/Elastic/Endpoint/elastic-endpoint uninstall --uninstall-token 12345678901234567890123456789012
+elastic-endpoint uninstall --uninstall-token 12345678901234567890123456789012
 ------
 
 [discrete]
@@ -338,6 +338,6 @@ Show the version of {elastic-endpoint}.
 
 [source,shell]
 ------
-sudo /Library/Elastic/Endpoint/elastic-endpoint version
+elastic-endpoint version
 ------
 

--- a/docs/management/manage-intro.asciidoc
+++ b/docs/management/manage-intro.asciidoc
@@ -14,3 +14,4 @@ include::{security-docs-root}/docs/management/admin/endpoint-artifacts.asciidoc[
 include::{security-docs-root}/docs/management/admin/endpoint-event-capture.asciidoc[leveloffset=+1]
 include::{security-docs-root}/docs/management/admin/allowlist-endpoint-3rd-party-av.asciidoc[leveloffset=+1]
 include::{security-docs-root}/docs/management/admin/endpoint-self-protection.asciidoc[leveloffset=+1]
+include::{security-docs-root}/docs/management/admin/endpoint-command-ref.asciidoc[leveloffset=+1]

--- a/docs/serverless/edr-manage/endpoint-command-ref.mdx
+++ b/docs/serverless/edr-manage/endpoint-command-ref.mdx
@@ -90,7 +90,7 @@ Elastic doesn't publish independent ((elastic-endpoint)) packages since ((elasti
 ### Options
 
 `--resources <string>`
-    : Specify a resources `.zip` file to be used during the installation.
+    : Specify a resources `.zip` file to be used during the installation. This option is required.
 
 `--upgrade`
     : Upgrade the existing installation.
@@ -98,7 +98,7 @@ Elastic doesn't publish independent ((elastic-endpoint)) packages since ((elasti
 ### Example
 
 ```
-sudo /Library/Elastic/Endpoint/elastic-endpoint install --upgrade
+sudo /Library/Elastic/Endpoint/elastic-endpoint install --upgrade --resources endpoint-security-resources.zip
 ```
 
 ## elastic-endpoint memorydump
@@ -181,7 +181,7 @@ sudo /Library/Elastic/Endpoint/elastic-endpoint test output
 ### Example output
 
 ```
-Testing output connections using config file: [C:\Program Files\Elastic\Endpoint\elastic-endpoint.yaml]
+Testing output connections
 
 Using proxy:
 

--- a/docs/serverless/edr-manage/endpoint-command-ref.mdx
+++ b/docs/serverless/edr-manage/endpoint-command-ref.mdx
@@ -1,0 +1,226 @@
+---
+slug: /serverless/security/endpoint-command-ref
+title: ((elastic-endpoint)) command reference
+description: Manage and troubleshoot ((elastic-endpoint)) using CLI commands.
+tags: ["security","reference","manage"]
+status: in review
+---
+
+<DocBadge template="technical preview" />
+<div id="endpoint-command-ref"></div>
+
+This page lists the commands for management and troubleshooting of ((elastic-endpoint)), the installed component that performs ((elastic-defend))'s threat monitoring and prevention.
+
+<DocCallOut title="Note">
+
+* The service is not added to the `PATH` system variable, so you must prepend the commands with the full OS-dependent path:
+    * On Windows: `"C:\Program Files\Elastic\Endpoint\elastic-endpoint.exe"`
+    * On macOS: `/Library/Elastic/Endpoint/elastic-endpoint`
+    * On Linux: `/opt/Elastic/Endpoint/elastic-endpoint`
+
+* You must run the commands with elevated privileges—as the root user on POSIX systems, or as Administrator on Windows.
+
+</DocCallOut>
+
+The following ((elastic-endpoint)) commands are available:
+
+* <DocLink slug="/serverless/security/endpoint-command-ref" section="elastic-endpoint-diagnostics">diagnostics</DocLink>
+* <DocLink slug="/serverless/security/endpoint-command-ref" section="elastic-endpoint-help">help</DocLink>
+* <DocLink slug="/serverless/security/endpoint-command-ref" section="elastic-endpoint-inspect">inspect</DocLink>
+* <DocLink slug="/serverless/security/endpoint-command-ref" section="elastic-endpoint-install">install</DocLink>
+* <DocLink slug="/serverless/security/endpoint-command-ref" section="elastic-endpoint-memorydump">memorydump</DocLink>
+* <DocLink slug="/serverless/security/endpoint-command-ref" section="elastic-endpoint-run">run</DocLink>
+* <DocLink slug="/serverless/security/endpoint-command-ref" section="elastic-endpoint-send">send</DocLink>
+* <DocLink slug="/serverless/security/endpoint-command-ref" section="elastic-endpoint-status">status</DocLink>
+* <DocLink slug="/serverless/security/endpoint-command-ref" section="elastic-endpoint-test">test</DocLink>
+* <DocLink slug="/serverless/security/endpoint-command-ref" section="elastic-endpoint-top">top</DocLink>
+* <DocLink slug="/serverless/security/endpoint-command-ref" section="elastic-endpoint-uninstall">uninstall</DocLink>
+* <DocLink slug="/serverless/security/endpoint-command-ref" section="elastic-endpoint-version">version</DocLink>
+
+Each of the commands accepts the following logging options:
+
+* `--log [stdout,stderr,debugview,file]`
+* `--log-level [error,info,debug]`
+
+## elastic-endpoint diagnostics
+
+Gather diagnostics information from ((elastic-endpoint)). This command produces an archive that contains:
+
+- `version.txt`: Version information
+- `elastic-endpoint.yaml`: Current policy
+- `metrics.json`: Metrics document
+- `policy_response.json`: Last policy response
+- `system_info.txt`: System information
+- `analysis.txt`: Diagnostic analysis report
+- `logs` directory: Copy of ((elastic-endpoint)) log files
+
+## elastic-endpoint help
+
+Show help for the available commands.
+
+## elastic-endpoint inspect
+
+Show the current ((elastic-endpoint)) configuration.
+
+## elastic-endpoint install
+
+Install ((elastic-endpoint)) as a system service.
+
+<DocCallOut title="Note">
+Elastic doesn't publish independent ((elastic-endpoint)) packages since ((elastic-endpoint)) is managed by ((agent)).
+</DocCallOut>
+### Options
+
+`--resources <string>`
+    : Specify a resources `.zip` file to be used during the installation.
+
+`--upgrade`
+    : Upgrade the existing installation.
+
+## elastic-endpoint memorydump
+
+Save a memory dump of the ((elastic-endpoint)) service.
+
+### Options
+
+`--compress`
+    : Compress the saved memory dump.
+
+`--timeout <duration>`
+    : Specify the memory collection timeout, in seconds; the default is 60 seconds.
+
+## elastic-endpoint run
+
+Run `elastic-endpoint` as a foreground process if no other instance is already running.
+
+## elastic-endpoint send
+
+Send the requested document to the ((stack)).
+
+### Subcommands
+
+`metadata`
+    : Send an off-schedule metrics document to the ((stack)).
+
+## elastic-endpoint status
+
+Retrieve the current status of the running ((elastic-endpoint)) service. The command also returns the last known status of ((agent)).
+
+### Options
+
+`--output`
+    : Control the level of detail and formatting of the information. Valid values are:
+
+    * `human`: Returns limited information when ((elastic-endpoint))'s status is `Healthy`. If any policy actions weren't successfully applied, the relevant details are displayed.
+    * `full`: Always returns the full status information.
+    * `json`: Always returns the full status information.
+
+## elastic-endpoint test
+
+Perform the requested test.
+
+### Subcommands
+
+`output`
+    : Test whether ((elastic-endpoint)) can connect to remote resources.
+
+### Example
+
+```
+Testing output connections using config file: [C:\Program Files\Elastic\Endpoint\elastic-endpoint.yaml]
+
+Using proxy:
+
+Elasticsearch server: https://example.elastic.co:443
+        Status: Success
+
+Global artifact server: https://artifacts.security.elastic.co
+        Status: Success
+
+Fleet server: https://fleet.example.elastic.co:443
+        Status: Success
+```
+
+## elastic-endpoint top
+
+Show a breakdown of the executables that triggered ((elastic-endpoint)) CPU usage within the last interval. This utility displays which ((elastic-endpoint)) features are resource-intensive for a particular executable.
+
+<DocCallOut title="Note">
+The meaning and output of this command are similar, but not identical, to the POSIX `top` command. The `elastic-endpoint top` command aggregates multiple processes by executable. The utilization values aren't measured by the OS scheduler but by a wall clock in user mode. The output helps identify outliers causing excessive CPU utilization, allowing you to fine-tune the ((elastic-defend)) policy and exception lists in your deployment.
+</DocCallOut>
+
+### Options
+
+`--interval <duration>`
+    : Specify the data collection interval, in seconds; the default is 5 seconds.
+
+`--limit <number>`
+    : Specify the number of updates to collect; by default, data is collected until interrupted by **Ctrl+C**.
+
+`--normalized`
+    : Normalize CPU usage values to a total of 100% across all CPUs on multi-CPU systems.
+
+### Example
+
+```
+| PROCESS                                            | OVERALL | API | BHVR | DIAG BHVR | DNS | FILE   | LIB | MEM SCAN | MLWR  | NET | PROC | RANSOM | REG |
+=============================================================================================================================================================
+| MSBuild.exe                                        |  3146.0 | 0.0 |  0.8 |       0.7 | 0.0 | 2330.9 | 0.0 |    226.2 | 586.9 | 0.0 |  0.0 |    0.4 | 0.0 |
+| Microsoft.Management.Services.IntuneWindowsAgen... |    30.0 | 0.0 |  0.0 |       0.0 | 0.0 |    0.0 | 0.2 |     29.8 |   0.0 | 0.0 |  0.0 |    0.0 | 0.0 |
+| svchost.exe                                        |    27.3 | 0.0 |  0.1 |       0.1 | 0.0 |    0.4 | 0.2 |      0.0 |  26.6 | 0.0 |  0.0 |    0.0 | 0.0 |
+| LenovoVantage-(LenovoServiceBridgeAddin).exe       |     0.1 | 0.0 |  0.0 |       0.0 | 0.0 |    0.0 | 0.1 |      0.0 |   0.0 | 0.0 |  0.0 |    0.0 | 0.0 |
+| Lenovo.Modern.ImController.PluginHost.Device.exe   |     0.0 | 0.0 |  0.0 |       0.0 | 0.0 |    0.0 | 0.0 |      0.0 |   0.0 | 0.0 |  0.0 |    0.0 | 0.0 |
+| msedgewebview2.exe                                 |     0.0 | 0.0 |  0.0 |       0.0 | 0.0 |    0.0 | 0.0 |      0.0 |   0.0 | 0.0 |  0.0 |    0.0 | 0.0 |
+| msedge.exe                                         |     0.0 | 0.0 |  0.0 |       0.0 | 0.0 |    0.0 | 0.0 |      0.0 |   0.0 | 0.0 |  0.0 |    0.0 | 0.0 |
+| powershell.exe                                     |     0.0 | 0.0 |  0.0 |       0.0 | 0.0 |    0.0 | 0.0 |      0.0 |   0.0 | 0.0 |  0.0 |    0.0 | 0.0 |
+| WmiPrvSE.exe                                       |     0.0 | 0.0 |  0.0 |       0.0 | 0.0 |    0.0 | 0.0 |      0.0 |   0.0 | 0.0 |  0.0 |    0.0 | 0.0 |
+| Lenovo.Modern.ImController.PluginHost.Device.exe   |     0.0 | 0.0 |  0.0 |       0.0 | 0.0 |    0.0 | 0.0 |      0.0 |   0.0 | 0.0 |  0.0 |    0.0 | 0.0 |
+| Slack.exe                                          |     0.0 | 0.0 |  0.0 |       0.0 | 0.0 |    0.0 | 0.0 |      0.0 |   0.0 | 0.0 |  0.0 |    0.0 | 0.0 |
+| uhssvc.exe                                         |     0.0 | 0.0 |  0.0 |       0.0 | 0.0 |    0.0 | 0.0 |      0.0 |   0.0 | 0.0 |  0.0 |    0.0 | 0.0 |
+| explorer.exe                                       |     0.0 | 0.0 |  0.0 |       0.0 | 0.0 |    0.0 | 0.0 |      0.0 |   0.0 | 0.0 |  0.0 |    0.0 | 0.0 |
+| taskhostw.exe                                      |     0.0 | 0.0 |  0.0 |       0.0 | 0.0 |    0.0 | 0.0 |      0.0 |   0.0 | 0.0 |  0.0 |    0.0 | 0.0 |
+| Widgets.exe                                        |     0.0 | 0.0 |  0.0 |       0.0 | 0.0 |    0.0 | 0.0 |      0.0 |   0.0 | 0.0 |  0.0 |    0.0 | 0.0 |
+| elastic-endpoint.exe                               |     0.0 | 0.0 |  0.0 |       0.0 | 0.0 |    0.0 | 0.0 |      0.0 |   0.0 | 0.0 |  0.0 |    0.0 | 0.0 |
+| sppsvc.exe                                         |     0.0 | 0.0 |  0.0 |       0.0 | 0.0 |    0.0 | 0.0 |      0.0 |   0.0 | 0.0 |  0.0 |    0.0 | 0.0 |
+
+Endpoint service (16 CPU): 113.0% out of 1600%
+
+Collecting data.  Press Ctrl-C to cancel
+```
+
+#### Column abbreviations
+
+* `API`: Event Tracing for Windows (ETW) API events
+* `AUTH`: Authentication events
+* `BHVR`: Malicious behavior protection
+* `CRED`: Credential access events
+* `DIAG BHVR`: Diagnostic malicious behavior protection
+* `DNS`: DNS events
+* `FILE`: File events
+* `LIB`: Library load events
+* `MEM SCAN`: Memory scanning
+* `MLWR`: Malware protection
+* `NET`: Network events
+* `PROC`: Process events
+* `PROC INJ`: Process injection
+* `RANSOM`: Ransomware protection
+* `REG`: Registry events
+
+## elastic-endpoint uninstall
+
+Uninstall ((elastic-endpoint)).
+
+<DocCallOut title="Note">
+((elastic-endpoint)) is managed by ((agent)). To remove ((elastic-endpoint)) from the target machine permanently, remove the ((elastic-defend)) integration from the ((fleet)) policy. The <DocLink slug="/serverless/security/uninstall-agent">elastic-agent uninstall</DocLink> command also uninstalls ((elastic-endpoint)); therefore, in practice, the `elastic-endpoint uninstall` command is used only to troubleshoot broken installations.
+</DocCallOut>
+
+### Options
+
+`--uninstall-token <string>`
+    : Provide the uninstall token. The token is required if <DocLink slug="/serverless/security/agent-tamper-protection">agent tamper protection</DocLink> is enabled.
+
+## elastic-endpoint version
+
+Show the version of ((elastic-endpoint)).
+
+

--- a/docs/serverless/edr-manage/endpoint-command-ref.mdx
+++ b/docs/serverless/edr-manage/endpoint-command-ref.mdx
@@ -13,12 +13,12 @@ This page lists the commands for management and troubleshooting of ((elastic-end
 
 <DocCallOut title="Note">
 
-* The service is not added to the `PATH` system variable, so you must prepend the commands with the full OS-dependent path:
+* ((elastic-endpoint)) is not added to the `PATH` system variable, so you must prepend the commands with the full OS-dependent path:
     * On Windows: `"C:\Program Files\Elastic\Endpoint\elastic-endpoint.exe"`
     * On macOS: `/Library/Elastic/Endpoint/elastic-endpoint`
     * On Linux: `/opt/Elastic/Endpoint/elastic-endpoint`
 
-* You must run the commands with elevated privileges—as the root user on POSIX systems, or as Administrator on Windows.
+* You must run the commands with elevated privileges—as the root user on Linux and macOS, or as Administrator on Windows.
 
 </DocCallOut>
 
@@ -197,7 +197,7 @@ Fleet server: https://fleet.example.elastic.co:443
 
 ## elastic-endpoint top
 
-Show a breakdown of the executables that triggered ((elastic-endpoint)) CPU usage within the last interval. This utility displays which ((elastic-endpoint)) features are resource-intensive for a particular executable.
+Show a breakdown of the executables that triggered ((elastic-endpoint)) CPU usage within the last interval. This displays which ((elastic-endpoint)) features are resource-intensive for a particular executable.
 
 <DocCallOut title="Note">
 The meaning and output of this command are similar, but not identical, to the POSIX `top` command. The `elastic-endpoint top` command aggregates multiple processes by executable. The utilization values aren't measured by the OS scheduler but by a wall clock in user mode. The output helps identify outliers causing excessive CPU utilization, allowing you to fine-tune the ((elastic-defend)) policy and exception lists in your deployment.

--- a/docs/serverless/edr-manage/endpoint-command-ref.mdx
+++ b/docs/serverless/edr-manage/endpoint-command-ref.mdx
@@ -54,13 +54,31 @@ Gather diagnostics information from ((elastic-endpoint)). This command produces 
 - `analysis.txt`: Diagnostic analysis report
 - `logs` directory: Copy of ((elastic-endpoint)) log files
 
+### Example
+
+```
+sudo /Library/Elastic/Endpoint/elastic-endpoint diagnostics
+```
+
 ## elastic-endpoint help
 
 Show help for the available commands.
 
+### Example
+
+```
+sudo /Library/Elastic/Endpoint/elastic-endpoint help
+```
+
 ## elastic-endpoint inspect
 
 Show the current ((elastic-endpoint)) configuration.
+
+### Example
+
+```
+sudo /Library/Elastic/Endpoint/elastic-endpoint inspect
+```
 
 ## elastic-endpoint install
 
@@ -77,6 +95,12 @@ Elastic doesn't publish independent ((elastic-endpoint)) packages since ((elasti
 `--upgrade`
     : Upgrade the existing installation.
 
+### Example
+
+```
+sudo /Library/Elastic/Endpoint/elastic-endpoint install --upgrade
+```
+
 ## elastic-endpoint memorydump
 
 Save a memory dump of the ((elastic-endpoint)) service.
@@ -89,9 +113,21 @@ Save a memory dump of the ((elastic-endpoint)) service.
 `--timeout <duration>`
     : Specify the memory collection timeout, in seconds; the default is 60 seconds.
 
+### Example
+
+```
+sudo /Library/Elastic/Endpoint/elastic-endpoint memorydump --timeout 120
+```
+
 ## elastic-endpoint run
 
 Run `elastic-endpoint` as a foreground process if no other instance is already running.
+
+### Example
+
+```
+sudo /Library/Elastic/Endpoint/elastic-endpoint run
+```
 
 ## elastic-endpoint send
 
@@ -101,6 +137,12 @@ Send the requested document to the ((stack)).
 
 `metadata`
     : Send an off-schedule metrics document to the ((stack)).
+
+### Example
+
+```
+sudo /Library/Elastic/Endpoint/elastic-endpoint send metadata
+```
 
 ## elastic-endpoint status
 
@@ -115,6 +157,12 @@ Retrieve the current status of the running ((elastic-endpoint)) service. The com
     * `full`: Always returns the full status information.
     * `json`: Always returns the full status information.
 
+### Example
+
+```
+sudo /Library/Elastic/Endpoint/elastic-endpoint status --output json
+```
+
 ## elastic-endpoint test
 
 Perform the requested test.
@@ -125,6 +173,12 @@ Perform the requested test.
     : Test whether ((elastic-endpoint)) can connect to remote resources.
 
 ### Example
+
+```
+sudo /Library/Elastic/Endpoint/elastic-endpoint test output
+```
+
+### Example output
 
 ```
 Testing output connections using config file: [C:\Program Files\Elastic\Endpoint\elastic-endpoint.yaml]
@@ -161,6 +215,12 @@ The meaning and output of this command are similar, but not identical, to the PO
     : Normalize CPU usage values to a total of 100% across all CPUs on multi-CPU systems.
 
 ### Example
+
+```
+sudo /Library/Elastic/Endpoint/elastic-endpoint top --interval 10 --limit 5
+```
+
+### Example output
 
 ```
 | PROCESS                                            | OVERALL | API | BHVR | DIAG BHVR | DNS | FILE   | LIB | MEM SCAN | MLWR  | NET | PROC | RANSOM | REG |
@@ -219,8 +279,18 @@ Uninstall ((elastic-endpoint)).
 `--uninstall-token <string>`
     : Provide the uninstall token. The token is required if <DocLink slug="/serverless/security/agent-tamper-protection">agent tamper protection</DocLink> is enabled.
 
+### Example
+
+```
+sudo /Library/Elastic/Endpoint/elastic-endpoint uninstall --uninstall-token 12345678901234567890123456789012
+```
+
 ## elastic-endpoint version
 
 Show the version of ((elastic-endpoint)).
 
+### Example
 
+```
+sudo /Library/Elastic/Endpoint/elastic-endpoint version
+```

--- a/docs/serverless/edr-manage/endpoint-command-ref.mdx
+++ b/docs/serverless/edr-manage/endpoint-command-ref.mdx
@@ -18,7 +18,7 @@ This page lists the commands for management and troubleshooting of ((elastic-end
     * On macOS: `/Library/Elastic/Endpoint/elastic-endpoint`
     * On Linux: `/opt/Elastic/Endpoint/elastic-endpoint`
 
-* You must run the commands with elevated privileges—as the root user on Linux and macOS, or as Administrator on Windows.
+* You must run the commands with elevated privileges—using `sudo` to run as the root user on Linux and macOS, or running as Administrator on Windows.
 
 </DocCallOut>
 
@@ -57,7 +57,7 @@ Gather diagnostics information from ((elastic-endpoint)). This command produces 
 ### Example
 
 ```
-sudo /Library/Elastic/Endpoint/elastic-endpoint diagnostics
+elastic-endpoint diagnostics
 ```
 
 ## elastic-endpoint help
@@ -67,7 +67,7 @@ Show help for the available commands.
 ### Example
 
 ```
-sudo /Library/Elastic/Endpoint/elastic-endpoint help
+elastic-endpoint help
 ```
 
 ## elastic-endpoint inspect
@@ -77,7 +77,7 @@ Show the current ((elastic-endpoint)) configuration.
 ### Example
 
 ```
-sudo /Library/Elastic/Endpoint/elastic-endpoint inspect
+elastic-endpoint inspect
 ```
 
 ## elastic-endpoint install
@@ -85,7 +85,7 @@ sudo /Library/Elastic/Endpoint/elastic-endpoint inspect
 Install ((elastic-endpoint)) as a system service.
 
 <DocCallOut title="Note">
-Elastic doesn't publish independent ((elastic-endpoint)) packages since ((elastic-endpoint)) is managed by ((agent)).
+We do not recommend installing ((elastic-endpoint)) using this command. ((elastic-endpoint)) is managed by ((agent)) and cannot function as a standalone service. Therefore, there is no separate installation package for ((elastic-endpoint)), and it should not be installed independently.
 </DocCallOut>
 ### Options
 
@@ -98,7 +98,7 @@ Elastic doesn't publish independent ((elastic-endpoint)) packages since ((elasti
 ### Example
 
 ```
-sudo /Library/Elastic/Endpoint/elastic-endpoint install --upgrade --resources endpoint-security-resources.zip
+elastic-endpoint install --upgrade --resources endpoint-security-resources.zip
 ```
 
 ## elastic-endpoint memorydump
@@ -116,7 +116,7 @@ Save a memory dump of the ((elastic-endpoint)) service.
 ### Example
 
 ```
-sudo /Library/Elastic/Endpoint/elastic-endpoint memorydump --timeout 120
+elastic-endpoint memorydump --timeout 120
 ```
 
 ## elastic-endpoint run
@@ -126,7 +126,7 @@ Run `elastic-endpoint` as a foreground process if no other instance is already r
 ### Example
 
 ```
-sudo /Library/Elastic/Endpoint/elastic-endpoint run
+elastic-endpoint run
 ```
 
 ## elastic-endpoint send
@@ -141,7 +141,7 @@ Send the requested document to the ((stack)).
 ### Example
 
 ```
-sudo /Library/Elastic/Endpoint/elastic-endpoint send metadata
+elastic-endpoint send metadata
 ```
 
 ## elastic-endpoint status
@@ -160,7 +160,7 @@ Retrieve the current status of the running ((elastic-endpoint)) service. The com
 ### Example
 
 ```
-sudo /Library/Elastic/Endpoint/elastic-endpoint status --output json
+elastic-endpoint status --output json
 ```
 
 ## elastic-endpoint test
@@ -175,7 +175,7 @@ Perform the requested test.
 ### Example
 
 ```
-sudo /Library/Elastic/Endpoint/elastic-endpoint test output
+elastic-endpoint test output
 ```
 
 ### Example output
@@ -217,7 +217,7 @@ The meaning and output of this command are similar, but not identical, to the PO
 ### Example
 
 ```
-sudo /Library/Elastic/Endpoint/elastic-endpoint top --interval 10 --limit 5
+elastic-endpoint top --interval 10 --limit 5
 ```
 
 ### Example output
@@ -282,7 +282,7 @@ Uninstall ((elastic-endpoint)).
 ### Example
 
 ```
-sudo /Library/Elastic/Endpoint/elastic-endpoint uninstall --uninstall-token 12345678901234567890123456789012
+elastic-endpoint uninstall --uninstall-token 12345678901234567890123456789012
 ```
 
 ## elastic-endpoint version
@@ -292,5 +292,5 @@ Show the version of ((elastic-endpoint)).
 ### Example
 
 ```
-sudo /Library/Elastic/Endpoint/elastic-endpoint version
+elastic-endpoint version
 ```

--- a/docs/serverless/serverless-security.docnav.json
+++ b/docs/serverless/serverless-security.docnav.json
@@ -176,6 +176,9 @@
         },
         {
           "slug": "/serverless/security/endpoint-self-protection"
+        },
+        {
+          "slug": "/serverless/security/endpoint-command-ref"
         }
       ]
     },


### PR DESCRIPTION
Resolves https://github.com/elastic/security-docs/issues/5097 by adding a new page that documents the commands for managing and troubleshooting Elastic Endpoint.


### Previews
* ESS: [Elastic Endpoint command reference](https://security-docs_bk_5778.docs-preview.app.elstc.co/guide/en/security/master/endpoint-command-ref.html)
* Serverless: Open the link in [this comment](https://github.com/elastic/security-docs/pull/5778#issuecomment-2331314083) and navigate to Security -> View serverless docs -> Manage Elastic Defend -> Elastic Endpoint command reference 