### PR TITLE
[Known Issue] Doc Elastic Defend bug that stopped security events from populating the user.name field

### DIFF
--- a/docs/release-notes/8.14.asciidoc
+++ b/docs/release-notes/8.14.asciidoc
@@ -6,6 +6,27 @@
 === 8.14.3
 
 [discrete]
+[[known-issue-8.14.3]]
+==== Known issues
+
+// tag::known-issue-14686[]
+[discrete]
+.{elastic-endpoint} does not properly populate the `user.name` field 
+[%collapsible]
+====
+*Details* +
+{elastic-endpoint} for Windows will not properly populate the `user.name` field with security events.
+
+*Workaround* +
+Upgrade to 8.15.1.
+
+*Resolved* +
+On September 5, 2024, this issue was resolved.
+
+====
+// end::known-issue-14686[]
+
+[discrete]
 [[bug-fixes-8.14.3]]
 ==== Bug fixes
 
@@ -16,6 +37,27 @@
 === 8.14.2
 
 [discrete]
+[[known-issue-8.14.2]]
+==== Known issues
+
+// tag::known-issue-14686[]
+[discrete]
+.{elastic-endpoint} does not properly populate the `user.name` field 
+[%collapsible]
+====
+*Details* +
+{elastic-endpoint} for Windows will not properly populate the `user.name` field with security events.
+
+*Workaround* +
+Upgrade to 8.15.1.
+
+*Resolved* +
+On September 5, 2024, this issue was resolved.
+
+====
+// end::known-issue-14686[]
+
+[discrete]
 [[bug-fixes-8.14.2]]
 ==== Bug fixes
 
@@ -24,6 +66,27 @@ There are no user-facing changes in 8.14.2.
 [discrete]
 [[release-notes-8.14.1]]
 === 8.14.1
+
+[discrete]
+[[known-issue-8.14.1]]
+==== Known issues
+
+// tag::known-issue-14686[]
+[discrete]
+.{elastic-endpoint} does not properly populate the `user.name` field 
+[%collapsible]
+====
+*Details* +
+{elastic-endpoint} for Windows will not properly populate the `user.name` field with security events.
+
+*Workaround* +
+Upgrade to 8.15.1.
+
+*Resolved* +
+On September 5, 2024, this issue was resolved.
+
+====
+// end::known-issue-14686[]
 
 [discrete]
 [[bug-fixes-8.14.1]]
@@ -38,6 +101,27 @@ There are no user-facing changes in 8.14.2.
 [discrete]
 [[release-notes-8.14.0]]
 === 8.14.0
+
+[discrete]
+[[known-issue-8.14.0]]
+==== Known issues
+
+// tag::known-issue-14686[]
+[discrete]
+.{elastic-endpoint} does not properly populate the `user.name` field 
+[%collapsible]
+====
+*Details* +
+{elastic-endpoint} for Windows will not properly populate the `user.name` field with security events.
+
+*Workaround* +
+Upgrade to 8.15.1.
+
+*Resolved* +
+On September 5, 2024, this issue was resolved.
+
+====
+// end::known-issue-14686[]
 
 [discrete]
 [[features-8.14.0]]

--- a/docs/release-notes/8.14.asciidoc
+++ b/docs/release-notes/8.14.asciidoc
@@ -73,7 +73,7 @@ There are no user-facing changes in 8.14.2.
 
 // tag::known-issue-14686[]
 [discrete]
-.{elastic-endpoint} does not properly populate the `user.name` field 
+.{elastic-endpoint} does not properly populate the `user.name` field in security events
 [%collapsible]
 ====
 *Details* +

--- a/docs/release-notes/8.14.asciidoc
+++ b/docs/release-notes/8.14.asciidoc
@@ -11,7 +11,7 @@
 
 // tag::known-issue-14686[]
 [discrete]
-.{elastic-endpoint} does not properly populate the `user.name` field 
+.{elastic-endpoint} does not properly populate the `user.name` field in security events
 [%collapsible]
 ====
 *Details* +

--- a/docs/release-notes/8.14.asciidoc
+++ b/docs/release-notes/8.14.asciidoc
@@ -108,7 +108,7 @@ On September 5, 2024, this issue was resolved.
 
 // tag::known-issue-14686[]
 [discrete]
-.{elastic-endpoint} does not properly populate the `user.name` field 
+.{elastic-endpoint} does not properly populate the `user.name` field in security events
 [%collapsible]
 ====
 *Details* +

--- a/docs/release-notes/8.14.asciidoc
+++ b/docs/release-notes/8.14.asciidoc
@@ -42,7 +42,7 @@ On September 5, 2024, this issue was resolved.
 
 // tag::known-issue-14686[]
 [discrete]
-.{elastic-endpoint} does not properly populate the `user.name` field 
+.{elastic-endpoint} does not properly populate the `user.name` field in security events
 [%collapsible]
 ====
 *Details* +

--- a/docs/release-notes/8.15.asciidoc
+++ b/docs/release-notes/8.15.asciidoc
@@ -45,7 +45,7 @@ On August 1, 2024, it was discovered that Elastic AI Assistant's responses when 
 * Fixes an {elastic-defend} bug that sometimes caused {elastic-endpoint} to report an incorrect version if it used an independent {agent} release.
 * Fixes an {elastic-defend} bug where the `process.thread.Ext.call_stack_final_user_module.protection_provenance_path` field might be populated with a non-path value. This fix is for Windows endpoints only.
 * Fixes an {elastic-defend} bug that can lead to {elastic-endpoint} reporting `STATUS_ACCESS_DENIED` when attempting to open files for `GENERIC_READ`. {elastic-endpoint} almost always recovered from this issue, but with this fix, it succeeds on the first try. This fix is for Windows endpoints only.
-* Fixes an {elastic-defend} regression that was introduced in 8.13.1, where security events did not populate the `user.name` field. This fix is for Windows endpoints only.
+* Fixes an {elastic-defend} regression that was introduced in 8.14.0, where security events did not populate the `user.name` field. This fix is for Windows endpoints only.
 * Fixes an {elastic-defend} bug where {elastic-endpoint} sometimes missed file and network events on newer kernels that support eBPF. This only occurred if {elastic-endpoint} failed to enable eBPF probes and fell back to Kprobes. This fix is for Linux endpoints only.
 * Fixes a bug that caused errors if you used Azure OpenAI connector for streaming ({kibana-pull}191552[#191552]).
 * Fixes a bug that prevented duplicated prebuilt rules from inheriting **Required fields** and **Related integrations** field values ({kibana-pull}191065[#191065]).
@@ -90,6 +90,23 @@ On September 5, 2024, this issue was resolved.
 
 ====
 // end::known-issue-5713[]
+
+// tag::known-issue-14686[]
+[discrete]
+.{elastic-endpoint} does not properly populate the `user.name` field 
+[%collapsible]
+====
+*Details* +
+{elastic-endpoint} for Windows will not properly populate the `user.name` field with security events.
+
+*Workaround* +
+Upgrade to 8.15.1.
+
+*Resolved* +
+On September 5, 2024, this issue was resolved.
+
+====
+// end::known-issue-14686[]
 
 [discrete]
 [[breaking-changes-8.15.0]]

--- a/docs/release-notes/8.15.asciidoc
+++ b/docs/release-notes/8.15.asciidoc
@@ -93,7 +93,7 @@ On September 5, 2024, this issue was resolved.
 
 // tag::known-issue-14686[]
 [discrete]
-.{elastic-endpoint} does not properly populate the `user.name` field 
+.{elastic-endpoint} does not properly populate the `user.name` field in security events
 [%collapsible]
 ====
 *Details* +


### PR DESCRIPTION
Fixes https://github.com/elastic/security-docs/issues/5765 by documenting the known issue for all releases between 8.14-8.15. 

Previews:
- [8.14.0-8.14.3 release notes](https://security-docs_bk_5786.docs-preview.app.elstc.co/guide/en/security/master/release-notes-header-8.14.0.html) - Adds the known issue to each version
- [8.15.0-8.15.1 release notes](https://security-docs_bk_5786.docs-preview.app.elstc.co/guide/en/security/master/release-notes-header-8.15.0.html) - Adds the known issue to 8.15 and updates the fixed bug description in 8.15.1 to show that the bug was discovered in 8.14.0.