### PR TITLE
[Docs IA][Serverless] Create Investigation Tools section

### DIFF
--- a/docs/serverless/cloud-native-security/session-view.mdx
+++ b/docs/serverless/cloud-native-security/session-view.mdx
@@ -14,9 +14,8 @@ in a tree-like structure according to the Linux logical event model, with proces
 It displays events in a highly readable format that is inspired by the terminal. This makes it a powerful tool for monitoring
 and investigating session activity on your Linux infrastructure and understanding user and service behavior.
 
-<div id="session-view-data"></div>
+Session View has the following features:
 
-**Session View displays**:
 * **Interactive and non-interactive processes:** Processes and services with or without a controlling terminal.
 * **User information:** The Linux user that executed each session or process, and any exec user changes.
 * **Process and event telemetry:** Process information included in the Linux logical event model.

--- a/docs/serverless/investigate/investigate-events.mdx
+++ b/docs/serverless/investigate/investigate-events.mdx
@@ -1,6 +1,6 @@
 ---
 slug: /serverless/security/investigate-events
-title: Investigate security events
+title: Investigation tools
 description: Investigate security events and track security issues in ((elastic-sec)).
 tags: [ 'serverless', 'security', 'overview' ]
 status: in review
@@ -14,7 +14,8 @@ The following sections describe tools for investigating security events and trac
 
 These features are available in the ((security-app))'s side navigation menu:
 
-* <DocLink slug="/serverless/security/cases-overview">**Cases**</DocLink>: Track investigation details about security issues.
 * **Investigations** → <DocLink slug="/serverless/security/timelines-ui">**Timelines**</DocLink>: Workspace for investigations and threat hunting.
+* <DocLink slug="/serverless/security/cases-overview">**Cases**</DocLink>: Track investigation details about security issues.
 * **Investigations** → <DocLink slug="/serverless/security/query-operating-systems">**Osquery**</DocLink>: Run live and scheduled queries on operating systems.
 * <DocLink slug="/serverless/security/indicators-of-compromise">**Intelligence**</DocLink>: Indicators of compromise used for threat intelligence.
+* <DocLink slug="/serverless/security/cases-overview">**Cases**</DocLink>

--- a/docs/serverless/investigate/investigate-events.mdx
+++ b/docs/serverless/investigate/investigate-events.mdx
@@ -14,7 +14,7 @@ The following sections describe tools for investigating security events and trac
 
 These features are available in the ((security-app))'s side navigation menu:
 
+* <DocLink slug="/serverless/security/cases-overview">**Cases**</DocLink>: Track investigation details about security issues.
 * **Investigations** → <DocLink slug="/serverless/security/timelines-ui">**Timelines**</DocLink>: Workspace for investigations and threat hunting.
 * **Investigations** → <DocLink slug="/serverless/security/query-operating-systems">**Osquery**</DocLink>: Run live and scheduled queries on operating systems.
 * <DocLink slug="/serverless/security/indicators-of-compromise">**Intelligence**</DocLink>: Indicators of compromise used for threat intelligence.
-* <DocLink slug="/serverless/security/cases-overview">**Cases**</DocLink>: Track investigation details about security issues.

--- a/docs/serverless/investigate/investigate-events.mdx
+++ b/docs/serverless/investigate/investigate-events.mdx
@@ -15,7 +15,6 @@ The following sections describe tools for investigating security events and trac
 These features are available in the ((security-app))'s side navigation menu:
 
 * **Investigations** → <DocLink slug="/serverless/security/timelines-ui">**Timelines**</DocLink>: Workspace for investigations and threat hunting.
-* <DocLink slug="/serverless/security/cases-overview">**Cases**</DocLink>: Track investigation details about security issues.
 * **Investigations** → <DocLink slug="/serverless/security/query-operating-systems">**Osquery**</DocLink>: Run live and scheduled queries on operating systems.
 * <DocLink slug="/serverless/security/indicators-of-compromise">**Intelligence**</DocLink>: Indicators of compromise used for threat intelligence.
-* <DocLink slug="/serverless/security/cases-overview">**Cases**</DocLink>
+* <DocLink slug="/serverless/security/cases-overview">**Cases**</DocLink>: Track investigation details about security issues.

--- a/docs/serverless/investigate/timeline-templates-ui.mdx
+++ b/docs/serverless/investigate/timeline-templates-ui.mdx
@@ -1,6 +1,6 @@
 ---
 slug: /serverless/security/timeline-templates-ui
-title: Create Timeline templates
+title: Timeline templates
 description: Attach Timeline templates to detection rules to streamline investigations.
 tags: [ 'serverless', 'security', 'how-to', 'analyze', 'manage' ]
 status:  in review

--- a/docs/serverless/investigate/timelines-ui.mdx
+++ b/docs/serverless/investigate/timelines-ui.mdx
@@ -1,6 +1,6 @@
 ---
 slug: /serverless/security/timelines-ui
-title: Investigate events in Timeline
+title: Timeline
 description: Investigate events and complex threats in your network.
 tags: [ 'serverless', 'security', 'how-to', 'analyze', 'manage' ]
 status: in review

--- a/docs/serverless/osquery/use-osquery.mdx
+++ b/docs/serverless/osquery/use-osquery.mdx
@@ -1,6 +1,6 @@
 ---
 slug: /serverless/security/query-operating-systems
-title: Query operating systems
+title: Osquery
 description: Integrate Osquery with ((elastic-sec)) for comprehensive data collection and security monitoring.
 tags: [ 'serverless', 'security', 'overview' ]
 status: in review

--- a/docs/serverless/serverless-security.docnav.json
+++ b/docs/serverless/serverless-security.docnav.json
@@ -618,7 +618,7 @@
               "classic-sources": [ "enSecurityCasesOpenManage" ]
             },
             {
-              "slug": "/serverless/security/cases-settings",
+              "slug": "/serverless/security/cases-settings", 
               "classic-sources": [ "enSecurityCasesSettings" ]
             }
           ]

--- a/docs/serverless/serverless-security.docnav.json
+++ b/docs/serverless/serverless-security.docnav.json
@@ -318,10 +318,6 @@
           "classic-sources": [ "enSecurityCloudWorkloadProtection" ],
           "items": [
             {
-              "slug": "/serverless/security/session-view", 
-              "classic-sources": [ "enSecuritySessionView" ]
-            },
-            {
               "slug": "/serverless/security/environment-variable-capture", 
               "classic-sources": [ "enSecurityEnvironmentVariableCapture" ]
             }
@@ -503,10 +499,6 @@
           "classic-sources": [ "enSecurityReduceNotificationsAlerts" ]
         },
         {
-          "slug": "/serverless/security/visual-event-analyzer",
-          "classic-sources": [ "enSecurityVisualEventAnalyzer" ]
-        },
-        {
           "slug": "/serverless/security/query-alert-indices",
           "classic-sources": [ "enSecurityQueryAlertIndices" ]
         },
@@ -580,6 +572,44 @@
           ]
         },
         {
+          "slug": "/serverless/security/visual-event-analyzer",
+          "classic-sources": [ "enSecurityVisualEventAnalyzer" ]
+        },
+        {
+          "slug": "/serverless/security/session-view", 
+          "classic-sources": [ "enSecuritySessionView" ]
+        },
+        {
+          "slug": "/serverless/security/query-operating-systems",
+          "classic-sources": [ "enSecurityUseOsquery" ],
+          "items": [
+            {
+              "slug": "/serverless/security/osquery-response-action",
+              "classic-sources": [ "enSecurityOsqueryResponseAction" ]
+            },
+            {
+              "slug": "/serverless/security/invest-guide-run-osquery",
+              "classic-sources": [ "enSecurityInvestGuideRunOsquery" ]
+            },
+            {
+              "slug": "/serverless/security/alerts-run-osquery",
+              "classic-sources": [ "enSecurityAlertsRunOsquery" ]
+            },
+            {
+              "slug": "/serverless/security/examine-osquery-results",
+              "classic-sources": [ "enSecurityViewOsqueryResults" ]
+            },
+            {
+              "slug": "/serverless/security/osquery-placeholder-fields",
+              "classic-sources": [ "enSecurityOsqueryPlaceholderFields" ]
+            }
+          ]
+        },
+        {
+          "slug": "/serverless/security/indicators-of-compromise",
+          "classic-sources": [ "enSecurityIndicatorsOfCompromise" ]
+        },
+        {
           "slug": "/serverless/security/cases-overview",
           "classic-sources": [ "enSecurityCasesOverview" ],
           "items": [
@@ -589,38 +619,9 @@
             },
             {
               "slug": "/serverless/security/cases-settings"
+              "classic-sources": [ "enSecurityCasesSettings" ]
             }
           ]
-        },
-        {
-          "slug": "/serverless/security/indicators-of-compromise",
-          "classic-sources": [ "enSecurityIndicatorsOfCompromise" ]
-        }
-      ]
-    },
-    {
-      "slug": "/serverless/security/query-operating-systems",
-      "classic-sources": [ "enSecurityUseOsquery" ],
-      "items": [
-        {
-          "slug": "/serverless/security/osquery-response-action",
-          "classic-sources": [ "enSecurityOsqueryResponseAction" ]
-        },
-        {
-          "slug": "/serverless/security/invest-guide-run-osquery",
-          "classic-sources": [ "enSecurityInvestGuideRunOsquery" ]
-        },
-        {
-          "slug": "/serverless/security/alerts-run-osquery",
-          "classic-sources": [ "enSecurityAlertsRunOsquery" ]
-        },
-        {
-          "slug": "/serverless/security/examine-osquery-results",
-          "classic-sources": [ "enSecurityViewOsqueryResults" ]
-        },
-        {
-          "slug": "/serverless/security/osquery-placeholder-fields",
-          "classic-sources": [ "enSecurityOsqueryPlaceholderFields" ]
         }
       ]
     },

--- a/docs/serverless/serverless-security.docnav.json
+++ b/docs/serverless/serverless-security.docnav.json
@@ -618,7 +618,7 @@
               "classic-sources": [ "enSecurityCasesOpenManage" ]
             },
             {
-              "slug": "/serverless/security/cases-settings"
+              "slug": "/serverless/security/cases-settings",
               "classic-sources": [ "enSecurityCasesSettings" ]
             }
           ]


### PR DESCRIPTION
Fixes https://github.com/elastic/security-docs/issues/5761 by applying the changes in https://github.com/elastic/security-docs/pull/5736 to the Serverless TOC.

Preview: [Investigation tools](https://elastic-dot-co-docs-production-dge6mz0b3-elastic-dev.vercel.app/current/serverless/security/investigate-events)