### PR TITLE
Update ML jobs list on rule monitoring page

### DIFF
--- a/docs/detections/rules-ui-monitor.asciidoc
+++ b/docs/detections/rules-ui-monitor.asciidoc
@@ -146,6 +146,8 @@ The following Elastic prebuilt rules use the new `v3` {ml} jobs to generate aler
 
 * <<unusual-linux-network-port-activity>>: `v3_linux_anomalous_network_port_activity`
 
+* <<unusual-linux-network-connection-discovery>>: `v3_linux_anomalous_network_connection_discovery`
+
 * <<anomalous-process-for-a-linux-population>>: `v3_linux_anomalous_process_all_hosts`
 
 * <<unusual-linux-username>>: `v3_linux_anomalous_user_name`

--- a/docs/serverless/rules/alerts-ui-monitor.mdx
+++ b/docs/serverless/rules/alerts-ui-monitor.mdx
@@ -190,6 +190,8 @@ we add prebuilt rule pages to the serverless docs.*/}
 
 * Unusual Linux Network Port Activity: `v3_linux_anomalous_network_port_activity`
 
+* Unusual Linux Network Connection Discovery: `v3_linux_anomalous_network_connection_discovery`
+
 * Anomalous Process For a Linux Population: `v3_linux_anomalous_process_all_hosts`
 
 * Unusual Linux Username: `v3_linux_anomalous_user_name`


### PR DESCRIPTION
Follow-up of https://github.com/elastic/security-docs/pull/5774 to apply same update to `main` and serverless docs.