### PR TITLE
Fixes "Enrol"/"Enroll" typo

### DIFF
--- a/docs/cloud-native-security/cspm-get-started-aws.asciidoc
+++ b/docs/cloud-native-security/cspm-get-started-aws.asciidoc
@@ -28,7 +28,7 @@ This page explains how to get started monitoring the security posture of your cl
 [[cspm-setup]]
 == Set up CSPM for AWS
 
-You can set up CSPM for AWS either by enroling a single cloud account, or by enroling an organization containing multiple accounts. Either way, first you will add the CSPM integration, then enable cloud account access.
+You can set up CSPM for AWS either by enrolling a single cloud account, or by enrolling an organization containing multiple accounts. Either way, first you will add the CSPM integration, then enable cloud account access.
 
 [discrete]
 [[cspm-add-and-name-integration]]

--- a/docs/cloud-native-security/cspm-get-started-gcp.asciidoc
+++ b/docs/cloud-native-security/cspm-get-started-gcp.asciidoc
@@ -28,7 +28,7 @@ This page explains how to get started monitoring the security posture of your GC
 [[cspm-setup-gcp]]
 == Initial setup
 
-You can set up CSPM for GCP either by enroling a single project, or by enroling an organization containing multiple projects. Either way, you need to first add the CSPM integration, then enable cloud account access.
+You can set up CSPM for GCP either by enrolling a single project, or by enrolling an organization containing multiple projects. Either way, you need to first add the CSPM integration, then enable cloud account access.
 
 
 [discrete]

--- a/docs/serverless/cloud-native-security/cspm-get-started-gcp.mdx
+++ b/docs/serverless/cloud-native-security/cspm-get-started-gcp.mdx
@@ -31,7 +31,7 @@ This page explains how to get started monitoring the security posture of your cl
 
 ## Initial setup
 
-You can set up CSPM for GCP either by enroling a single project, or by enroling an organization containing multiple projects. Either way, you need to first add the CSPM integration, then enable cloud account access.
+You can set up CSPM for GCP either by enrolling a single project, or by enrolling an organization containing multiple projects. Either way, you need to first add the CSPM integration, then enable cloud account access.
 
 <div id="cspm-add-and-name-integration-gcp"></div>
 

--- a/docs/serverless/cloud-native-security/cspm-get-started.mdx
+++ b/docs/serverless/cloud-native-security/cspm-get-started.mdx
@@ -31,7 +31,7 @@ This page explains how to get started monitoring the security posture of your cl
 
 ## Set up CSPM for AWS
 
-You can set up CSPM for AWS either by enroling a single cloud account, or by enroling an organization containing multiple accounts. Either way, first you will add the CSPM integration, then enable cloud account access.
+You can set up CSPM for AWS either by enrolling a single cloud account, or by enrolling an organization containing multiple accounts. Either way, first you will add the CSPM integration, then enable cloud account access.
 
 <div id="cspm-add-and-name-integration"></div>
 


### PR DESCRIPTION
Fixes #5794 - the British English form of "Enrol" (instead of "Enroll") was used in Get started with CSPM docs