### PR TITLE
LLM performance matrix Serverless IA update

### DIFF
--- a/docs/serverless/AI-for-security/llm-performance-matrix.mdx
+++ b/docs/serverless/AI-for-security/llm-performance-matrix.mdx
@@ -10,7 +10,7 @@ This table describes the performance of various large language models (LLMs) for
 
 |           **Feature**        | **Model**             |                    |                    |            |                 |                   |           |  
 |-------------------------------|-----------------------|--------------------|--------------------|------------|-----------------|------------------|-----------|
-|                              | **Claude 3: Opus** | **Claude 3.5: Sonnet** | **Claude 3: Haiku** | **GPT-4o** | **GPT-4 Turbo** | Gemini 1.5 Pro | Gemini 1.5 Flash |
+|                              | **Claude 3: Opus** | **Claude 3.5: Sonnet** | **Claude 3: Haiku** | **GPT-4o** | **GPT-4 Turbo** | **Gemini 1.5 Pro** | **Gemini 1.5 Flash** |
 | **Assistant: general**       | Excellent              | Excellent          | Excellent          | Excellent  | Excellent       | Excellent        | Excellent |
 | **Assistant: ((esql)) generation** | Great            | Great              | Poor               | Excellent  | Poor            | Good              | Poor    |
 | **Assistant: alert questions** | Excellent            | Excellent          | Excellent          | Excellent  | Poor            | Excellent         | Good    |

--- a/docs/serverless/serverless-security.docnav.json
+++ b/docs/serverless/serverless-security.docnav.json
@@ -33,6 +33,9 @@
           "slug": "/serverless/security/llm-connector-guides",
           "items": [
             {
+              "slug": "/serverless/security/llm-performance-matrix"
+            },
+            {
               "slug": "/serverless/security/connect-to-azure-openai"
             },
             {
@@ -62,9 +65,6 @@
               "slug": "/serverless/security/ai-assistant-esql-queries"
             }
           ]
-        },
-        {
-          "slug": "/serverless/security/llm-performance-matrix"
         }
       ]
     },


### PR DESCRIPTION
Fixes #5818 by adding an IA change to serverless that is already present in ESS docs - moves the LLM Performance matrix to a different subsection. Also opportunistically fixes a minor formatting issue on the LLM Performance matrix page.

Preview:[ LLM performance matrix](https://elastic-dot-co-docs-production-p3mevbzfo-elastic-dev.vercel.app/current/serverless/security/llm-performance-matrix)

