### PR TITLE
Creates new template for breaking changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/breaking-change.yaml
+++ b/.github/ISSUE_TEMPLATE/breaking-change.yaml
@@ -1,0 +1,40 @@
+name: "Breaking change report"
+description: "Report a breaking change in Elastic Security"
+title: "[BREAKING CHANGE] "
+labels: "breaking-change"
+body: 
+  - type: markdown
+    attributes:
+      value: |
+        Hello! Use this form to report a breaking change in Elastic Security software to the [@elastic/security-docs](https://github.com/orgs/elastic/teams/security-docs) team. We will add it to the release notes for the version that introduces the breaking change.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What feature will break? Any more details about how it will break? Please include any recommendations for users who were using the feature with the breaking change.
+    validations:
+      required: true
+  - type: dropdown
+    id: doc-set
+    attributes:
+      label: Which deployment types does this breaking change apply to?
+      description: ESS (classic), serverless, or both?
+      options:
+        - ESS and serverless
+        - ESS only
+        - Serverless only
+        - Unknown
+      default: 0
+    validations:
+      required: true
+  - type: textarea
+    id: software-version
+    attributes:
+      label: Release version
+      description: If you selected ESS above, please list which Stack version(s) this breaking change applies to. 
+      placeholder: |
+        For example:
+        "This breaking change applies to Stack versions 8.10 and newer." 
+         "N/A"
+    validations:
+      required: false


### PR DESCRIPTION
Fixes #5833 — creates a draft of a new template for breaking changes. This would help us keep better track of these types of issues when they're reported to us. I created a new issue label "breaking-change" that gets automatically added to issues created via the template.

Please share any feedback and ideas you have for the template!

Preview: 