### PR TITLE
Updates ESS get started page with tutorial links

### DIFF
--- a/docs/getting-started/index.asciidoc
+++ b/docs/getting-started/index.asciidoc
@@ -2,8 +2,6 @@
 [[getting-started]]
 = Get started with {elastic-sec}
 
-Looking to get started with {elastic-sec}? This section describes the {elastic-sec} UI in {kib}, the system requirements required to run the {agent} with the {elastic-defend} integration, and instructions on how to configure and install {elastic-sec} on your host.
-
 This section describes how to set up {elastic-sec}, install {agent} and the {elastic-defend} on your hosts, and use the {elastic-sec} UI in {kib}.
 To get started, click on one of the following tutorials, depending on your use case:
 

--- a/docs/getting-started/index.asciidoc
+++ b/docs/getting-started/index.asciidoc
@@ -2,7 +2,7 @@
 [[getting-started]]
 = Get started with {elastic-sec}
 
-This section describes how to set up {elastic-sec}, install {agent} and the {elastic-defend} on your hosts, and use the {elastic-sec} UI in {kib}.
+This section describes how to set up {elastic-sec}, install {agent} and the {elastic-defend} integration on your hosts, and use the {elastic-sec} UI in {kib}.
 To get started, click on one of the following tutorials, depending on your use case:
 
 * https://www.elastic.co/getting-started/security/detect-threats-in-my-data-with-siem[Detect threats in my data with SIEM]

--- a/docs/getting-started/index.asciidoc
+++ b/docs/getting-started/index.asciidoc
@@ -10,9 +10,6 @@ To get started, click on one of the following tutorials, depending on your use c
 * https://www.elastic.co/getting-started/security/secure-my-cloud-assets-with-cloud-security-posture-management[Secure my cloud assets with cloud posture management (CSPM)]
 
 
-TIP: View the https://www.elastic.co/training/elastic-security-quick-start[{elastic-sec} Quick Start video] to learn how to configure your endpoints with {elastic-sec} so you can stream, detect, and visualize threats in real time on {ecloud}.
-
-
 include::sec-app-requirements.asciidoc[leveloffset=+1]
 
 include::security-ui.asciidoc[leveloffset=+1]

--- a/docs/getting-started/index.asciidoc
+++ b/docs/getting-started/index.asciidoc
@@ -4,7 +4,16 @@
 
 Looking to get started with {elastic-sec}? This section describes the {elastic-sec} UI in {kib}, the system requirements required to run the {agent} with the {elastic-defend} integration, and instructions on how to configure and install {elastic-sec} on your host.
 
+This section describes how to set up {elastic-sec}, install {agent} and the {elastic-defend} on your hosts, and use the {elastic-sec} UI in {kib}.
+To get started, click on one of the following tutorials, depending on your use case:
+
+* https://www.elastic.co/getting-started/security/detect-threats-in-my-data-with-siem[Detect threats in my data with SIEM]
+* https://www.elastic.co/getting-started/security/secure-my-hosts-with-endpoint-security[Secure my hosts with endpoint security]
+* https://www.elastic.co/getting-started/security/secure-my-cloud-assets-with-cloud-security-posture-management[Secure my cloud assets with cloud posture management (CSPM)]
+
+
 TIP: View the https://www.elastic.co/training/elastic-security-quick-start[{elastic-sec} Quick Start video] to learn how to configure your endpoints with {elastic-sec} so you can stream, detect, and visualize threats in real time on {ecloud}.
+
 
 include::sec-app-requirements.asciidoc[leveloffset=+1]
 


### PR DESCRIPTION
Fixes #5832 by updating the get started page and adding tutorial links. Removed the old sidebar (and outdated reference to a video). 

Preview: [Get started](https://security-docs_bk_5854.docs-preview.app.elstc.co/guide/en/security/master/getting-started.html)

