### PR TITLE
[Serverless][8.16] Logs request during preview rule execution

### DIFF
--- a/docs/detections/rules-ui-create.asciidoc
+++ b/docs/detections/rules-ui-create.asciidoc
@@ -830,7 +830,7 @@ When previewing a rule, you can also learn about its {es} queries, which are sub
 
 To learn more about your rule's {es} queries, preview its results and do the following:
 
-. Select the **Show Elasticsearch requests, ran during rule executions** option below the preview's date and time picker. The **Preview logged results** section displays under the histogram and alerts table. 
+. Select the **Show {es} requests, ran during rule executions** option below the preview's date and time picker. The **Preview logged results** section displays under the histogram and alerts table. 
 . Click the **Preview logged results** section to expand it. Within the section, each rule execution is shown on an individual row. 
 . Expand each row to learn more about the {es} queries that the rule submits each time it executes. The following details are provided:
 ** When the rule execution started, and how long it took to complete

--- a/docs/detections/rules-ui-create.asciidoc
+++ b/docs/detections/rules-ui-create.asciidoc
@@ -821,7 +821,7 @@ TIP: Avoid setting long time ranges with short rule intervals, or the rule previ
 * To close the preview, click the *Rule preview* button again.
 
 [discrete]
-[[view-es-rule-queries]]
+[[view-rule-es-queries]]
 ==== View {es} queries sent by your rule (optional)
 
 NOTE: This option is only offered for {esql} and event correlation rules.

--- a/docs/detections/rules-ui-create.asciidoc
+++ b/docs/detections/rules-ui-create.asciidoc
@@ -826,9 +826,9 @@ TIP: Avoid setting long time ranges with short rule intervals, or the rule previ
 
 NOTE: This option is only offered for {esql} and event correlation rules.
 
-When previewing an {esql} rule, you can also learn more about the {es} queries that are submitted when the rule runs. This information can be helpful for identifying and troubleshooting potential rule issues, or validating that your rule is retrieving the expected data.    
+When previewing a rule, you can also learn more about the {es} queries that are submitted when the rule runs. This information can be helpful for identifying and troubleshooting potential rule issues, or validating that your rule is retrieving the expected data.    
 
-To learn more your rule's {es} queries, preview its results and do the following:
+To learn more about your rule's {es} queries, preview its results and do the following:
 
 . Beneath the rule preview's date and time picker, find the **Show Elasticsearch requests, ran during rule executions** option and select it. The **Preview logged results** section displays under the the histogram and alerts table in the panel. 
 . Expand the **Preview logged results** section to display subsections with more information about the rule's {es} queries. The following details are provided:

--- a/docs/detections/rules-ui-create.asciidoc
+++ b/docs/detections/rules-ui-create.asciidoc
@@ -820,3 +820,20 @@ TIP: Avoid setting long time ranges with short rule intervals, or the rule previ
 
 * To close the preview, click the *Rule preview* button again.
 
+[discrete]
+[[debug-rule-queries]]
+==== Debug rule queries (optional)
+
+NOTE: This option is only offered for {esql} rules.
+
+When previewing an {esql} rule, you can also learn more about the {es} queries that are submitted when the rule runs. This information can be helpful for identifying and troubleshooting potential rule issues, or validating that your rule is retrieving the expected data.    
+
+To learn more your rule's {es} queries, preview its results and do the following:
+
+. Beneath the rule preview's date and time picker, find the **Show Elasticsearch requests, ran during rule executions** option and select it. The **Preview logged results** section displays under the the histogram and alerts table in the panel. 
+. Expand the **Preview logged results** section to display subsections with more information about the rule's {es} queries. The following details are provided:
+** The expected start date and time of each rule execution and how long it took to complete
+** A brief explanation of the {es} queries
+** The actual {es} queries that the rule submits when it runs   
++
+TIP: Copy the queries and run them in Dev Tools (**{kib}** -> **Management** -> **Dev Tools**) to determine if your rule is retrieving the expected data.

--- a/docs/detections/rules-ui-create.asciidoc
+++ b/docs/detections/rules-ui-create.asciidoc
@@ -830,11 +830,11 @@ When previewing a rule, you can also learn about its {es} queries, which are sub
 
 To learn more about your rule's {es} queries, preview its results and do the following:
 
-. Select the **Show Elasticsearch requests, ran during rule executions** option below the preview's date and time picker. The **Preview logged results** section displays under the the histogram and alerts table. 
+. Select the **Show Elasticsearch requests, ran during rule executions** option below the preview's date and time picker. The **Preview logged results** section displays under the histogram and alerts table. 
 . Click the **Preview logged results** section to expand it. Within the section, each rule execution is shown on an individual row. 
 . Expand each row to learn more about the {es} queries that the rule submits each time it executes. The following details are provided:
-** When the rule execution started and how long it took to complete
+** When the rule execution started, and how long it took to complete
 ** A brief explanation of what the {es} queries do
 ** The actual {es} queries that the rule sends to search indices containing events that are used during alert creation   
 +
-TIP: Run the queries in Dev Tools (**{kib}** -> **Management** -> **Dev Tools**) to determine if your rule is retrieving the expected data. For example, test your rule's exceptions by using its {es} queries to find events that should be ignored during alert creation. If alerts aren't created for those events, your rule's exceptions are working as expected.
+TIP: Run the queries in Dev Tools (**{kib}** -> **Management** -> **Dev Tools**) to determine if your rule is retrieving the expected data. For example, to test your rule's exceptions, use the rule's {es} queries to find events that should be ignored during alert creation. If alerts weren't created for those events, your rule's exceptions are working as expected.

--- a/docs/detections/rules-ui-create.asciidoc
+++ b/docs/detections/rules-ui-create.asciidoc
@@ -826,7 +826,7 @@ TIP: Avoid setting long time ranges with short rule intervals, or the rule previ
 
 NOTE: This option is only offered for {esql} and event correlation rules.
 
-When previewing a rule, you can also learn about its {es} queries, which are submitted when the rule runs. This information can be helpful for identifying and troubleshooting potential rule issues. You can also use it to confirm that your rule is retrieving the expected data.    
+When previewing a rule, you can also learn about its {es} queries, which are submitted when the rule runs. This information can help you identify and troubleshoot potential rule issues. You can also use it to confirm that your rule is retrieving the expected data.   
 
 To learn more about your rule's {es} queries, preview its results and do the following:
 
@@ -835,6 +835,6 @@ To learn more about your rule's {es} queries, preview its results and do the fol
 . Expand each row to learn more about the {es} queries that the rule submits each time it executes. The following details are provided:
 ** When the rule execution started, and how long it took to complete
 ** A brief explanation of what the {es} queries do
-** The actual {es} queries that the rule submits to indices containing events that are used during rule execution  
+** The actual {es} queries that the rule submits to indices containing events that are used during the rule execution  
 +
 TIP: Run the queries in Dev Tools (**{kib}** -> **Management** -> **Dev Tools**) to determine if your rule is retrieving the expected data. For example, to test your rule’s exceptions, run the rule’s {es} queries, which will also contain exceptions added to the rule. If your rule’s exceptions are working as intended, the query will not return events that should be ignored.

--- a/docs/detections/rules-ui-create.asciidoc
+++ b/docs/detections/rules-ui-create.asciidoc
@@ -822,7 +822,7 @@ TIP: Avoid setting long time ranges with short rule intervals, or the rule previ
 
 [discrete]
 [[debug-rule-queries]]
-==== Debug rule queries (optional)
+==== View {es} queries sent by your rule (optional)
 
 NOTE: This option is only offered for {esql} and event correlation rules.
 

--- a/docs/detections/rules-ui-create.asciidoc
+++ b/docs/detections/rules-ui-create.asciidoc
@@ -832,7 +832,7 @@ To learn more about your rule's {es} queries, preview its results and do the fol
 
 . Beneath the rule preview's date and time picker, find the **Show Elasticsearch requests, ran during rule executions** option and select it. The **Preview logged results** section displays under the the histogram and alerts table in the panel. 
 . Expand the **Preview logged results** section to display subsections with more information about the rule's {es} queries. The following details are provided:
-** The expected start date and time of each rule execution and how long it took to complete
+** The start date and time for each rule execution and how long it took to complete
 ** A brief explanation of the {es} queries
 ** The actual {es} queries that the rule submits when it runs   
 +

--- a/docs/detections/rules-ui-create.asciidoc
+++ b/docs/detections/rules-ui-create.asciidoc
@@ -837,4 +837,4 @@ To learn more about your rule's {es} queries, preview its results and do the fol
 ** A brief explanation of what the {es} queries do
 ** The actual {es} queries that the rule submits to indices containing events that are used during the rule execution  
 +
-TIP: Run the queries in Dev Tools (**{kib}** -> **Management** -> **Dev Tools**) to determine if your rule is retrieving the expected data. For example, to test your rule’s exceptions, run the rule’s {es} queries, which will also contain exceptions added to the rule. If your rule’s exceptions are working as intended, the query will not return events that should be ignored.
+TIP: Run the queries in {kibana-ref}/console-kibana.html[Console] to determine if your rule is retrieving the expected data. For example, to test your rule’s exceptions, run the rule’s {es} queries, which will also contain exceptions added to the rule. If your rule’s exceptions are working as intended, the query will not return events that should be ignored.

--- a/docs/detections/rules-ui-create.asciidoc
+++ b/docs/detections/rules-ui-create.asciidoc
@@ -835,6 +835,6 @@ To learn more about your rule's {es} queries, preview its results and do the fol
 . Expand each row to learn more about the {es} queries that the rule submits each time it executes. The following details are provided:
 ** When the rule execution started, and how long it took to complete
 ** A brief explanation of what the {es} queries do
-** The actual {es} queries that the rule sends to search indices containing events used during rule execution  
+** The actual {es} queries that the rule submits to indices containing events that are used during rule execution  
 +
 TIP: Run the queries in Dev Tools (**{kib}** -> **Management** -> **Dev Tools**) to determine if your rule is retrieving the expected data. For example, to test your rule’s exceptions, run the rule’s {es} queries, which will also contain exceptions added to the rule. If your rule’s exceptions are working as intended, the query will not return events that should be ignored.

--- a/docs/detections/rules-ui-create.asciidoc
+++ b/docs/detections/rules-ui-create.asciidoc
@@ -821,7 +821,7 @@ TIP: Avoid setting long time ranges with short rule intervals, or the rule previ
 * To close the preview, click the *Rule preview* button again.
 
 [discrete]
-[[debug-rule-queries]]
+[[view-es-rule-queries]]
 ==== View {es} queries sent by your rule (optional)
 
 NOTE: This option is only offered for {esql} and event correlation rules.
@@ -830,10 +830,11 @@ When previewing a rule, you can also learn more about the {es} queries that are 
 
 To learn more about your rule's {es} queries, preview its results and do the following:
 
-. Beneath the rule preview's date and time picker, find the **Show Elasticsearch requests, ran during rule executions** option and select it. The **Preview logged results** section displays under the the histogram and alerts table in the panel. 
-. Expand the **Preview logged results** section to display subsections with more information about the rule's {es} queries. The following details are provided:
-** The start date and time for each rule execution and how long it took to complete
-** A brief explanation of the {es} queries
-** The actual {es} queries that the rule submits when it runs   
+. Select the **Show Elasticsearch requests, ran during rule executions** option below the preview's date and time picker. The **Preview logged results** section displays under the the histogram and alerts table. 
+. Click the **Preview logged results** section to expand it. Within the section, each rule execution is shown on an individual row. 
+. Expand each row to learn more about the {es} queries that the rule submits each time it executes. The following details are provided:
+** When the rule execution started and how long it took to complete
+** A brief explanation of what the {es} queries do
+** The actual {es} queries that the rule sends to search indices containing events that are used during alert creation   
 +
-TIP: Copy the queries and run them in Dev Tools (**{kib}** -> **Management** -> **Dev Tools**) to determine if your rule is retrieving the expected data.
+TIP: Run the queries in Dev Tools (**{kib}** -> **Management** -> **Dev Tools**) to determine if your rule is retrieving the expected data. For example, test your rule's exceptions by using its {es} queries to find events that should be ignored during alert creation. If alerts aren't created for those events, your rule's exceptions are working as expected.

--- a/docs/detections/rules-ui-create.asciidoc
+++ b/docs/detections/rules-ui-create.asciidoc
@@ -822,7 +822,7 @@ TIP: Avoid setting long time ranges with short rule intervals, or the rule previ
 
 [discrete]
 [[view-rule-es-queries]]
-==== View {es} queries sent by your rule (optional)
+==== View your rule's {es} queries (optional)
 
 NOTE: This option is only offered for {esql} and event correlation rules.
 

--- a/docs/detections/rules-ui-create.asciidoc
+++ b/docs/detections/rules-ui-create.asciidoc
@@ -826,7 +826,7 @@ TIP: Avoid setting long time ranges with short rule intervals, or the rule previ
 
 NOTE: This option is only offered for {esql} and event correlation rules.
 
-When previewing a rule, you can also learn more about the {es} queries that are submitted when the rule runs. This information can be helpful for identifying and troubleshooting potential rule issues, or validating that your rule is retrieving the expected data.    
+When previewing a rule, you can also learn about its {es} queries, which are submitted when the rule runs. This information can be helpful for identifying and troubleshooting potential rule issues. You can also use it to confirm that your rule is retrieving the expected data.    
 
 To learn more about your rule's {es} queries, preview its results and do the following:
 

--- a/docs/detections/rules-ui-create.asciidoc
+++ b/docs/detections/rules-ui-create.asciidoc
@@ -824,7 +824,7 @@ TIP: Avoid setting long time ranges with short rule intervals, or the rule previ
 [[debug-rule-queries]]
 ==== Debug rule queries (optional)
 
-NOTE: This option is only offered for {esql} rules.
+NOTE: This option is only offered for {esql} and event correlation rules.
 
 When previewing an {esql} rule, you can also learn more about the {es} queries that are submitted when the rule runs. This information can be helpful for identifying and troubleshooting potential rule issues, or validating that your rule is retrieving the expected data.    
 

--- a/docs/detections/rules-ui-create.asciidoc
+++ b/docs/detections/rules-ui-create.asciidoc
@@ -835,6 +835,6 @@ To learn more about your rule's {es} queries, preview its results and do the fol
 . Expand each row to learn more about the {es} queries that the rule submits each time it executes. The following details are provided:
 ** When the rule execution started, and how long it took to complete
 ** A brief explanation of what the {es} queries do
-** The actual {es} queries that the rule sends to search indices containing events that are used during alert creation   
+** The actual {es} queries that the rule sends to search indices containing events used during rule execution  
 +
 TIP: Run the queries in Dev Tools (**{kib}** -> **Management** -> **Dev Tools**) to determine if your rule is retrieving the expected data. For example, to test your rule's exceptions, use the rule's {es} queries to find events that should be ignored during alert creation. If alerts weren't created for those events, your rule's exceptions are working as expected.

--- a/docs/detections/rules-ui-create.asciidoc
+++ b/docs/detections/rules-ui-create.asciidoc
@@ -837,4 +837,4 @@ To learn more about your rule's {es} queries, preview its results and do the fol
 ** A brief explanation of what the {es} queries do
 ** The actual {es} queries that the rule sends to search indices containing events used during rule execution  
 +
-TIP: Run the queries in Dev Tools (**{kib}** -> **Management** -> **Dev Tools**) to determine if your rule is retrieving the expected data. For example, to test your rule's exceptions, use the rule's {es} queries to find events that should be ignored during alert creation. If alerts weren't created for those events, your rule's exceptions are working as expected.
+TIP: Run the queries in Dev Tools (**{kib}** -> **Management** -> **Dev Tools**) to determine if your rule is retrieving the expected data. For example, to test your rule’s exceptions, run the rule’s {es} queries, which will also contain exceptions added to the rule. If your rule’s exceptions are working as intended, the query will not return events that should be ignored.

--- a/docs/serverless/rules/rules-ui-create.mdx
+++ b/docs/serverless/rules/rules-ui-create.mdx
@@ -887,14 +887,14 @@ When previewing a rule, you can also learn about its ((es)) queries, which are s
 
 To learn more about your rule's ((es)) queries, preview its results and do the following:
 
-1. Select the **Show Elasticsearch requests, ran during rule executions** option below the preview's date and time picker. The **Preview logged results** section displays under the the histogram and alerts table. 
+1. Select the **Show Elasticsearch requests, ran during rule executions** option below the preview's date and time picker. The **Preview logged results** section displays under the histogram and alerts table. 
 1. Click the **Preview logged results** section to expand it. Within the section, each rule execution is shown on an individual row.  
 1. Expand each row to learn more about the ((es)) queries that the rule submits each time it executes. The following details are provided:
-    * When it started and how long it took to complete
+    * When it started, and how long it took to complete
     * A brief explanation of what the {es} queries do
     * The actual ((es)) queries that the rule sends to search indices containing events that are used during alert creation   
 
         <DocCallOut title="Note">
-        Run the queries in Console (**Developer tools** -> **Console**) to determine if your rule is retrieving the expected data. For example, test your rule's exceptions by using its ((es)) queries to find events that should be ignored during alert creation. If alerts aren't created for those events, your rule's exceptions are working as expected. 
+        Run the queries in Console (**Developer tools** -> **Console**) to determine if your rule is retrieving the expected data. For example, to test your rule's exceptions, use the rule's {es} queries to find events that should be ignored during alert creation. If alerts weren't created for those events, your rule's exceptions are working as expected.
 
         </DocCallOut>

--- a/docs/serverless/rules/rules-ui-create.mdx
+++ b/docs/serverless/rules/rules-ui-create.mdx
@@ -875,9 +875,9 @@ To interact with the rule preview:
 
 * To close the preview, click the **Rule preview** button again.
 
-<div id="debug-rule-queries"></div>
+<div id="view-es-rule-queries"></div>
 
-### Debug rule queries (optional)
+### View ((es)) queries sent by your rule (optional)
 
 <DocCallOut title="Note">
 This option is only offered for ((esql)) and event correlation rules.
@@ -887,12 +887,14 @@ When previewing a rule, you can also learn more about the ((es)) queries that ar
 
 To learn more about your rule's ((es)) queries, preview its results and do the following:
 
-1. Beneath the rule preview's date and time picker, find the **Show Elasticsearch requests, ran during rule executions** option and select it. The **Preview logged results** section displays under the the histogram and alerts table in the panel. 
-1. Expand the **Preview logged results** section to display subsections with more information about the rule's ((es)) queries. The following details are provided:
-    * The expected start date and time of each rule execution and how long it took to complete
-    * A brief explanation of the ((es)) queries
-    * The actual ((es)) queries that the rule submits when it runs   
+1. Select the **Show Elasticsearch requests, ran during rule executions** option below the preview's date and time picker. The **Preview logged results** section displays under the the histogram and alerts table. 
+1. Click the **Preview logged results** section to expand it. Within the section, each rule execution is shown on an individual row.  
+1. Expand each row to learn more about the ((es)) queries that the rule submits each time it executes. The following details are provided:
+    * When it started and how long it took to complete
+    * A brief explanation of what the {es} queries do
+    * The actual ((es)) queries that the rule sends to search indices containing events that are used during alert creation   
 
-        <DocCallOut title="Tip">
-        Copy the queries and run them in Console (**Developer tools** -> **Console**) to determine if your rule is retrieving the expected data.
+        <DocCallOut title="Note">
+        Run the queries in Console (**Developer tools** -> **Console**) to determine if your rule is retrieving the expected data. For example, test your rule's exceptions by using its ((es)) queries to find events that should be ignored during alert creation. If alerts aren't created for those events, your rule's exceptions are working as expected. 
+
         </DocCallOut>

--- a/docs/serverless/rules/rules-ui-create.mdx
+++ b/docs/serverless/rules/rules-ui-create.mdx
@@ -891,9 +891,9 @@ To learn more about your rule's ((es)) queries, preview its results and do the f
 1. Click the **Preview logged results** section to expand it. Within the section, each rule execution is shown on an individual row.  
 1. Expand each row to learn more about the ((es)) queries that the rule submits each time it executes. The following details are provided:
     * When it started, and how long it took to complete
-    * A brief explanation of what the {es} queries do
+    * A brief explanation of what the ((es)) queries do
     * The actual ((es)) queries that the rule submits to indices containing events that are used during rule execution   
 
         <DocCallOut title="Tip">
-        Run the queries in Console (**Developer tools** -> **Console**) to determine if your rule is retrieving the expected data. For example, to test your rule’s exceptions, run the rule’s {es} queries, which will also contain exceptions added to the rule. If your rule’s exceptions are working as intended, the query will not return events that should be ignored.
+        Run the queries in Console (**Developer tools** -> **Console**) to determine if your rule is retrieving the expected data. For example, to test your rule’s exceptions, run the rule’s ((es)) queries, which will also contain exceptions added to the rule. If your rule’s exceptions are working as intended, the query will not return events that should be ignored.
         </DocCallOut>

--- a/docs/serverless/rules/rules-ui-create.mdx
+++ b/docs/serverless/rules/rules-ui-create.mdx
@@ -894,7 +894,6 @@ To learn more about your rule's ((es)) queries, preview its results and do the f
     * A brief explanation of what the {es} queries do
     * The actual ((es)) queries that the rule sends to search indices containing events that are used during alert creation   
 
-        <DocCallOut title="Note">
-        Run the queries in Console (**Developer tools** -> **Console**) to determine if your rule is retrieving the expected data. For example, to test your rule's exceptions, use the rule's {es} queries to find events that should be ignored during alert creation. If alerts weren't created for those events, your rule's exceptions are working as expected.
-
+        <DocCallOut title="Tip">
+        Run the queries in Console (**Developer tools** -> **Console**) to determine if your rule is retrieving the expected data. For example, to test your rule's exceptions, use the rule's ((es)) queries to find events that should be ignored during alert creation. If alerts weren't created for those events, your rule's exceptions are working as expected.
         </DocCallOut>

--- a/docs/serverless/rules/rules-ui-create.mdx
+++ b/docs/serverless/rules/rules-ui-create.mdx
@@ -877,7 +877,7 @@ To interact with the rule preview:
 
 <div id="view-rule-es-queries"></div>
 
-### View ((es)) queries sent by your rule (optional)
+### View your rule's ((es)) queries (optional)
 
 <DocCallOut title="Note">
 This option is only offered for ((esql)) and event correlation rules.

--- a/docs/serverless/rules/rules-ui-create.mdx
+++ b/docs/serverless/rules/rules-ui-create.mdx
@@ -883,7 +883,7 @@ To interact with the rule preview:
 This option is only offered for ((esql)) and event correlation rules.
 </DocCallOut>
 
-When previewing a rule, you can also learn more about the ((es)) queries that are submitted when the rule runs. This information can be helpful for identifying and troubleshooting potential rule issues, or validating that your rule is retrieving the expected data.    
+When previewing a rule, you can also learn about its ((es)) queries, which are submitted when the rule runs. This information can be helpful for identifying and troubleshooting potential rule issues. You can also use it to confirm that your rule is retrieving the expected data.   
 
 To learn more about your rule's ((es)) queries, preview its results and do the following:
 

--- a/docs/serverless/rules/rules-ui-create.mdx
+++ b/docs/serverless/rules/rules-ui-create.mdx
@@ -892,8 +892,8 @@ To learn more about your rule's ((es)) queries, preview its results and do the f
 1. Expand each row to learn more about the ((es)) queries that the rule submits each time it executes. The following details are provided:
     * When it started, and how long it took to complete
     * A brief explanation of what the {es} queries do
-    * The actual ((es)) queries that the rule sends to search indices containing events that are used during alert creation   
+    * The actual ((es)) queries that the rule submits to indices containing events that are used during rule execution   
 
         <DocCallOut title="Tip">
-        Run the queries in Console (**Developer tools** -> **Console**) to determine if your rule is retrieving the expected data. For example, to test your rule's exceptions, use the rule's ((es)) queries to find events that should be ignored during alert creation. If alerts weren't created for those events, your rule's exceptions are working as expected.
+        Run the queries in Console (**Developer tools** -> **Console**) to determine if your rule is retrieving the expected data. For example, to test your rule’s exceptions, run the rule’s {es} queries, which will also contain exceptions added to the rule. If your rule’s exceptions are working as intended, the query will not return events that should be ignored.
         </DocCallOut>

--- a/docs/serverless/rules/rules-ui-create.mdx
+++ b/docs/serverless/rules/rules-ui-create.mdx
@@ -895,5 +895,5 @@ To learn more about your rule's ((es)) queries, preview its results and do the f
     * The actual ((es)) queries that the rule submits to indices containing events that are used during the rule execution  
 
         <DocCallOut title="Tip">
-        Run the queries in <DocLink id="run-api-requests-in-the-console">Console</DocLink> to determine if your rule is retrieving the expected data. For example, to test your rule’s exceptions, run the rule’s ((es)) queries, which will also contain exceptions added to the rule. If your rule’s exceptions are working as intended, the query will not return events that should be ignored.
+        Run the queries in <DocLink id="/serverless/devtools/run-api-requests-in-the-console">Console</DocLink> to determine if your rule is retrieving the expected data. For example, to test your rule’s exceptions, run the rule’s ((es)) queries, which will also contain exceptions added to the rule. If your rule’s exceptions are working as intended, the query will not return events that should be ignored.
         </DocCallOut>

--- a/docs/serverless/rules/rules-ui-create.mdx
+++ b/docs/serverless/rules/rules-ui-create.mdx
@@ -880,12 +880,12 @@ To interact with the rule preview:
 ### Debug rule queries (optional)
 
 <DocCallOut title="Note">
-This option is only offered for ((esql)) rules.
+This option is only offered for ((esql)) and event correlation rules.
 </DocCallOut>
 
-When previewing an ((esql)) rule, you can also learn more about the ((es)) queries that are submitted when the rule runs. This information can be helpful for identifying and troubleshooting potential rule issues, or validating that your rule is retrieving the expected data.    
+When previewing a rule, you can also learn more about the ((es)) queries that are submitted when the rule runs. This information can be helpful for identifying and troubleshooting potential rule issues, or validating that your rule is retrieving the expected data.    
 
-To learn more your rule's ((es)) queries, preview its results and do the following:
+To learn more about your rule's ((es)) queries, preview its results and do the following:
 
 1. Beneath the rule preview's date and time picker, find the **Show Elasticsearch requests, ran during rule executions** option and select it. The **Preview logged results** section displays under the the histogram and alerts table in the panel. 
 1. Expand the **Preview logged results** section to display subsections with more information about the rule's ((es)) queries. The following details are provided:

--- a/docs/serverless/rules/rules-ui-create.mdx
+++ b/docs/serverless/rules/rules-ui-create.mdx
@@ -887,7 +887,7 @@ When previewing a rule, you can also learn about its ((es)) queries, which are s
 
 To learn more about your rule's ((es)) queries, preview its results and do the following:
 
-1. Select the **Show Elasticsearch requests, ran during rule executions** option below the preview's date and time picker. The **Preview logged results** section displays under the histogram and alerts table. 
+1. Select the **Show ((es)) requests, ran during rule executions** option below the preview's date and time picker. The **Preview logged results** section displays under the histogram and alerts table. 
 1. Click the **Preview logged results** section to expand it. Within the section, each rule execution is shown on an individual row.  
 1. Expand each row to learn more about the ((es)) queries that the rule submits each time it executes. The following details are provided:
     * When it started, and how long it took to complete

--- a/docs/serverless/rules/rules-ui-create.mdx
+++ b/docs/serverless/rules/rules-ui-create.mdx
@@ -895,5 +895,5 @@ To learn more about your rule's ((es)) queries, preview its results and do the f
     * The actual ((es)) queries that the rule submits to indices containing events that are used during the rule execution  
 
         <DocCallOut title="Tip">
-        Run the queries in Console (**Developer tools** -> **Console**) to determine if your rule is retrieving the expected data. For example, to test your rule’s exceptions, run the rule’s ((es)) queries, which will also contain exceptions added to the rule. If your rule’s exceptions are working as intended, the query will not return events that should be ignored.
+        Run the queries in [Console](((kibana-ref))/run-api-requests-in-the-console.html) to determine if your rule is retrieving the expected data. For example, to test your rule’s exceptions, run the rule’s ((es)) queries, which will also contain exceptions added to the rule. If your rule’s exceptions are working as intended, the query will not return events that should be ignored.
         </DocCallOut>

--- a/docs/serverless/rules/rules-ui-create.mdx
+++ b/docs/serverless/rules/rules-ui-create.mdx
@@ -883,7 +883,7 @@ To interact with the rule preview:
 This option is only offered for ((esql)) and event correlation rules.
 </DocCallOut>
 
-When previewing a rule, you can also learn about its ((es)) queries, which are submitted when the rule runs. This information can be helpful for identifying and troubleshooting potential rule issues. You can also use it to confirm that your rule is retrieving the expected data.   
+When previewing a rule, you can also learn about its ((es)) queries, which are submitted when the rule runs. This information can help you identify and troubleshoot potential rule issues. You can also use it to confirm that your rule is retrieving the expected data.   
 
 To learn more about your rule's ((es)) queries, preview its results and do the following:
 
@@ -892,7 +892,7 @@ To learn more about your rule's ((es)) queries, preview its results and do the f
 1. Expand each row to learn more about the ((es)) queries that the rule submits each time it executes. The following details are provided:
     * When it started, and how long it took to complete
     * A brief explanation of what the ((es)) queries do
-    * The actual ((es)) queries that the rule submits to indices containing events that are used during rule execution   
+    * The actual ((es)) queries that the rule submits to indices containing events that are used during the rule execution  
 
         <DocCallOut title="Tip">
         Run the queries in Console (**Developer tools** -> **Console**) to determine if your rule is retrieving the expected data. For example, to test your rule’s exceptions, run the rule’s ((es)) queries, which will also contain exceptions added to the rule. If your rule’s exceptions are working as intended, the query will not return events that should be ignored.

--- a/docs/serverless/rules/rules-ui-create.mdx
+++ b/docs/serverless/rules/rules-ui-create.mdx
@@ -875,3 +875,24 @@ To interact with the rule preview:
 
 * To close the preview, click the **Rule preview** button again.
 
+<div id="debug-rule-queries"></div>
+
+### Debug rule queries (optional)
+
+<DocCallOut title="Note">
+This option is only offered for ((esql)) rules.
+</DocCallOut>
+
+When previewing an ((esql)) rule, you can also learn more about the ((es)) queries that are submitted when the rule runs. This information can be helpful for identifying and troubleshooting potential rule issues, or validating that your rule is retrieving the expected data.    
+
+To learn more your rule's ((es)) queries, preview its results and do the following:
+
+1. Beneath the rule preview's date and time picker, find the **Show Elasticsearch requests, ran during rule executions** option and select it. The **Preview logged results** section displays under the the histogram and alerts table in the panel. 
+1. Expand the **Preview logged results** section to display subsections with more information about the rule's ((es)) queries. The following details are provided:
+    * The expected start date and time of each rule execution and how long it took to complete
+    * A brief explanation of the ((es)) queries
+    * The actual ((es)) queries that the rule submits when it runs   
+
+        <DocCallOut title="Tip">
+        Copy the queries and run them in Console (**Developer tools** -> **Console**) to determine if your rule is retrieving the expected data.
+        </DocCallOut>

--- a/docs/serverless/rules/rules-ui-create.mdx
+++ b/docs/serverless/rules/rules-ui-create.mdx
@@ -875,7 +875,7 @@ To interact with the rule preview:
 
 * To close the preview, click the **Rule preview** button again.
 
-<div id="view-es-rule-queries"></div>
+<div id="view-rule-es-queries"></div>
 
 ### View ((es)) queries sent by your rule (optional)
 

--- a/docs/serverless/rules/rules-ui-create.mdx
+++ b/docs/serverless/rules/rules-ui-create.mdx
@@ -894,6 +894,6 @@ To learn more about your rule's ((es)) queries, preview its results and do the f
     * A brief explanation of what the ((es)) queries do
     * The actual ((es)) queries that the rule submits to indices containing events that are used during the rule execution  
 
-        <DocCallOut title="Tip">
-        Run the queries in <DocLink id="/serverless/devtools/run-api-requests-in-the-console">Console</DocLink> to determine if your rule is retrieving the expected data. For example, to test your rule’s exceptions, run the rule’s ((es)) queries, which will also contain exceptions added to the rule. If your rule’s exceptions are working as intended, the query will not return events that should be ignored.
+        <DocCallOut title="Tip"> 
+        Run the queries in <DocLink slug="/serverless/devtools/run-api-requests-in-the-console">Console</DocLink> to determine if your rule is retrieving the expected data. For example, to test your rule’s exceptions, run the rule’s ((es)) queries, which will also contain exceptions added to the rule. If your rule’s exceptions are working as intended, the query will not return events that should be ignored.
         </DocCallOut>

--- a/docs/serverless/rules/rules-ui-create.mdx
+++ b/docs/serverless/rules/rules-ui-create.mdx
@@ -895,5 +895,5 @@ To learn more about your rule's ((es)) queries, preview its results and do the f
     * The actual ((es)) queries that the rule submits to indices containing events that are used during the rule execution  
 
         <DocCallOut title="Tip">
-        Run the queries in [Console](((kibana-ref))/run-api-requests-in-the-console.html) to determine if your rule is retrieving the expected data. For example, to test your rule’s exceptions, run the rule’s ((es)) queries, which will also contain exceptions added to the rule. If your rule’s exceptions are working as intended, the query will not return events that should be ignored.
+        Run the queries in <DocLink id="run-api-requests-in-the-console">Console</DocLink> to determine if your rule is retrieving the expected data. For example, to test your rule’s exceptions, run the rule’s ((es)) queries, which will also contain exceptions added to the rule. If your rule’s exceptions are working as intended, the query will not return events that should be ignored.
         </DocCallOut>


### PR DESCRIPTION
Fixes https://github.com/elastic/security-docs/issues/5844 by adding a new section that explains how to use the new **Show Elasticsearch requests, ran during rule executions** option in the rule preview.

Previews:
- ESS: https://security-docs_bk_5871.docs-preview.app.elstc.co/guide/en/security/master/rules-ui-create.html#view-rule-es-queries
- Serverless: https://elastic-dot-co-docs-production-7pe5v3ygb-elastic-dev.vercel.app/current/serverless/security/rules-create#view-your-rules-es-queries-optional