### PR TITLE
[bug] Fixes support matrix bug in k8s dashboard doc

### DIFF
--- a/docs/dashboards/kubernetes-dashboard.asciidoc
+++ b/docs/dashboards/kubernetes-dashboard.asciidoc
@@ -50,7 +50,7 @@ This feature is currently available on GKE and EKS using Linux hosts and Kuberne
 |===
 | | EKS 1.24-1.26 (AL2022) | GKE 1.24-1.26 (COS)
 | Process event exports | ✓ | ✓
-| Network event exports | ✓ | ✓
+| Network event exports | ✗ | ✗
 | File event exports | ✓ | ✓
 | File blocking | ✓ | ✓
 | Process blocking | ✓ | ✓

--- a/docs/serverless/dashboards/kubernetes-dashboard-dash.mdx
+++ b/docs/serverless/dashboards/kubernetes-dashboard-dash.mdx
@@ -56,7 +56,7 @@ This feature is currently available on GKE and EKS using Linux hosts and Kuberne
 |---|---|---|
 | | EKS 1.24-1.26 (AL2022) | GKE 1.24-1.26 (COS) |
 | Process event exports | ✓ | ✓ |
-| Network event exports | ✓ | ✓ |
+| Network event exports | ✗ | ✗ |
 | File event exports | ✓ | ✓ |
 | File blocking | ✓ | ✓ |
 | Process blocking | ✓ | ✓ |


### PR DESCRIPTION
Fixes #5880 by updating the supporting matrix on the K8s dashboard page (ESS and serverless)

Preview:[ K8s dashboard](https://elastic-dot-co-docs-production-bicwo4vmm-elastic-dev.vercel.app/current/serverless/security/kubernetes-dashboard-dash)