### PR TITLE
Risk scoring recalculation after file upload

### DIFF
--- a/docs/advanced-entity-analytics/asset-criticality.asciidoc
+++ b/docs/advanced-entity-analytics/asset-criticality.asciidoc
@@ -30,7 +30,7 @@ Entities do not have a default asset criticality level. You can either assign as
 
 When you assign, change, or unassign an individual entity's asset criticality level, that entity's risk score is immediately recalculated.
 
-NOTE: If you assign asset criticality using the file import feature, risk scores are **not** immediately recalculated. The newly assigned or updated asset criticality levels will impact entity risk scores during the next hourly risk scoring calculation.
+NOTE: If you assign asset criticality using the file import feature, risk scores are **not** immediately recalculated. However, you can trigger an immediate recalculation by clicking **Recalculate entity risk scores now**. Otherwise, the newly assigned or updated asset criticality levels will be factored in during the next hourly risk scoring calculation.
 
 You can view, assign, change, or unassign asset criticality from the following places in the {elastic-sec} app:
 
@@ -84,7 +84,9 @@ To import a file:
 NOTE: The file validation step highlights any lines that don't follow the required file structure. The asset criticality levels for those entities won't be assigned. We recommend that you fix any invalid lines and re-upload the file.
 . Click **Assign**. 
 
-This process overwrites any previously assigned asset criticality levels for the entities included in the imported file. The newly assigned or updated asset criticality levels are immediately visible within all asset criticality workflows and will impact entity risk scores during the next risk scoring calculation.
+This process overwrites any previously assigned asset criticality levels for the entities included in the imported file. The newly assigned or updated asset criticality levels are immediately visible within all asset criticality workflows.
+
+You can trigger an immediate recalculation of entity risk scores by clicking **Recalculate entity risk scores now**. Otherwise, the newly assigned or updated asset criticality levels will be factored in during the next hourly risk scoring calculation.
 
 [discrete]
 == Improve your security operations

--- a/docs/serverless/advanced-entity-analytics/asset-criticality.mdx
+++ b/docs/serverless/advanced-entity-analytics/asset-criticality.mdx
@@ -34,7 +34,7 @@ Entities do not have a default asset criticality level. You can either assign as
 When you assign, change, or unassign an individual entity's asset criticality level, that entity's risk score is immediately recalculated.
 
 <DocCallOut title="Note">
-If you assign asset criticality using the file import feature, risk scores are **not** immediately recalculated. The newly assigned or updated asset criticality levels will impact entity risk scores during the next hourly risk scoring calculation.
+If you assign asset criticality using the file import feature, risk scores are **not** immediately recalculated. However, you can trigger an immediate recalculation by clicking **Recalculate entity risk scores now**. Otherwise, the newly assigned or updated asset criticality levels will be factored in during the next hourly risk scoring calculation.
 </DocCallOut>
 
 You can view, assign, change, or unassign asset criticality from the following places in the ((elastic-sec)) app:
@@ -85,7 +85,9 @@ To import a file:
 
 1. Click **Assign**. 
 
-This process overwrites any previously assigned asset criticality levels for the entities included in the imported file. The newly assigned or updated asset criticality levels are immediately visible within all asset criticality workflows and will impact entity risk scores during the next risk scoring calculation.
+This process overwrites any previously assigned asset criticality levels for the entities included in the imported file. The newly assigned or updated asset criticality levels are immediately visible within all asset criticality workflows.
+
+You can trigger an immediate recalculation of entity risk scores by clicking **Recalculate entity risk scores now**. Otherwise, the newly assigned or updated asset criticality levels will be factored in during the next hourly risk scoring calculation.
 
 ## Improve your security operations
 


### PR DESCRIPTION
Resolves https://github.com/elastic/security-docs/issues/5912 by updating the information about risk scoring recalculation when using the file upload feature. Users can now manually trigger an immediate recalculation of risk scores after uploading asset criticality using file upload.

## Preview

ESS: [Asset criticality](https://security-docs_bk_5924.docs-preview.app.elstc.co/guide/en/security/master/asset-criticality.html)

Serverless: Open the link in [this comment](https://github.com/elastic/security-docs/pull/5924#issuecomment-2414311992) and navigate to Security -> View serverless docs -> Advanced Entity Analytics -> Entity risk scoring -> Asset criticality