### PR TITLE
Entity risk scoring available in multiple Kibana spaces

### DIFF
--- a/docs/advanced-entity-analytics/ers-req.asciidoc
+++ b/docs/advanced-entity-analytics/ers-req.asciidoc
@@ -40,9 +40,7 @@ Follow these guidelines to ensure clusters have adequate memory to handle data v
 [discrete]
 === Known limitations
 
-* You can only enable the risk scoring engine in a single {kib} space within a cluster.
-
-* The risk scoring engine uses an internal user role to score all hosts and users, and doesn't respect privileges applied to custom users or roles. After you turn on the risk scoring engine for a {kib} space, all alerts in the space will contribute to host and user risk scores.
+The risk scoring engine uses an internal user role to score all hosts and users, and doesn't respect privileges applied to custom users or roles. After you turn on the risk scoring engine for a {kib} space, all alerts in the space will contribute to host and user risk scores.
 
 [discrete]
 == Asset criticality


### PR DESCRIPTION
Resolves https://github.com/elastic/security-docs/issues/5913 by removing the known limitation about risk scoring availability in multiple spaces.

No changes needed to serverless docs, since spaces weren't available in serverless when those docs were written, so that limitation was not documented.

Preview: [Entity risk scoring requirements](https://security-docs_bk_5931.docs-preview.app.elstc.co/guide/en/security/master/ers-requirements.html)