### PR TITLE
Fixes list formatting for note in manual run docs

### DIFF
--- a/docs/detections/rules-ui-manage.asciidoc
+++ b/docs/detections/rules-ui-manage.asciidoc
@@ -128,6 +128,7 @@ The manual run's details are shown in the <<manual-runs-table,Manual runs>> tabl
 [NOTE] 
 =====
 Be mindful of the following:
+
 * Rule actions are not activated during manual runs. 
 * Except for threshold rules, duplicate alerts aren't created if you manually run a rule during a time range that was already covered by a scheduled run.
 * Manual runs are executed with low priority and limited concurrency, meaning they might take longer to complete. This can be especially apparent for rules requiring multiple executions.


### PR DESCRIPTION
Fixes [list formatting](https://www.elastic.co/guide/en/security/master/rules-ui-management.html#manually-run-rules) issue in the note at the end of the ESS manual run docs: 

[Preview](https://security-docs_bk_5942.docs-preview.app.elstc.co/guide/en/security/master/rules-ui-management.html#manually-run-rules)