### PR TITLE
Asset criticality navigation change

### DIFF
--- a/docs/advanced-entity-analytics/asset-criticality.asciidoc
+++ b/docs/advanced-entity-analytics/asset-criticality.asciidoc
@@ -78,7 +78,7 @@ host,host-001,extreme_impact
 
 To import a file:
 
-. Go to **Manage** → **Asset criticality**.
+. Find **Entity Store*** in the main menu or by using the {kibana-ref}/introduction.html#kibana-navigation-search[global search field].
 . Select or drag and drop the file you want to import.
 +
 NOTE: The file validation step highlights any lines that don't follow the required file structure. The asset criticality levels for those entities won't be assigned. We recommend that you fix any invalid lines and re-upload the file.

--- a/docs/advanced-entity-analytics/asset-criticality.asciidoc
+++ b/docs/advanced-entity-analytics/asset-criticality.asciidoc
@@ -78,7 +78,7 @@ host,host-001,extreme_impact
 
 To import a file:
 
-. Find **Entity Store*** in the main menu or by using the {kibana-ref}/introduction.html#kibana-navigation-search[global search field].
+. Find **Entity Store** in the main menu or by using the {kibana-ref}/introduction.html#kibana-navigation-search[global search field].
 . Select or drag and drop the file you want to import.
 +
 NOTE: The file validation step highlights any lines that don't follow the required file structure. The asset criticality levels for those entities won't be assigned. We recommend that you fix any invalid lines and re-upload the file.

--- a/docs/serverless/advanced-entity-analytics/asset-criticality.mdx
+++ b/docs/serverless/advanced-entity-analytics/asset-criticality.mdx
@@ -76,7 +76,7 @@ host,host-001,extreme_impact
 ````
 
 To import a file:
-1. Go to **Project Settings** → **Stack Management** → **Asset criticality**.
+1. Go to **Project Settings** → **Stack Management** → **Entity Store**.
 1. Select or drag and drop the file you want to import.
 
     <DocCallOut title="Note">


### PR DESCRIPTION
Resolves https://github.com/elastic/security-docs/issues/5976 by updating the name of the Asset criticality page to Entity Store. 

### Previews

ESS: [Asset criticality | Bulk assign asset criticality](https://security-docs_bk_5990.docs-preview.app.elstc.co/guide/en/security/master/asset-criticality.html#bulk-assign-asset-criticality)

Serverless: Open the link in [this comment](https://github.com/elastic/security-docs/pull/5990#issuecomment-2435574319), then navigate to Security -> View serverless docs -> Advanced Entity Analytics -> Entity risk scoring -> Asset criticality.