### PR TITLE
Asset criticality advanced setting removed

### DIFF
--- a/docs/advanced-entity-analytics/api/asset-criticality-api-overview.asciidoc
+++ b/docs/advanced-entity-analytics/api/asset-criticality-api-overview.asciidoc
@@ -8,4 +8,4 @@
 For the most up-to-date API details, refer to {api-kibana}/group/endpoint-security-entity-analytics-api[Entity Analytics APIs].
 --
 
-You can manage <<asset-criticality, asset criticality>> records through the API. To use this API, you must first turn on the `securitySolution:enableAssetCriticality` <<enable-asset-criticality, advanced setting>>.
+You can manage <<asset-criticality, asset criticality>> records through the API.

--- a/docs/advanced-entity-analytics/asset-criticality.asciidoc
+++ b/docs/advanced-entity-analytics/asset-criticality.asciidoc
@@ -4,12 +4,7 @@
 .Requirements
 [sidebar]
 --
-To view and assign asset criticality, you must:
-
-* Have the appropriate user role.
-* Turn on the `securitySolution:enableAssetCriticality` <<enable-asset-criticality, advanced setting>>.
-
-For more information, refer to <<ers-requirements, Entity risk scoring prerequisites>>.
+To view and assign asset criticality, you must have the appropriate user role. For more information, refer to <<ers-requirements, Entity risk scoring prerequisites>>.
 --
 
 The asset criticality feature allows you to classify your organization's entities based on various operational factors that are important to your organization. Through this classification, you can improve your threat detection capabilities by focusing your alert triage, threat-hunting, and investigation activities on high-impact entities.

--- a/docs/advanced-entity-analytics/entity-risk-scoring.asciidoc
+++ b/docs/advanced-entity-analytics/entity-risk-scoring.asciidoc
@@ -30,11 +30,7 @@ Entity risk scores are determined by the following risk inputs:
 
 The resulting entity risk scores are stored in the `risk-score.risk-score-<space-id>` data stream alias.
 
-[NOTE]
-======
-* Entities without any alerts, or with only `Closed` alerts, are not assigned a risk score.
-* To use asset criticality, you must enable the `securitySolution:enableAssetCriticality` <<enable-asset-criticality, advanced setting>>.
-======
+NOTE: Entities without any alerts, or with only `Closed` alerts, are not assigned a risk score.
 
 [discrete]
 [[how-is-risk-score-calculated]]

--- a/docs/advanced-entity-analytics/ers-req.asciidoc
+++ b/docs/advanced-entity-analytics/ers-req.asciidoc
@@ -45,8 +45,6 @@ The risk scoring engine uses an internal user role to score all hosts and users,
 [discrete]
 == Asset criticality
 
-To use the asset criticality feature, turn on the `securitySolution:enableAssetCriticality` <<enable-asset-criticality, advanced setting>>.
-
 [discrete]
 === Privileges
 

--- a/docs/getting-started/advanced-setting.asciidoc
+++ b/docs/getting-started/advanced-setting.asciidoc
@@ -103,11 +103,6 @@ Security *Overview* page.
 retrieved.
 
 [discrete]
-[[enable-asset-criticality]]
-== Enable asset criticality workflows
-The `securitySolution:enableAssetCriticality` setting determines whether asset criticality is included as a risk input to entity risk scoring. This setting is turned off by default. Turn it on to enable asset criticality workflows and to use asset criticality as part of entity risk scoring.
-
-[discrete]
 [[exclude-cold-frozen-tiers]]
 == Exclude cold and frozen tier data from analyzer queries
 

--- a/docs/getting-started/users-page.asciidoc
+++ b/docs/getting-started/users-page.asciidoc
@@ -36,7 +36,7 @@ A user's details page displays all relevant information for the selected user. T
 
 The user details page includes the following sections: 
 
-* **Asset Criticality**: If the `securitySolution:enableAssetCriticality` <<enable-asset-criticality, advanced setting>> is on, this section displays the user's current <<asset-criticality, asset criticality level>>.
+* **Asset Criticality**: This section displays the user's current <<asset-criticality, asset criticality level>>.
 
 * *Summary*: Details such as the user ID, when the user was first and last seen, the associated IP address(es), and operating system. If the user risk score feature is enabled, this section also displays user risk score data. 
 
@@ -98,12 +98,6 @@ image::images/users/user-risk-inputs.png[User risk inputs]
 [discrete]
 [[user-asset-criticality-section]]
 === Asset Criticality
-
-.Requirements
-[sidebar]
---
-The **Asset Criticality** section is only available if the `securitySolution:enableAssetCriticality` <<enable-asset-criticality, advanced setting>> is on.
---
 
 The **Asset Criticality** section displays the selected user's <<asset-criticality, asset criticality level>>. Asset criticality contributes to the overall <<entity-risk-scoring, user risk score>>. The criticality level defines how impactful the user is when calculating the risk score.
 

--- a/docs/management/hosts/hosts-overview.asciidoc
+++ b/docs/management/hosts/hosts-overview.asciidoc
@@ -42,7 +42,7 @@ A host's details page displays all relevant information for the selected host. T
 
 The host details page includes the following sections: 
 
-* **Asset Criticality**: If the `securitySolution:enableAssetCriticality` <<enable-asset-criticality, advanced setting>> is on, this section displays the host's current <<asset-criticality, asset criticality level>>.
+* **Asset Criticality**: This section displays the host's current <<asset-criticality, asset criticality level>>.
 * *Summary*: Details such as the host ID, when the host was first and last seen, the associated IP addresses, and associated operating system. If the host risk score feature is enabled, this section also displays host risk score data. 
 * *Alert metrics*: The total number of alerts by severity, rule, and status (`Open`, `Acknowledged`, or `Closed`).  
 * *Data tables*: The same data tables as on the main Hosts page, except with values for the selected host instead of all hosts. 
@@ -101,12 +101,6 @@ image::images/host-risk-inputs.png[Host risk inputs]
 [discrete]
 [[host-asset-criticality-section]]
 === Asset Criticality
-
-.Requirements
-[sidebar]
---
-The **Asset Criticality** section is only available if the `securitySolution:enableAssetCriticality` <<enable-asset-criticality, advanced setting>> is on.
---
 
 The **Asset Criticality** section displays the selected host's <<asset-criticality, asset criticality level>>. Asset criticality contributes to the overall <<entity-risk-scoring, host risk score>>. The criticality level defines how impactful the host is when calculating the risk score.
 

--- a/docs/serverless/advanced-entity-analytics/asset-criticality.mdx
+++ b/docs/serverless/advanced-entity-analytics/asset-criticality.mdx
@@ -9,11 +9,7 @@ status: in review
 <DocBadge template="technical preview" />
 
 <DocCallOut title="Requirements">
-To view and assign asset criticality, you must:
-* Have the appropriate user role.
-* Turn on the `securitySolution:enableAssetCriticality` <DocLink slug="/serverless/security/advanced-settings" section="enable-asset-criticality-workflows" >advanced setting</DocLink>.
-
-For more information, refer to <DocLink slug="/serverless/security/ers-requirements">Entity risk scoring prerequisites</DocLink>.
+To view and assign asset criticality, you must have the appropriate user role. For more information, refer to <DocLink slug="/serverless/security/ers-requirements">Entity risk scoring prerequisites</DocLink>.
 </DocCallOut>
 
 The asset criticality feature allows you to classify your organization's entities based on various operational factors that are important to your organization. Through this classification, you can improve your threat detection capabilities by focusing your alert triage, threat-hunting, and investigation activities on high-impact entities.

--- a/docs/serverless/advanced-entity-analytics/entity-risk-scoring.mdx
+++ b/docs/serverless/advanced-entity-analytics/entity-risk-scoring.mdx
@@ -42,8 +42,7 @@ The resulting entity risk scores are stored in the `risk-score.risk-score-<space
 
 <DocCallOut title="Note">
 
-* Entities without any alerts, or with only `Closed` alerts, are not assigned a risk score.
-* To use asset criticality, you must enable the `securitySolution:enableAssetCriticality` <DocLink slug="/serverless/security/advanced-settings" section="enable-asset-criticality-workflows" >advanced setting</DocLink>.
+Entities without any alerts, or with only `Closed` alerts, are not assigned a risk score.
 
 </DocCallOut>
 

--- a/docs/serverless/advanced-entity-analytics/ers-req.mdx
+++ b/docs/serverless/advanced-entity-analytics/ers-req.mdx
@@ -41,8 +41,6 @@ To turn on the risk scoring engine, you need either the appropriate <DocLink slu
 
 ## Asset criticality
 
-To use the asset criticality feature, turn on the `securitySolution:enableAssetCriticality` <DocLink slug="/serverless/security/advanced-settings" section="enable-asset-criticality-workflows" >advanced setting</DocLink>.
-
 ### User roles
 
 To use asset criticality, you need either the appropriate <DocLink slug="/serverless/general/assign-user-roles">predefined Security user role</DocLink> or a <DocLink slug="/serverless/custom-roles">custom role</DocLink> with the right privileges:

--- a/docs/serverless/explore/hosts-overview.mdx
+++ b/docs/serverless/explore/hosts-overview.mdx
@@ -50,7 +50,7 @@ A host's details page displays all relevant information for the selected host. T
 
 The host details page includes the following sections: 
 
-* **Asset Criticality**: If the `securitySolution:enableAssetCriticality` <DocLink slug="/serverless/security/advanced-settings" section="enable-asset-criticality-workflows" >advanced setting</DocLink> is on, this section displays the host's current <DocLink slug="/serverless/security/asset-criticality">asset criticality level</DocLink>.
+* **Asset Criticality**: This section displays the host's current <DocLink slug="/serverless/security/asset-criticality">asset criticality level</DocLink>.
 * **Summary**: Details such as the host ID, when the host was first and last seen, the associated IP addresses, and associated operating system. If the entity risk score feature is enabled, this section also displays host risk score data. 
 * **Alert metrics**: The total number of alerts by severity, rule, and status (`Open`, `Acknowledged`, or `Closed`).  
 * **Data tables**: The same data tables as on the main Hosts page, except with values for the selected host instead of all hosts. 
@@ -98,10 +98,6 @@ If more than 10 alerts contributed to the risk scoring calculation, the remainin
 ![Host risk inputs](../images/hosts-overview/-host-risk-inputs.png)
 
 ### Asset Criticality
-
-<DocCallOut title="Requirements">
-The **Asset Criticality** section is only available if the `securitySolution:enableAssetCriticality` <DocLink slug="/serverless/security/advanced-settings" section="enable-asset-criticality-workflows" >advanced setting</DocLink> is on.
-</DocCallOut>
 
 The **Asset Criticality** section displays the selected host's <DocLink slug="/serverless/security/asset-criticality">asset criticality level</DocLink>. Asset criticality contributes to the overall <DocLink slug="/serverless/security/entity-risk-scoring" >host risk score</DocLink>. The criticality level defines how impactful the host is when calculating the risk score.
 

--- a/docs/serverless/explore/users-page.mdx
+++ b/docs/serverless/explore/users-page.mdx
@@ -41,7 +41,7 @@ A user's details page displays all relevant information for the selected user. T
 
 The user details page includes the following sections: 
 
-* **Asset Criticality**: If the `securitySolution:enableAssetCriticality` <DocLink slug="/serverless/security/advanced-settings" section="enable-asset-criticality-workflows" >advanced setting</DocLink> is on, this section displays the user's current <DocLink slug="/serverless/security/asset-criticality">asset criticality level</DocLink>.
+* **Asset Criticality**: This section displays the user's current <DocLink slug="/serverless/security/asset-criticality">asset criticality level</DocLink>.
 
 * **Summary**: Details such as the user ID, when the user was first and last seen, the associated IP address(es), and operating system. If the entity risk score feature is enabled, this section also displays user risk score data. 
 
@@ -92,10 +92,6 @@ If more than 10 alerts contributed to the risk scoring calculation, the remainin
 ![User risk inputs](../images/users-page/-user-risk-inputs.png)
 
 ### Asset Criticality
-
-<DocCallOut title="Requirement">
-The **Asset Criticality** section is only available if the `securitySolution:enableAssetCriticality` <DocLink slug="/serverless/security/advanced-settings" section="enable-asset-criticality-workflows" >advanced setting</DocLink> is on.
-</DocCallOut>
 
 The **Asset Criticality** section displays the selected user's <DocLink slug="/serverless/security/asset-criticality">asset criticality level</DocLink>. Asset criticality contributes to the overall <DocLink slug="/serverless/security/entity-risk-scoring" >user risk score</DocLink>. The criticality level defines how impactful the user is when calculating the risk score.
 

--- a/docs/serverless/settings/advanced-settings.mdx
+++ b/docs/serverless/settings/advanced-settings.mdx
@@ -126,10 +126,6 @@ You can change these settings, which affect the news feed displayed on the
 * `securitySolution:newsFeedUrl`: The URL from which the security news feed content is
     retrieved.
 
-## Enable asset criticality workflows
-
-The `securitySolution:enableAssetCriticality` setting determines whether asset criticality is included as a risk input to entity risk scoring. This setting is turned off by default. Turn it on to enable asset criticality workflows and to use asset criticality as part of entity risk scoring.
-
 ## Exclude cold and frozen tier data from analyzer queries
 
 Including data from cold and frozen [data tiers](((ref))/data-tiers.html) in <DocLink slug="/serverless/security/visual-event-analyzer">visual event analyzer</DocLink> queries may result in performance degradation. The `securitySolution:excludeColdAndFrozenTiersInAnalyzer` setting allows you to exclude this data from analyzer queries. This setting is turned off by default.


### PR DESCRIPTION
Resolves https://github.com/elastic/security-docs/issues/5975. Removes all references to the asset criticality advanced setting. The setting has been removed and asset criticality is now available by default.

### Previews

ESS:

- [Asset criticality API](https://security-docs_bk_5991.docs-preview.app.elstc.co/guide/en/security/master/asset-criticality-api-overview.html)
- [Configure advanced settings](https://security-docs_bk_5991.docs-preview.app.elstc.co/guide/en/security/master/advanced-settings.html)
- [Hosts page](https://security-docs_bk_5991.docs-preview.app.elstc.co/guide/en/security/master/hosts-overview.html)
- [Users page](https://security-docs_bk_5991.docs-preview.app.elstc.co/guide/en/security/master/users-page.html)
- [Entity risk scoring requirements | Asset criticality](https://security-docs_bk_5991.docs-preview.app.elstc.co/guide/en/security/master/ers-requirements.html#_asset_criticality)
- [Entity risk scoring](https://security-docs_bk_5991.docs-preview.app.elstc.co/guide/en/security/master/entity-risk-scoring.html)
- [Asset criticality](https://security-docs_bk_5991.docs-preview.app.elstc.co/guide/en/security/master/asset-criticality.html)

Serverless:

Open the link in [this comment](https://github.com/elastic/security-docs/pull/5991#issuecomment-2435627815), navigate to Security -> View serverless docs, and then to the following pages:

- Manage settings -> Advanced settings 
- Explore your data -> Host page
- Explore your data -> Users page
- Advanced Entity Analytics -> Entity risk scoring
- Advanced Entity Analytics -> Entity risk scoring -> Entity risk scoring requirements
- Advanced Entity Analytics -> Entity risk scoring -> Asset criticality