### PR TITLE
Fixes incorrect attribute

### DIFF
--- a/docs/serverless/advanced-entity-analytics/turn-on-risk-engine.asciidoc
+++ b/docs/serverless/advanced-entity-analytics/turn-on-risk-engine.asciidoc
@@ -24,7 +24,7 @@ You can preview risky entities before installing the risk engine. The preview sh
 
 [NOTE]
 ====
-The preview is limited to two risk scores per {serverless-short} {security} project.
+The preview is limited to two risk scores per {serverless-short} {elastic-sec} project.
 ====
 
 To preview risky entities, go to **Project settings** → **Management** → **Entity Risk Score**:

--- a/docs/serverless/investigate/cases-settings.asciidoc
+++ b/docs/serverless/investigate/cases-settings.asciidoc
@@ -1,12 +1,12 @@
 [[security-cases-settings]]
 = Configure case settings
 
-// :description: Change the default behavior of {security} cases by adding connectors, custom fields, templates, and closure options.
+// :description: Change the default behavior of {elastic-sec} cases by adding connectors, custom fields, templates, and closure options.
 // :keywords: serverless, security, how-to, configure
 
 preview:[]
 
-To access case settings in a {security} project, go to **Cases** → **Settings**.
+To access case settings in an {elastic-sec} project, go to **Cases** → **Settings**.
 
 [role="screenshot"]
 image::images/cases-settings/security-cases-settings.png[Shows the case settings page]


### PR DESCRIPTION
As Liam reported in [this thread](https://elastic.slack.com/archives/C05PP2LEC1X/p1730884542702359), some attributes were incorrect post migration of serverless docs from mdx to asciidoc. This PR updates the occurrences of the `{security}` attribute to `{elastic-sec}`.

Previews:
* [Turn on risk scoring](https://security-docs_bk_6069.docs-preview.app.elstc.co/guide/en/serverless/current/security-turn-on-risk-engine.html)
* [Configure case settings](https://security-docs_bk_6069.docs-preview.app.elstc.co/guide/en/serverless/current/security-cases-settings.html)

Related PR that fixes the same issue in the `docs-content` repo: https://github.com/elastic/docs-content/pull/174