### PR TITLE
Update allowlist-endpoint-3rd-party-av.asciidoc

### DIFF
--- a/docs/management/admin/allowlist-endpoint-3rd-party-av.asciidoc
+++ b/docs/management/admin/allowlist-endpoint-3rd-party-av.asciidoc
@@ -13,8 +13,8 @@ NOTE: Your AV software may refer to allowlisted processes as process exclusions,
 
 File paths:
 
-* ELAM driver: `c:\Windows\system32\drivers\elastic-endpoint-driver.sys`
-* Driver: `c:\Windows\system32\drivers\ElasticElam.sys`
+* ELAM driver: `c:\Windows\system32\drivers\ElasticElam.sys`
+* Driver: `c:\Windows\system32\drivers\elastic-endpoint-driver.sys`
 * Executable: `c:\Program Files\Elastic\Endpoint\elastic-endpoint.exe`
 +
 NOTE: The executable runs as `elastic-endpoint.exe`.


### PR DESCRIPTION
the `driver` and `ELAM` paths were inverted