### PR TITLE
Fix image reference bug

### DIFF
--- a/docs/detections/prebuilt-rules-management.asciidoc
+++ b/docs/detections/prebuilt-rules-management.asciidoc
@@ -43,7 +43,7 @@ TIP: To examine the details of a rule before you install it, select the rule nam
 --
 * Install all available rules: Click *Install all* at the top of the page. (This doesn't enable the rules; you still need to do that manually.)
 * Install a single rule: In the rules table, either click **Install** to install a rule without enabling it, or click image:images/boxesVertical.svg[Vertical boxes button] → **Install and enable** to start running the rule once it's installed.
-* Install multiple rules: Select the rules, and then at the top of the page either click *Install _x_ selected rule(s)* to install without enabling the rules, or click image:images/icons/boxesVertical.svg[Vertical boxes button] → **Install and enable** to install and start running the rules.
+* Install multiple rules: Select the rules, and then at the top of the page either click *Install _x_ selected rule(s)* to install without enabling the rules, or click image:images/boxesVertical.svg[Vertical boxes button] → **Install and enable** to install and start running the rules.
 --
 +
 TIP: Use the search bar and *Tags* filter to find the rules you want to install. For example, filter by `OS: Windows` if your environment only includes Windows endpoints. For more on tag categories, refer to <<prebuilt-rule-tags>>.


### PR DESCRIPTION
Follow up fix for image reference bug introduced in https://github.com/elastic/security-docs/pull/6051.

The bug doesn't manifest in the `main` branch, but will become a problem for future backport branches created off of `main`. I noticed this in the backport PRs https://github.com/elastic/security-docs/pull/6051 and https://github.com/elastic/security-docs/pull/6093 and fixed the errors in those PRs, but then realized that the problem might re-emerge again any time another backport branch gets created.

The problem is that the `images/icons` subdirectory won't exist for those ESS-only backport branches, because the location only exists in serverless docs.