### PR TITLE
Fixes incorrect ref in the 8.15.4 release notes 

### DIFF
--- a/docs/release-notes/8.15.asciidoc
+++ b/docs/release-notes/8.15.asciidoc
@@ -31,7 +31,7 @@ On August 1, 2024, it was discovered that Elastic AI Assistant's responses when 
 * Fixes a conflict that could result in a Windows boot failure `0xC000007B` for `ElasticElam.sys` when {elastic-defend} 8.15.2 or 8.15.3 was installed alongside CrowdStrike.
 * Fixes a bug that caused an Elastic AI Assistant error if you had over 20 conversations and tried to access or update any of them ({kibana-pull}197305[#197305]).
 * Makes Automatic Import more forgiving if LLMs return ECS mappings in unexpected formats ({kibana-pull}195167[#195167]).
-* Fixes a bug that caused fields from all indices to display when adding a filter to a rule that you were editing. Now, only fields from the rule's specified indices appear ({kibana-pull}194678[#194678], {kibana-pull}181643[#181643]).
+* Fixes a bug that caused fields from all indices to display when adding a filter to a rule that you were editing. Now, only fields from the rule's specified indices appear ({kibana-pull}194678[#194678], {kibana-issue}181643[#181643]).
 * Improves {elastic-defend} by making the `elastic-endpoint status` command more reliable. Before this fix, the command occasionally failed with an I/O error.
 * Fixes an {elastic-defend} process crash that could occur if it was configured to use the Kafka output.
 * Fixes a bug where {elastic-defend} could fail to properly enrich Windows API events for short-lived processes on older operating systems that didn't natively include this telemetry, such as Windows Server 2019. This could result in dropped or unattributed API events.  


### PR DESCRIPTION
Fixes the ref so it links to the correct Kibana issue.

[Preview](https://security-docs_bk_6126.docs-preview.app.elstc.co/guide/en/security/master/release-notes-header-8.15.0.html#bug-fixes-8.15.4)