### PR TITLE
[ESS & Serverless] Adds OrganizationUnitIDs description to agentless section of AWS CSPM guide

### DIFF
--- a/docs/cloud-native-security/cspm-get-started-aws.asciidoc
+++ b/docs/cloud-native-security/cspm-get-started-aws.asciidoc
@@ -43,6 +43,9 @@ beta::[]
 . Click **Advanced options**, then select **Agentless (BETA)**.
 . Next, you'll need to authenticate to AWS. Two methods are available:
 .. Option 1: Direct access keys/CloudFormation (Recommended). Under **Preferred method**, select **Direct access keys**. Expand the **Steps to Generate AWS Account Credentials** section, then follow the displayed instructions to automatically create the necessary credentials using CloudFormation.
++
+NOTE: If you don't want to monitor every account in your organization, specify which to monitor using the `OrganizationalUnitIDs` field that appears after you click **Launch CloudFormation**.
++
 .. Option 2: Temporary keys. To authenticate using temporary keys, refer to the instructions for <<cspm-use-temp-credentials, temporary keys>>.  
 . Once you've selected an authentication method and provided all necessary credentials, click **Save and continue** to finish deployment. Your data should start to appear within a few minutes.
 
@@ -76,7 +79,7 @@ For most use cases, the simplest option is to use AWS CloudFormation to automati
 . Return to your {kib} tab. Click *Save and continue* at the bottom of the page.
 . Review the information, then click *Launch CloudFormation*.
 . A CloudFormation template appears in a new browser tab.
-. For organization-level deployments only, you must enter the ID of the organizational unit where you want to deploy into the `OrganizationalUnitIds` field in the CloudFormation template. You can find it in the AWS console under *AWS Organizations -> AWS Accounts* (it appears under the organization name).
+. For organization-level deployments only, you must enter the ID of the organizational unit(s) where you want to deploy into the CloudFormation template's `OrganizationalUnitIds` field. You can find organizational unit IDs in the AWS console under *AWS Organizations -> AWS Accounts* (under each organization's name). You can also use this field to specify which accounts in your organization to monitor, and which to skip.
 . (Optional) Switch to the AWS region where you want to deploy using the controls in the upper right corner.
 . Tick the checkbox under *Capabilities* to authorize the creation of necessary resources.
 +

--- a/docs/cloud-native-security/cspm-get-started-aws.asciidoc
+++ b/docs/cloud-native-security/cspm-get-started-aws.asciidoc
@@ -79,7 +79,7 @@ For most use cases, the simplest option is to use AWS CloudFormation to automati
 . Return to your {kib} tab. Click *Save and continue* at the bottom of the page.
 . Review the information, then click *Launch CloudFormation*.
 . A CloudFormation template appears in a new browser tab.
-. For organization-level deployments only, you must enter the ID of the organizational unit(s) where you want to deploy into the CloudFormation template's `OrganizationalUnitIds` field. You can find organizational unit IDs in the AWS console under *AWS Organizations -> AWS Accounts* (under each organization's name). You can also use this field to specify which accounts in your organization to monitor, and which to skip.
+. For organization-level deployments only, you must enter the ID of the organizational units where you want to deploy into the CloudFormation template's `OrganizationalUnitIds` field. You can find organizational unit IDs in the AWS console under *AWS Organizations -> AWS Accounts* (under each organization's name). You can also use this field to specify which accounts in your organization to monitor, and which to skip.
 . (Optional) Switch to the AWS region where you want to deploy using the controls in the upper right corner.
 . Tick the checkbox under *Capabilities* to authorize the creation of necessary resources.
 +

--- a/docs/serverless/cloud-native-security/cspm-get-started.asciidoc
+++ b/docs/serverless/cloud-native-security/cspm-get-started.asciidoc
@@ -45,6 +45,9 @@ beta:[]
 . Click **Advanced options**, then select **Agentless (BETA)**.
 . Next, you'll need to authenticate to AWS. Two methods are available:
 .. Option 1: Direct access keys/CloudFormation (Recommended). Under **Preferred method** select **Direct access keys**. Expand the **Steps to Generate AWS Account Credentials** section, then follow the displayed instructions to automatically create the necessary credentials using CloudFormation.
++
+NOTE: If you don't want to monitor every account in your organization, specify which to monitor using the `OrganizationalUnitIDs` field that appears after you click **Launch CloudFormation**.
++
 .. Option 2: Temporary keys. To authenticate using temporary keys, refer to the instructions for <<cspm-use-temp-credentials,Temporary keys>>.
 . Once you've selected an authentication method and provided all necessary credentials, click **Save and continue** to finish deployment. Your data should start to appear within a few minutes.
 
@@ -79,7 +82,7 @@ For most use cases, the simplest option is to use AWS CloudFormation to automati
 . Return to your {kib} tab. Click **Save and continue** at the bottom of the page.
 . Review the information, then click **Launch CloudFormation**.
 . A CloudFormation template appears in a new browser tab.
-. For organization-level deployments only, you must enter the ID of the organizational unit where you want to deploy into the `OrganizationalUnitIds` field in the CloudFormation template. You can find it in the AWS console under **AWS Organizations → AWS Accounts** (it appears under the organization name).
+. For organization-level deployments only, you must enter the ID of the organizational unit(s) where you want to deploy into the CloudFormation template's `OrganizationalUnitIds` field. You can find organizational unit IDs in the AWS console under *AWS Organizations -> AWS Accounts* (under each organization's name). You can also use this field to specify which accounts in your organization to monitor, and which to skip.
 . (Optional) Switch to the AWS region where you want to deploy using the controls in the upper right corner.
 . Tick the checkbox under **Capabilities** to authorize the creation of necessary resources.
 +

--- a/docs/serverless/cloud-native-security/cspm-get-started.asciidoc
+++ b/docs/serverless/cloud-native-security/cspm-get-started.asciidoc
@@ -82,7 +82,7 @@ For most use cases, the simplest option is to use AWS CloudFormation to automati
 . Return to your {kib} tab. Click **Save and continue** at the bottom of the page.
 . Review the information, then click **Launch CloudFormation**.
 . A CloudFormation template appears in a new browser tab.
-. For organization-level deployments only, you must enter the ID of the organizational unit(s) where you want to deploy into the CloudFormation template's `OrganizationalUnitIds` field. You can find organizational unit IDs in the AWS console under *AWS Organizations -> AWS Accounts* (under each organization's name). You can also use this field to specify which accounts in your organization to monitor, and which to skip.
+. For organization-level deployments only, you must enter the ID of the organizational units where you want to deploy into the CloudFormation template's `OrganizationalUnitIds` field. You can find organizational unit IDs in the AWS console under *AWS Organizations -> AWS Accounts* (under each organization's name). You can also use this field to specify which accounts in your organization to monitor, and which to skip.
 . (Optional) Switch to the AWS region where you want to deploy using the controls in the upper right corner.
 . Tick the checkbox under **Capabilities** to authorize the creation of necessary resources.
 +


### PR DESCRIPTION
Fixes #5636 
Adds OrganizationalUnitIDs field to the agentless CSPM AWS guides, edits the field's description in agent-based method.

Preview: CSPM for AWS ([ESS](https://security-docs_bk_6155.docs-preview.app.elstc.co/guide/en/security/master/cspm-get-started.html)), ([Serverless](https://security-docs_bk_6155.docs-preview.app.elstc.co/guide/en/serverless/current/security-cspm-get-started.html))