### PR TITLE
Update serverless Discover URL

### DIFF
--- a/docs/serverless/investigate/timelines-ui.asciidoc
+++ b/docs/serverless/investigate/timelines-ui.asciidoc
@@ -255,7 +255,7 @@ When querying indices that tend to be large (for example, `logs-*`), performance
 * When specifying data sources for an {esql} query, autocomplete doesn't suggest hidden indices, such as `.alerts-*`. You must manually enter the index name or pattern.
 ====
 * Click the help icon (image:images/icons/iInCircle.svg[Click the ES|QL help icon]) on the far right side of the query editor to open the in-product reference documentation for all {esql} commands and functions.
-* Visualize query results using <<elasticsearch-explore-your-data-discover-your-data,Discover>> functionality.
+* Visualize query results using {kibana-ref}/discover.html[Discover] functionality.
 
 [role="screenshot"]
 image::images/timelines-ui/-events-esql-tab.png[Example of the ES|QL tab in Timeline]

--- a/docs/serverless/security-ui.asciidoc
+++ b/docs/serverless/security-ui.asciidoc
@@ -80,7 +80,7 @@ The {security-app} contains the following pages that enable analysts to view, an
 [[security-ui-discover]]
 === Discover
 
-Use the <<elasticsearch-explore-your-data-discover-your-data,Discover UI>> to filter your data or learn about its structure.
+Use the {kibana-ref}/discover.html[Discover] UI to filter your data or learn about its structure.
 
 [discrete]
 [[security-ui-dashboards]]


### PR DESCRIPTION
👋 We're de-duplicating content in the Elasticsearch serverless docs, and this is an example of a feature that will have its single-source-of-truth in the Kibana docs. I'll need this change merged, in order to get a green build on my PR in the `docs-content` repo.