### PR TITLE
Removes 199791 from the 8.16.1 release notes

### DIFF
--- a/docs/release-notes/8.16.asciidoc
+++ b/docs/release-notes/8.16.asciidoc
@@ -38,7 +38,6 @@ On November 12, 2024, it was discovered that manually running a custom query rul
 * Fixes a bug that caused the Elastic AI Assistant Knowledge Base to fail if the current user had a colon (`:`) in their username and attempted to access Knowledge Base entries ({kibana-pull}200131[#200131]).
 * Fixes a bug that made values unavailable for the Knowledge Base **Index** field, which lets you specify an index as a knowledge source ({kibana-pull}199990[#199990]).
 * Fixes a bug that unset the `required_fields` field if you updated a rule by sending a `PATCH` request that didn't contain the `required_fields` field ({kibana-pull}199901[#199901]).
-* Fixes an issue that prevented you from successfully importing TSV files with asset criticality data if you were on Windows ({kibana-pull}199791[#199791]).
 * Fixes the entity store initialization error that was caused by risk engine failures. Now, when you upgrade to 8.16.1, or follow the standard flow for initializing the entity store, the risk engine no longer fails while deleting the component template. In addition, the index template will correctly reference the new component template, ensuring the successful initialization of the entity store ({kibana-pull}199734[#199734]).
 * Improves the warning message that displays when asset criticality assignments are duplicated during the bulk assignment flow ({kibana-pull}199651[#199651]).
 * Fixes a time skew bug that occurred when Linux virtual machines using eBPF event probes were suspended and then resumed.


### PR DESCRIPTION
Addresses [this comment](https://github.com/elastic/security-docs/pull/6178#discussion_r1851598802) and removes 199791 from the 8.16.1 release notes.

Preview:https://security-docs_bk_6207.docs-preview.app.elstc.co/guide/en/security/master/release-notes-header-8.16.0.html