### PR TITLE
[8.x] Update .mergify.yml

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -23,7 +23,7 @@ pull_request_rules:
         assignees:
           - "{{ author }}"
         branches:
-          - "8.x"
+          - "8.17"
         title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
         labels:
           - backport


### PR DESCRIPTION
Updates `8.x` mergify backport to change `8.17` target from `8.x` to `8.17`.