### PR TITLE
[ESS][9.0] Create breaking changes and deprecations placeholder for 9.0

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,6 +3,6 @@
 
 This section summarizes the changes in each release.
 
-* <<release-notes-9.0.0, {elastic-sec} version 8.9.0>>
+* <<release-notes-9.0.0, {elastic-sec} version 9.0.0>>
 
 include::release-notes/9.0.asciidoc[]

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -1,5 +1,4 @@
 [[release-notes]]
-[chapter]
 = Release notes
 
 This section summarizes the changes in each release.

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,3 +3,7 @@
 = Release notes
 
 This section summarizes the changes in each release.
+
+* <<release-notes-9.0.0, {elastic-sec} version 8.9.0>>
+
+include::release-notes/9.0.asciidoc[]

--- a/docs/release-notes/9.0.asciidoc
+++ b/docs/release-notes/9.0.asciidoc
@@ -20,5 +20,3 @@
 [discrete]
 [[bug-fixes-9.0.0]]
 ==== Bug fixes
-
-

--- a/docs/release-notes/9.0.asciidoc
+++ b/docs/release-notes/9.0.asciidoc
@@ -12,6 +12,14 @@ coming::[9.0.0]
 ==== Known issues
 
 [discrete]
+[[breaking-changes-9.0.0]]
+==== Breaking changes
+
+[discrete]
+[[deprecations-9.0.0]]
+==== Deprecations
+
+[discrete]
 [[features-9.0.0]]
 ==== New features
 

--- a/docs/release-notes/9.0.asciidoc
+++ b/docs/release-notes/9.0.asciidoc
@@ -1,0 +1,24 @@
+[[release-notes-header-9.0.0]]
+== 9.0
+
+[discrete]
+[[release-notes-9.0.0]]
+=== 9.0.0
+
+[discrete]
+[[known-issue-9.0.0]]
+==== Known issues
+
+[discrete]
+[[features-9.0.0]]
+==== New features
+
+[discrete]
+[[enhancements-9.0.0]]
+==== Enhancements
+
+[discrete]
+[[bug-fixes-9.0.0]]
+==== Bug fixes
+
+

--- a/docs/release-notes/9.0.asciidoc
+++ b/docs/release-notes/9.0.asciidoc
@@ -1,6 +1,8 @@
 [[release-notes-header-9.0.0]]
 == 9.0
 
+coming::[9.0.0]
+
 [discrete]
 [[release-notes-9.0.0]]
 === 9.0.0


### PR DESCRIPTION
Fixes https://github.com/elastic/security-docs/issues/6039 by creating placeholder sections for the 9.0 breaking changes and deprecations. This PR also:
- Re-adds the release notes folder and creates a new page for the 9.0 release notes
- Creates placeholders for the other 9.0 release notes
- Adds a link to the 9.0 release notes from the release notes landing page  

Previews:
- [Release notes index page](https://security-docs_bk_6274.docs-preview.app.elstc.co/guide/en/security/master/release-notes.html)
- [9.0 release notes](https://security-docs_bk_6274.docs-preview.app.elstc.co/guide/en/security/master/release-notes-header-9.0.0.html)