### PR TITLE
Adds legend to LLM perf matrix

### DIFF
--- a/docs/AI-for-security/llm-performance-matrix.asciidoc
+++ b/docs/AI-for-security/llm-performance-matrix.asciidoc
@@ -14,3 +14,4 @@ This table describes the performance of various large language models (LLMs) for
 | *Attack Discovery*            | Great           |  Great                  | Excellent            | Poor               | Poor              | Great     | Poor          | Excellent           | Poor 
 |===
  
+NOTE: `Excellent` is the best rating, followed by `Great`, then by `Good`, and finally by `Poor`.

--- a/docs/serverless/AI-for-security/llm-performance-matrix.asciidoc
+++ b/docs/serverless/AI-for-security/llm-performance-matrix.asciidoc
@@ -18,3 +18,4 @@ This table describes the performance of various large language models (LLMs) for
 | *Attack Discovery*            | Great           |  Great                  | Excellent            | Poor               | Poor              | Great     | Poor          | Excellent           | Poor 
 |===
  
+NOTE: `Excellent` is the best rating, followed by `Great`, then by `Good`, and finally by `Poor`.


### PR DESCRIPTION
Fixes #6285 by adding a legend to the LLM Performance Matrix that specifies which of the possible ratings are superior to which.

Preview:[ LLM Performance matrix](https://security-docs_bk_6297.docs-preview.app.elstc.co/guide/en/security/master/llm-performance-matrix.html)