### PR TITLE
Removes alert suppression line from RN and highlights

### DIFF
--- a/docs/release-notes/8.17.asciidoc
+++ b/docs/release-notes/8.17.asciidoc
@@ -92,7 +92,6 @@ On November 12, 2024, it was discovered that manually running a custom query rul
 [[features-8.17.0]]
 ==== New features
 * Adds a signature option for trusted applications on macOS ({kibana-pull}197821[#197821]).
-* Allows you to use alert suppression on EQL sequence alerts ({kibana-pull}189725[#189725]).
 * Adds GA support for the case action feature, which lets rules automatically create cases ({kibana-pull}196973[#196973]).
 
 [discrete]

--- a/docs/whats-new.asciidoc
+++ b/docs/whats-new.asciidoc
@@ -11,19 +11,11 @@ Other versions: {security-guide-all}/8.16/whats-new.html[8.16] | {security-guide
 // tag::notable-highlights[]
 
 [float]
-== Detection rules and alerts enhancements
-
-[float]
-=== Logsdb index mode with detection rules and alerts
+== Logsdb index mode with detection rules and alerts
 
 The {ref}/logs-data-stream.html[logsdb index mode] allows you to store log data more efficiently. If you're considering using it, refer to {security-guide}/detections-logsdb-index-mode-impact.html[Using logsdb index mode with {elastic-sec}] to learn how it can impact your rules and alerts.
 
 NOTE: To use the {ref}/mapping-source-field.html#synthetic-source[synthetic `_source`] feature, you must have the appropriate subscription. Refer to the subscription page for https://www.elastic.co/subscriptions/cloud[{ecloud}] and {subscriptions}[{stack}/self-managed] for the breakdown of available features and their associated subscription tiers.
-
-[float]
-=== Suppress alerts for EQL sequence rules
-
-{security-guide}/alert-suppression.html[Alert suppression] now supports the EQL sequence rule type. You can use it to reduce the number of repeated or duplicate detection alerts generated from EQL sequence rules.
 
 [float]
 == Signature option available for macOS trusted applications conditions


### PR DESCRIPTION
Removes the line about alert suppression on EQL sequence alerts from 8.17 release notes and highlights, per [this comment](https://github.com/elastic/security-docs/pull/6224/files#r1883951350).

Previews:
* [What’s new in 8.17](https://security-docs_bk_6313.docs-preview.app.elstc.co/guide/en/security/8.x/whats-new.html)
* [8.17](https://security-docs_bk_6313.docs-preview.app.elstc.co/guide/en/security/8.x/release-notes-header-8.17.0.html)