### PR TITLE
Updates conditions for the 8.0 branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -260,6 +260,19 @@ pull_request_rules:
         title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
         labels:
           - backport
+  - name: backport patches to 8.0 branch
+    conditions:
+      - merged
+      - label=v8.0.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.0"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+        labels:
+          - backport
   - name: backport patches to 7.17 branch
     conditions:
       - merged
@@ -270,20 +283,6 @@ pull_request_rules:
           - "{{ author }}"
         branches:
           - "7.17"
-        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
-        labels:
-          - backport
-  - name: backport patches to 8.0 branch
-    conditions:
-      - merged
-      - base=main
-      - label=v8.0.0
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "8.0"
         title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
         labels:
           - backport


### PR DESCRIPTION
This PR makes two changes to our Mergify config file:
- Moves the entry for 8.0 above 7.17 so it's in the correct order
- Updates the conditions for the 8.0 branch so that the only criteria that need to be met are: PR is merged and the `v8.0.0` version label exists 