### PR TITLE
[ESS][7.17-8.15] Update `timeline-api-import.asciidoc`

### DIFF
--- a/docs/events/api/timeline-api-import.asciidoc
+++ b/docs/events/api/timeline-api-import.asciidoc
@@ -34,7 +34,7 @@ Imports the rules in the `timelines_export.ndjson` file:
 
 [source,console]
 --------------------------------------------------
-curl -X POST "api/detection_engine/rules/_import"
+curl -X POST "api/timeline/_import"
 -H 'kbn-xsrf: true' -H 'Content-Type: multipart/form-data'
 --form "file=@timelines_export.ndjson"
 --------------------------------------------------


### PR DESCRIPTION
Rebases https://github.com/elastic/security-docs/pull/6324 so it targets the 8.15 branch.