### PR TITLE
Re-adds known issues to 8.16.2 and 8.16.3 release notes

### DIFF
--- a/docs/release-notes/8.16.asciidoc
+++ b/docs/release-notes/8.16.asciidoc
@@ -6,6 +6,30 @@
 === 8.16.3
 
 [discrete]
+[[known-issue-8.16.3]]
+==== Known issues
+
+// tag::known-issue[]
+[discrete]
+.Duplicate alerts can be produced from manually running threshold rules 
+[%collapsible]
+====
+*Details* +
+On November 12, 2024, it was discovered that manually running threshold rules could produce duplicate alerts if the date range was already covered by a scheduled rule execution.
+====
+// end::known-issue[]
+
+// tag::known-issue[]
+[discrete]
+.Manually running custom query rules with suppression could suppress more alerts than expected
+[%collapsible]
+====
+*Details* +
+On November 12, 2024, it was discovered that manually running a custom query rule with suppression could incorrectly inflate the number of suppressed alerts. 
+====
+// end::known-issue[]
+
+[discrete]
 [[bug-fixes-8.16.3]]
 ==== Bug fixes
 
@@ -28,6 +52,30 @@ Affected users who are unable to upgrade should set one or both of the following
 [discrete]
 [[release-notes-8.16.2]]
 === 8.16.2
+
+[discrete]
+[[known-issue-8.16.2]]
+==== Known issues
+
+// tag::known-issue[]
+[discrete]
+.Duplicate alerts can be produced from manually running threshold rules 
+[%collapsible]
+====
+*Details* +
+On November 12, 2024, it was discovered that manually running threshold rules could produce duplicate alerts if the date range was already covered by a scheduled rule execution.
+====
+// end::known-issue[]
+
+// tag::known-issue[]
+[discrete]
+.Manually running custom query rules with suppression could suppress more alerts than expected
+[%collapsible]
+====
+*Details* +
+On November 12, 2024, it was discovered that manually running a custom query rule with suppression could incorrectly inflate the number of suppressed alerts. 
+====
+// end::known-issue[]
 
 [discrete]
 [[bug-fixes-8.16.2]]


### PR DESCRIPTION
Updates the 8.16.2 and 8.16.3 release notes to include the known issues about the manual rule run feature. 

Previews: [8.16.x release notes](https://security-docs_bk_6440.docs-preview.app.elstc.co/guide/en/security/8.x/release-notes-header-8.16.0.html)
