### PR TITLE
Fix doc indentation 8.16

### DIFF
--- a/docs/detections/prebuilt-rules/prebuilt-rules-downloadable-updates.asciidoc
+++ b/docs/detections/prebuilt-rules/prebuilt-rules-downloadable-updates.asciidoc
@@ -14,7 +14,7 @@ For previous rule updates, please navigate to the https://www.elastic.co/guide/e
 
 
 |<<prebuilt-rule-8-16-5-prebuilt-rules-8-16-5-summary, 8.16.5>> | 21 Jan 2025 | 29 | 109 | 
-This release includes new rules for Linux, Windows and AWS integration. Deprecated rules include `Deprecated - Suspicious JAVA Child Process` and `Deprecated - Potential Password Spraying of Access | ['Microsoft 365']`. New rules for Linux include detection for execution, discovery, persistence and defense evasion. New rules for Windows include detection for defense evasion. New Rules for AWS include detection for lateral movement, discovery, collection, impact and defense evasion. Additionally, significant rule tuning for Linux, Windows Crowdstrike and SentinelOne rules has been added for better rule efficacy and performance.
+This release includes new rules for Linux, Windows and AWS integration. Deprecated rules include `Deprecated - Suspicious JAVA Child Process` and `Deprecated - Potential Password Spraying of Access ['Microsoft 365']`. New rules for Linux include detection for execution, discovery, persistence and defense evasion. New rules for Windows include detection for defense evasion. New Rules for AWS include detection for lateral movement, discovery, collection, impact and defense evasion. Additionally, significant rule tuning for Linux, Windows, Crowdstrike and SentinelOne rules has been added for better rule efficacy and performance.
 
 
 |<<prebuilt-rule-8-16-4-prebuilt-rules-8-16-4-summary, 8.16.4>> | 08 Jan 2025 | 20 | 10 | 


### PR DESCRIPTION
As part of the PR https://github.com/elastic/security-docs/pull/6452 there was some indentation issues like below 

![image](https://github.com/user-attachments/assets/9eae4bfd-7545-4f83-b313-f9c7715c7c0b)

This PR fixes that issue 