### PR TITLE
Update custom dashboard docs

### DIFF
--- a/docs/dashboards/dashboards-overview.asciidoc
+++ b/docs/dashboards/dashboards-overview.asciidoc
@@ -17,8 +17,6 @@ To create a new custom dashboard, click **Create Dashboard**. You can control wh
 
 To create a new tag or edit existing tags, open the **Tags** menu and click **Manage tags**.
 
-TIP: To make a custom dashboard appear on this page, assign it the tag **Security Solution**.
-
 image::images/dashboards-landing-page.png[The dashboards landing page, 75%]
 
 Refer to documentation for the other {elastic-sec} dashboards to learn more about them. For more information about creating custom dashboards, refer to {kibana-ref}/create-a-dashboard-of-panels-with-web-server-data.html[Create your first Kibana dashboard].


### PR DESCRIPTION

Context: https://discuss.elastic.co/t/unable-to-add-tag-security-solution-in-elastic-security-serverless/373206

The default "Security Solution" tag is now a `managed` tag, so users won't be able to assign it to a dashboard.
Suggesting to remove the tips in the document to avoid confusion.

![Screenshot 2025-01-22 at 17 54 40](https://github.com/user-attachments/assets/a8682ad4-bdb7-4dd4-b03a-bb9b08127f45)
