### PR TITLE
Adds 202063 to the 8.17.1 release notes

### DIFF
--- a/docs/release-notes/8.17.asciidoc
+++ b/docs/release-notes/8.17.asciidoc
@@ -39,6 +39,7 @@ On November 12, 2024, it was discovered that manually running a custom query rul
 * Fixes a bug that caused a warning to display when you modified the index patterns of a rule that had a filter using `AND` or `OR` conditions ({kibana-pull}201776[#201776]).
 * Fixes a bug that caused the diff view to incorrectly mark certain characters as changed in specific cases ({kibana-pull}205138[#205138]).
 * Lists all policies to ensure that integrations are properly displayed ({kibana-pull}205103[#205103]).
+* Fixes an exceptions bug that prevented the **Exceptions** tab from properly loading if exceptions contained comments with newline characters (`\n`) ({kibana-pull}202063[#202063]).
 * Fixes incompatibility issues with {elastic-defend}. In 8.16.2 and 8.17.0, a portion of the Windows kernel driver was refactored to work around an incompatibility with CrowdStrike Falcon which could result in a `CRITICAL_PROCESS_DIED` bugcheck. It was discovered that this incompatibility could also be triggered by Memory Protection, so a portion of the kernel driver was refactored to avoid this conflict.
 +
 Affected users who are unable to upgrade should set one or both of the following in their {elastic-defend} advanced policy, depending on their version:
@@ -66,6 +67,8 @@ Affected users who are unable to upgrade should set one or both of the following
 On December 5, 2024, it was discovered that the **Exceptions** tab won't load properly if any exceptions contain comments with newline characters (`\n`). This issue occurs when you upgrade to 8.16.0 or later ({kibana-issue}201820[#201820]).
 
 *Workaround* + 
+
+Upgrade to 8.17.1, or follow the workarounds below.
 
 For custom rules:
 

--- a/docs/release-notes/8.17.asciidoc
+++ b/docs/release-notes/8.17.asciidoc
@@ -39,7 +39,7 @@ On November 12, 2024, it was discovered that manually running a custom query rul
 * Fixes a bug that caused a warning to display when you modified the index patterns of a rule that had a filter using `AND` or `OR` conditions ({kibana-pull}201776[#201776]).
 * Fixes a bug that caused the diff view to incorrectly mark certain characters as changed in specific cases ({kibana-pull}205138[#205138]).
 * Lists all policies to ensure that integrations are properly displayed ({kibana-pull}205103[#205103]).
-* Fixes an exceptions bug that prevented the **Exceptions** tab from properly loading if exceptions contained comments with newline characters (`\n`) ({kibana-pull}202063[#202063]).
+* Fixes a bug that prevented the **Exceptions** tab from properly loading if exceptions contained comments with newline characters (`\n`) ({kibana-pull}202063[#202063]).
 * Fixes incompatibility issues with {elastic-defend}. In 8.16.2 and 8.17.0, a portion of the Windows kernel driver was refactored to work around an incompatibility with CrowdStrike Falcon which could result in a `CRITICAL_PROCESS_DIED` bugcheck. It was discovered that this incompatibility could also be triggered by Memory Protection, so a portion of the kernel driver was refactored to avoid this conflict.
 +
 Affected users who are unable to upgrade should set one or both of the following in their {elastic-defend} advanced policy, depending on their version:


### PR DESCRIPTION
Adds 202063 to the 8.17.1 release notes and updates the known issue description in 8.17.0 release notes. Related issue: https://github.com/elastic/security-docs/issues/6275

Preview:
- [8.17.1 bug fixes](https://security-docs_bk_6475.docs-preview.app.elstc.co/guide/en/security/8.x/release-notes-header-8.17.0.html#bug-fixes-8.17.1) - See eighth list item
- [8.17.0 known issues](https://security-docs_bk_6475.docs-preview.app.elstc.co/guide/en/security/8.x/release-notes-header-8.17.0.html#known-issue-8.17.0) - Updated the workaround for the first known issue so users know they can either upgrade to 8.7.1 or use the provided workarounds.