### PR TITLE
8.17.0 known issue — D4C broken

### DIFF
--- a/docs/release-notes/8.17.asciidoc
+++ b/docs/release-notes/8.17.asciidoc
@@ -58,6 +58,13 @@ Affected users who are unable to upgrade should set one or both of the following
 [[known-issue-8.17.0]]
 ==== Known issues
 
+[discrete]
+.Defend for Containers (D4C) is broken in 8.17.0
+[%collapsible]
+====
+Defend for Containers is broken in 8.17.0. If you use it, consider updating to 8.17.1 instead.
+====
+
 // tag::known-issue[201820]
 [discrete]
 .The **Exceptions** tab won't properly load if exceptions contain comments with newline characters (`\n`)  


### PR DESCRIPTION
Fixes #6462 by adding a known issue to the 8.17.0 release notes. This branch was opened based on 8.17, and this PR proposes to merge it directly to 8.17, and we can backport it to 8.18, if I'm understanding our current setup correctly.

Preview: [8.17.0 RNs (minor addition)](https://security-docs_bk_6481.docs-preview.app.elstc.co/guide/en/security/8.17/release-notes-header-8.17.0.html)