### PR TITLE
[Main] Update .mergify.yml

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -25,8 +25,21 @@ pull_request_rules:
           - "backport"
         branches:
           - "main"
-        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})" 
   - name: backport patches to 8.x branch
+    conditions:
+      - merged
+      - label=v8.19.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.x"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+        labels:
+          - backport
+  - name: backport patches to 8.18 branch
     conditions:
       - merged
       - label=v8.18.0
@@ -35,7 +48,7 @@ pull_request_rules:
         assignees:
           - "{{ author }}"
         branches:
-          - "8.x"
+          - "8.18"
         title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
         labels:
           - backport


### PR DESCRIPTION
Per typical protocol, adds `8.18` and points `8.x` backports to `8.19` branch.