### PR TITLE
[Known Issue][8.17.0 & 8.17.1]: Elastic Security crashes in ECH on Kibana instances with 1 GB of RAM

### DIFF
--- a/docs/release-notes/8.17.asciidoc
+++ b/docs/release-notes/8.17.asciidoc
@@ -11,6 +11,22 @@
 
 // tag::known-issue[]
 [discrete]
+.{elastic-sec} crashes on {kib} instances with 1 GB of RAM 
+[%collapsible]
+====
+*Details* +
+Whenever you open a page in {elastic-sec}, there's an attempt to install the {fleet} package with prebuilt rules. If the package hasn't been installed yet, {kib} starts downloading the latest version of it, then crashes with an `Out Of Memory` error. The process will then automatically restart and crash for the same reasons.
+
+This issue was discovered on February 6, 2025.
+
+*Workaround* +
+To resolve this issue, increase {kib}'s RAM to 2 GB.
+
+====
+// end::known-issue[]
+
+// tag::known-issue[]
+[discrete]
 .Duplicate alerts can be produced from manually running threshold rules 
 [%collapsible]
 ====
@@ -57,6 +73,22 @@ Affected users who are unable to upgrade should set one or both of the following
 [discrete]
 [[known-issue-8.17.0]]
 ==== Known issues
+
+// tag::known-issue[]
+[discrete]
+.{elastic-sec} crashes on {kib} instances with 1 GB of RAM 
+[%collapsible]
+====
+*Details* +
+Whenever you open a page in {elastic-sec}, there's an attempt to install the {fleet} package with prebuilt rules. If the package hasn't been installed yet, {kib} starts downloading the latest version of it, then crashes with an `Out Of Memory` error. The process will then automatically restart and crash for the same reasons.
+
+This issue was discovered on February 6, 2025.
+
+*Workaround* +
+To resolve this issue, increase {kib}'s RAM to 2 GB.
+
+====
+// end::known-issue[]
 
 [discrete]
 .Defend for Containers (D4C) is broken in 8.17.0

--- a/docs/release-notes/8.17.asciidoc
+++ b/docs/release-notes/8.17.asciidoc
@@ -11,7 +11,7 @@
 
 // tag::known-issue[]
 [discrete]
-.{elastic-sec} crashes on {kib} instances with 1 GB of RAM 
+.{elastic-sec} crashes on {kib} instances with 1 GB of RAM in {ecloud} deployments
 [%collapsible]
 ====
 *Details* +

--- a/docs/release-notes/8.17.asciidoc
+++ b/docs/release-notes/8.17.asciidoc
@@ -11,7 +11,7 @@
 
 // tag::known-issue[]
 [discrete]
-.{elastic-sec} crashes on {kib} instances with 1 GB of RAM in {ecloud} deployments
+.{elastic-sec} crashes on {kib} instances with 1 GB of RAM on {ecloud} deployments
 [%collapsible]
 ====
 *Details* +
@@ -76,7 +76,7 @@ Affected users who are unable to upgrade should set one or both of the following
 
 // tag::known-issue[]
 [discrete]
-.{elastic-sec} crashes on {kib} instances with 1 GB of RAM 
+.{elastic-sec} crashes on {kib} instances with 1 GB of RAM on {ecloud} deployments
 [%collapsible]
 ====
 *Details* +


### PR DESCRIPTION
Fixes https://github.com/elastic/docs-content/issues/360

Previews:
- [8.17.0 known issues](https://security-docs_bk_6512.docs-preview.app.elstc.co/guide/en/security/8.x/release-notes-header-8.17.0.html#known-issue-8.17.0)
- [8.17.1 known issues](https://security-docs_bk_6512.docs-preview.app.elstc.co/guide/en/security/8.x/release-notes-header-8.17.0.html#known-issue-8.17.1)