### PR TITLE
[8.17] Existing logsdb impact note needs clarification to avoid confusion

### DIFF
--- a/docs/detections/detections-logsdb-impact.asciidoc
+++ b/docs/detections/detections-logsdb-impact.asciidoc
@@ -11,7 +11,7 @@ When the `_source` is reconstructed, {ref}/mapping-source-field.html#synthetic-s
 
 Continue reading to find out how this affects specific {elastic-sec} components. 
 
-NOTE: Logsdb is not recommended for {elastic-sec} at this time. Users must fully understand and accept the documented changes to detection alert documents (see below), and ensure their deployment has excess hot data tier CPU resource capacity before enabling logsdb mode, as logsdb mode requires additional CPU resources during the ingest/indexing process. Enabling logsdb without sufficient hot data tier CPU may result in data ingestion backups and/or security detection rule timeouts and errors.
+NOTE: Logsdb index mode is fully supported, and is recommended for new {elastic-sec} deployments. Logsdb is not recommended for existing {elastic-sec} deployments unless users fully understand and accept the documented changes to detection alert documents (see below), and ensure that their deployment has sufficient excess hot data tier CPU  capacity to support the Logsdb ingest and indexing process. Enabling logsdb index mode without sufficient excess hot data tier CPU capacity may result in data ingestion backups and or security detection rule timeouts and errors.
 
 [discrete]
 [[logsdb-alerts]]


### PR DESCRIPTION
Partially addresses https://github.com/elastic/security-docs/issues/6518 by updating the ESS dcos

Preview: Using logsdb index mode with Elastic Security