### PR TITLE
7.17.28 release notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.17.28, {elastic-sec} version 7.17.28>>
 * <<release-notes-7.17.27, {elastic-sec} version 7.17.27>>
 * <<release-notes-7.17.26, {elastic-sec} version 7.17.26>>
 * <<release-notes-7.17.25, {elastic-sec} version 7.17.25>>

--- a/docs/release-notes/7.17.asciidoc
+++ b/docs/release-notes/7.17.asciidoc
@@ -9,6 +9,7 @@
 [[bug-fixes-7.17.28]]
 ==== Bug fixes
 * Fixes a bug that prevented {defend} from correctly populating the `event.created` field for process events on Windows.
+* Fixes a bug that prevented {defend} from installing on SUSE Linux Enterprise Server (SLES) 15.6.
 
 [discrete]
 [[release-notes-7.17.27]]

--- a/docs/release-notes/7.17.asciidoc
+++ b/docs/release-notes/7.17.asciidoc
@@ -2,6 +2,15 @@
 == 7.17
 
 [discrete]
+[[release-notes-7.17.28]]
+=== 7.17.28
+
+[discrete]
+[[bug-fixes-7.17.28]]
+==== Bug fixes
+* Fixes a bug that prevented {defend} from correctly populating the `event.created` field for process events on Windows.
+
+[discrete]
 [[release-notes-7.17.27]]
 === 7.17.27
 

--- a/docs/release-notes/7.17.asciidoc
+++ b/docs/release-notes/7.17.asciidoc
@@ -8,8 +8,8 @@
 [discrete]
 [[bug-fixes-7.17.28]]
 ==== Bug fixes
-* Fixes a bug that prevented {defend} from correctly populating the `event.created` field for process events on Windows.
-* Fixes a bug that prevented {defend} from installing on SUSE Linux Enterprise Server (SLES) 15.6.
+* Fixes a bug that prevented {elastic-defend} from correctly populating the `event.created` field for process events on Windows.
+* Fixes a bug that prevented {elastic-defend} from installing on SUSE Linux Enterprise Server (SLES) 15.6.
 
 [discrete]
 [[release-notes-7.17.27]]


### PR DESCRIPTION
Writes the 7.17.28 release notes 

Preview: [7.17.28 release notes](https://security-docs_bk_6540.docs-preview.app.elstc.co/guide/en/security/7.17/release-notes-header-7.17.0.html#release-notes-7.17.28) 
