### PR TITLE
Doc incompatibility between agentless integration and traffic filtering

### DIFF
--- a/docs/cloud-native-security/cspm-get-started-aws.asciidoc
+++ b/docs/cloud-native-security/cspm-get-started-aws.asciidoc
@@ -42,6 +42,8 @@ NOTE: If you don't want to monitor every account in your organization, specify w
 .. Option 2: Temporary keys. To authenticate using temporary keys, refer to the instructions for <<cspm-use-temp-credentials, temporary keys>>.  
 . Once you've selected an authentication method and provided all necessary credentials, click **Save and continue** to finish deployment. Your data should start to appear within a few minutes.
 
+IMPORTANT: Agentless deployment does not work if you are using {cloud}/ec-traffic-filtering-deployment-configuration.html[Traffic filtering].
+
 [discrete]
 [[cspm-aws-agent-based]]
 == Agent-based deployment 

--- a/docs/cloud-native-security/cspm-get-started-azure.asciidoc
+++ b/docs/cloud-native-security/cspm-get-started-azure.asciidoc
@@ -37,6 +37,8 @@ beta::[]
 . Next, you'll need to authenticate to Azure by providing a **Client ID**, **Tenant ID**, and **Client Secret**. To learn how to generate them, refer to <<cspm-azure-client-secret, Service principal with client secret>>.
 . Once you've provided the necessary credentials, click **Save and continue** to finish deployment. Your data should start to appear within a few minutes.
 
+IMPORTANT: Agentless deployment does not work if you are using {cloud}/ec-traffic-filtering-deployment-configuration.html[Traffic filtering].
+
 [discrete]
 [[cspm-azure-agent-based]]
 == Agent-based deployment 

--- a/docs/cloud-native-security/cspm-get-started-gcp.asciidoc
+++ b/docs/cloud-native-security/cspm-get-started-gcp.asciidoc
@@ -37,6 +37,7 @@ beta::[]
 . Next, you'll need to authenticate to GCP. Expand the **Steps to Generate GCP Account Credentials** section, then follow the instructions that appear to automatically create the necessary credentials using Google Cloud Shell.
 . Once you've provided the necessary credentials, click **Save and continue** to finish deployment. Your data should start to appear within a few minutes.
 
+IMPORTANT: Agentless deployment does not work if you are using {cloud}/ec-traffic-filtering-deployment-configuration.html[Traffic filtering].
 
 [discrete]
 [[cspm-gcp-agent-based]]

--- a/docs/getting-started/agentless-troubleshooting.asciidoc
+++ b/docs/getting-started/agentless-troubleshooting.asciidoc
@@ -27,20 +27,20 @@ On the **{fleet}** page, the agent associated with an agentless integration has 
 
 * Confirm that you entered the correct credentials for the cloud provider you're monitoring. The following is an example of an error log resulting from using incorrect AWS credentials:
 + 
-```
+`
 [elastic_agent.cloudbeat][error] Failed to update registry: failed to get AWS accounts: operation error Organizations: ListAccounts, get identity: get credentials: failed to refresh cached credentials, operation error STS: AssumeRole, https response error StatusCode: 403, RequestID: XXX, api error AccessDenied: User: XXX is not authorized to perform: sts:AssumeRole on resource:XXX
-```
+`
 
 For instructions on checking {{fleet}} logs, refer to {fleet-guide}/fleet-troubleshooting.html[{fleet} troubleshooting]. 
 
 [discrete]
 == What does it mean if no agents appear in my integration policy?
 
-Your agentless integration policy won't display any enrolled agents if you are using traffic filtering. Agentless integrations do not work in environments with {cloud}/ec-traffic-filtering-deployment-configuration.html[Traffic filtering]. You can confirm whether this is the problem by checking your agent logs for the following error: 
+Your agentless integration policy won't have any enrolled agents if you are using traffic filtering, because agentless integrations do not work in environments with {cloud}/ec-traffic-filtering-deployment-configuration.html[Traffic filtering]. You can confirm whether this is the case by checking your agent logs for the following error: 
 
-```
+`
 Error: fail to enroll: fail to execute request to fleet-server: status code: 0, fleet-server returned an error: , message: Forbidden due to traffic filtering. Please see the Elastic documentation on Traffic Filtering for more information.
-```
+`
 
 [discrete]
 == How do I delete an agentless integration?

--- a/docs/getting-started/agentless-troubleshooting.asciidoc
+++ b/docs/getting-started/agentless-troubleshooting.asciidoc
@@ -31,7 +31,7 @@ On the **{fleet}** page, the agent associated with an agentless integration has 
 [elastic_agent.cloudbeat][error] Failed to update registry: failed to get AWS accounts: operation error Organizations: ListAccounts, get identity: get credentials: failed to refresh cached credentials, operation error STS: AssumeRole, https response error StatusCode: 403, RequestID: XXX, api error AccessDenied: User: XXX is not authorized to perform: sts:AssumeRole on resource:XXX
 ```
 
-For instructions on checking {{fleet}} logs, refer to {fleet-guide}/fleet-troubleshooting.html[{fleet} troubleshooting]. 
+For instructions on checking {fleet} logs, refer to {fleet-guide}/fleet-troubleshooting.html[{fleet} troubleshooting]. 
 
 [discrete]
 == What does it mean if no agents appear in my integration policy?

--- a/docs/getting-started/agentless-troubleshooting.asciidoc
+++ b/docs/getting-started/agentless-troubleshooting.asciidoc
@@ -36,11 +36,7 @@ For instructions on checking {{fleet}} logs, refer to {fleet-guide}/fleet-troubl
 [discrete]
 == What does it mean if no agents appear in my integration policy?
 
-Your agentless integration policy won't have any enrolled agents if you are using traffic filtering, because agentless integrations do not work in environments with {cloud}/ec-traffic-filtering-deployment-configuration.html[Traffic filtering]. You can confirm whether this is the case by checking your agent logs for the following error: 
-
-`
-Error: fail to enroll: fail to execute request to fleet-server: status code: 0, fleet-server returned an error: , message: Forbidden due to traffic filtering. Please see the Elastic documentation on Traffic Filtering for more information.
-`
+Your agentless integration policy won't have any enrolled agents if you are using traffic filtering, because agentless integrations do not work in environments with {cloud}/ec-traffic-filtering-deployment-configuration.html[Traffic filtering]. 
 
 [discrete]
 == How do I delete an agentless integration?

--- a/docs/getting-started/agentless-troubleshooting.asciidoc
+++ b/docs/getting-started/agentless-troubleshooting.asciidoc
@@ -37,7 +37,7 @@ For instructions on checking {{fleet}} logs, refer to {fleet-guide}/fleet-troubl
 == What does it mean if no agents appear in my integration policy?
 
 Your agentless integration policy won't display any enrolled agents if you are using traffic filtering. Agentless integrations do not work in environments with {cloud}/ec-traffic-filtering-deployment-configuration.html[Traffic filtering]. You can confirm whether this is the problem by checking your agent logs for the following error: 
-+
+
 ```
 Error: fail to enroll: fail to execute request to fleet-server: status code: 0, fleet-server returned an error: , message: Forbidden due to traffic filtering. Please see the Elastic documentation on Traffic Filtering for more information.
 ```

--- a/docs/getting-started/agentless-troubleshooting.asciidoc
+++ b/docs/getting-started/agentless-troubleshooting.asciidoc
@@ -34,6 +34,15 @@ On the **{fleet}** page, the agent associated with an agentless integration has 
 For instructions on checking {{fleet}} logs, refer to {fleet-guide}/fleet-troubleshooting.html[{fleet} troubleshooting]. 
 
 [discrete]
+== What does it mean if no agents appear in my integration policy?
+
+Your agentless integration policy won't display any enrolled agents if you are using traffic filtering. Agentless integrations do not work in environments with {cloud}/ec-traffic-filtering-deployment-configuration.html[Traffic filtering]. You can confirm whether this is the problem by checking your agent logs for the following error: 
++
+```
+Error: fail to enroll: fail to execute request to fleet-server: status code: 0, fleet-server returned an error: , message: Forbidden due to traffic filtering. Please see the Elastic documentation on Traffic Filtering for more information.
+```
+
+[discrete]
 == How do I delete an agentless integration?
 
 NOTE: Deleting your integration will remove all associated resources and stop data ingestion.

--- a/docs/getting-started/agentless-troubleshooting.asciidoc
+++ b/docs/getting-started/agentless-troubleshooting.asciidoc
@@ -27,9 +27,9 @@ On the **{fleet}** page, the agent associated with an agentless integration has 
 
 * Confirm that you entered the correct credentials for the cloud provider you're monitoring. The following is an example of an error log resulting from using incorrect AWS credentials:
 + 
-`
+```
 [elastic_agent.cloudbeat][error] Failed to update registry: failed to get AWS accounts: operation error Organizations: ListAccounts, get identity: get credentials: failed to refresh cached credentials, operation error STS: AssumeRole, https response error StatusCode: 403, RequestID: XXX, api error AccessDenied: User: XXX is not authorized to perform: sts:AssumeRole on resource:XXX
-`
+```
 
 For instructions on checking {{fleet}} logs, refer to {fleet-guide}/fleet-troubleshooting.html[{fleet} troubleshooting]. 
 

--- a/docs/getting-started/index.asciidoc
+++ b/docs/getting-started/index.asciidoc
@@ -14,7 +14,7 @@ include::ingest-data.asciidoc[leveloffset=+1]
 include::threat-intel-integrations.asciidoc[leveloffset=+2]
 include::automatic-import.asciidoc[leveloffset=+2]
 include::agentless-integrations.asciidoc[leveloffset=+2]
-include::agentless-troubleshooting.asciidoc[leveloffset=+3]
+include::agentless-troubleshooting.asciidoc[leveloffset=+2]
 
 include::security-spaces.asciidoc[leveloffset=+1]
 


### PR DESCRIPTION
Fixes #[500](https://github.com/elastic/docs-content/issues/500)

Updates the agentless intergation FAQ and the CSPM getting started guides for AWS, Azure, and GCP, to inform users that agentless integrations don't work in environments where traffic filtering is present.

Previews: [Agentless FAQ](https://security-docs_bk_6549.docs-preview.app.elstc.co/guide/en/security/current/agentless-integration-troubleshooting.html) (new FAQ item)
[Get started with CSPM for AWS](https://security-docs_bk_6549.docs-preview.app.elstc.co/guide/en/security/current/cspm-get-started.html#cspm-aws-agentless) (new note at the end of the agentless deployment section — changes to Azure and GCP guides are identical)