### PR TITLE
[docs] Clean up cross-repo links

### DIFF
--- a/docs/reference/prebuilt-jobs.md
+++ b/docs/reference/prebuilt-jobs.md
@@ -12,7 +12,7 @@ These {{anomaly-jobs}} automatically detect file system and network anomalies on
 
 Detect anomalous activity in your ECS-compatible authentication logs.
 
-In the {{ml-app}} app, these configurations are available only when data exists that matches the query specified in the [manifest file](https://github.com/elastic/kibana/blob/master/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/manifest.json). In the {{security-app}}, it looks in the {{data-source}} specified in the [`securitySolution:defaultIndex` advanced setting](kibana://docs/reference/advanced-settings.md#securitysolution-defaultindex) for data that matches the query.
+In the {{ml-app}} app, these configurations are available only when data exists that matches the query specified in the [manifest file](https://github.com/elastic/kibana/blob/master/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/manifest.json). In the {{security-app}}, it looks in the {{data-source}} specified in the [`securitySolution:defaultIndex` advanced setting](kibana://reference/advanced-settings.md#securitysolution-defaultindex) for data that matches the query.
 
 By default, when you create these job in the {{security-app}}, it uses a {{data-source}} that applies to multiple indices. To get the same results if you use the {{ml-app}} app, create a similar [{{data-source}}](https://github.com/elastic/kibana/blob/master/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/manifest.json#L7) then select it in the job wizard.
 
@@ -31,7 +31,7 @@ By default, when you create these job in the {{security-app}}, it uses a {{data-
 
 Detect suspicious activity recorded in your CloudTrail logs.
 
-In the {{ml-app}} app, these configurations are available only when data exists that matches the query specified in the [manifest file](https://github.com/elastic/kibana/blob/master/x-pack/plugins/ml/server/models/data_recognizer/modules/security_cloudtrail/manifest.json). In the {{security-app}}, it looks in the {{data-source}} specified in the [`securitySolution:defaultIndex` advanced setting](kibana://docs/reference/advanced-settings.md#securitysolution-defaultindex) for data that matches the query.
+In the {{ml-app}} app, these configurations are available only when data exists that matches the query specified in the [manifest file](https://github.com/elastic/kibana/blob/master/x-pack/plugins/ml/server/models/data_recognizer/modules/security_cloudtrail/manifest.json). In the {{security-app}}, it looks in the {{data-source}} specified in the [`securitySolution:defaultIndex` advanced setting](kibana://reference/advanced-settings.md#securitysolution-defaultindex) for data that matches the query.
 
 | Name | Description | Job | Datafeed |
 | --- | --- | --- | --- |
@@ -46,7 +46,7 @@ In the {{ml-app}} app, these configurations are available only when data exists 
 
 Anomaly detection jobs for host-based threat hunting and detection.
 
-In the {{ml-app}} app, these configurations are available only when data exists that matches the query specified in the [manifest file](https://github.com/elastic/kibana/blob/master/x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security_host/manifest.json). In the {{security-app}}, it looks in the {{data-source}} specified in the [`securitySolution:defaultIndex` advanced setting](kibana://docs/reference/advanced-settings.md#securitysolution-defaultindex) for data that matches the query.
+In the {{ml-app}} app, these configurations are available only when data exists that matches the query specified in the [manifest file](https://github.com/elastic/kibana/blob/master/x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security_host/manifest.json). In the {{security-app}}, it looks in the {{data-source}} specified in the [`securitySolution:defaultIndex` advanced setting](kibana://reference/advanced-settings.md#securitysolution-defaultindex) for data that matches the query.
 
 To access the host traffic anomalies dashboard in Kibana, go to: `Security -> Dashboards -> Host Traffic Anomalies`.
 
@@ -60,7 +60,7 @@ To access the host traffic anomalies dashboard in Kibana, go to: `Security -> Da
 
 Anomaly detection jobs for Linux host-based threat hunting and detection.
 
-In the {{ml-app}} app, these configurations are available only when data exists that matches the query specified in the [manifest file](https://github.com/elastic/kibana/blob/master/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/manifest.json). In the {{security-app}}, it looks in the {{data-source}} specified in the [`securitySolution:defaultIndex` advanced setting](kibana://docs/reference/advanced-settings.md#securitysolution-defaultindex) for data that matches the query.
+In the {{ml-app}} app, these configurations are available only when data exists that matches the query specified in the [manifest file](https://github.com/elastic/kibana/blob/master/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/manifest.json). In the {{security-app}}, it looks in the {{data-source}} specified in the [`securitySolution:defaultIndex` advanced setting](kibana://reference/advanced-settings.md#securitysolution-defaultindex) for data that matches the query.
 
 | Name | Description | Job | Datafeed |
 | --- | --- | --- | --- |
@@ -84,7 +84,7 @@ In the {{ml-app}} app, these configurations are available only when data exists 
 
 Detect anomalous network activity in your ECS-compatible network logs.
 
-In the {{ml-app}} app, these configurations are available only when data exists that matches the query specified in the [manifest file](https://github.com/elastic/kibana/blob/master/x-pack/plugins/ml/server/models/data_recognizer/modules/security_network/manifest.json). In the {{security-app}}, it looks in the {{data-source}} specified in the [`securitySolution:defaultIndex` advanced setting](kibana://docs/reference/advanced-settings.md#securitysolution-defaultindex) for data that matches the query.
+In the {{ml-app}} app, these configurations are available only when data exists that matches the query specified in the [manifest file](https://github.com/elastic/kibana/blob/master/x-pack/plugins/ml/server/models/data_recognizer/modules/security_network/manifest.json). In the {{security-app}}, it looks in the {{data-source}} specified in the [`securitySolution:defaultIndex` advanced setting](kibana://reference/advanced-settings.md#securitysolution-defaultindex) for data that matches the query.
 
 By default, when you create these jobs in the {{security-app}}, it uses a {{data-source}} that applies to multiple indices. To get the same results if you use the {{ml-app}} app, create a similar [{{data-source}}](https://github.com/elastic/kibana/blob/master/x-pack/plugins/ml/server/models/data_recognizer/modules/security_network/manifest.json#L7) then select it in the job wizard.
 
@@ -100,7 +100,7 @@ By default, when you create these jobs in the {{security-app}}, it uses a {{data
 
 Detect suspicious network activity in {{packetbeat}} data.
 
-In the {{ml-app}} app, these configurations are available only when data exists that matches the query specified in the [manifest file](https://github.com/elastic/kibana/blob/master/x-pack/plugins/ml/server/models/data_recognizer/modules/security_packetbeat/manifest.json). In the {{security-app}}, it looks in the {{data-source}} specified in the [`securitySolution:defaultIndex` advanced setting](kibana://docs/reference/advanced-settings.md#securitysolution-defaultindex) for data that matches the query.
+In the {{ml-app}} app, these configurations are available only when data exists that matches the query specified in the [manifest file](https://github.com/elastic/kibana/blob/master/x-pack/plugins/ml/server/models/data_recognizer/modules/security_packetbeat/manifest.json). In the {{security-app}}, it looks in the {{data-source}} specified in the [`securitySolution:defaultIndex` advanced setting](kibana://reference/advanced-settings.md#securitysolution-defaultindex) for data that matches the query.
 
 | Name | Description | Job | Datafeed |
 | --- | --- | --- | --- |
@@ -115,7 +115,7 @@ In the {{ml-app}} app, these configurations are available only when data exists 
 
 Anomaly detection jobs for Windows host-based threat hunting and detection.
 
-In the {{ml-app}} app, these configurations are available only when data exists that matches the query specified in the [manifest file](https://github.com/elastic/kibana/blob/master/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/manifest.json). In the {{security-app}}, it looks in the {{data-source}} specified in the [`securitySolution:defaultIndex` advanced setting](kibana://docs/reference/advanced-settings.md#securitysolution-defaultindex) for data that matches the query.
+In the {{ml-app}} app, these configurations are available only when data exists that matches the query specified in the [manifest file](https://github.com/elastic/kibana/blob/master/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/manifest.json). In the {{security-app}}, it looks in the {{data-source}} specified in the [`securitySolution:defaultIndex` advanced setting](kibana://reference/advanced-settings.md#securitysolution-defaultindex) for data that matches the query.
 
 If there are additional requirements such as installing the Windows System Monitor (Sysmon) or auditing process creation in the Windows security event log, they are listed for each job.
 
@@ -137,20 +137,20 @@ If there are additional requirements such as installing the Windows System Monit
 
 ## Security: Elastic Integrations [security-integrations-jobs]
 
-[Elastic Integrations](integration-docs://docs/reference/index.md) are a streamlined way to add Elastic assets to your environment, such as data ingestion, {{transforms}}, and in this case, {{ml}} capabilities for Security.
+[Elastic Integrations](integration-docs://reference/index.md) are a streamlined way to add Elastic assets to your environment, such as data ingestion, {{transforms}}, and in this case, {{ml}} capabilities for Security.
 
 The following Integrations use {{ml}} to analyze patterns of user and entity behavior, and help detect and alert when there is related suspicious activity in your environment.
 
-* [Data Exfiltration Detection](integration-docs://docs/reference/ded.md)
-* [Domain Generation Algorithm Detection](integration-docs://docs/reference/dga.md)
-* [Lateral Movement Detection](integration-docs://docs/reference/lmd.md)
-* [Living off the Land Attack Detection](integration-docs://docs/reference/problemchild.md)
+* [Data Exfiltration Detection](integration-docs://reference/ded.md)
+* [Domain Generation Algorithm Detection](integration-docs://reference/dga.md)
+* [Lateral Movement Detection](integration-docs://reference/lmd.md)
+* [Living off the Land Attack Detection](integration-docs://reference/problemchild.md)
 
 **Domain Generation Algorithm (DGA) Detection**
 
 {{ml-cap}} solution package to detect domain generation algorithm (DGA) activity in your network data. Refer to the [subscription page](https://www.elastic.co/subscriptions) to learn more about the required subscription.
 
-To download, refer to the [documentation](integration-docs://docs/reference/dga.md).
+To download, refer to the [documentation](integration-docs://reference/dga.md).
 
 | Name | Description |
 | --- | --- |
@@ -162,7 +162,7 @@ The job configurations and datafeeds can be found [here](https://github.com/elas
 
 {{ml-cap}} solution package to detect Living off the Land (LotL) attacks in your environment. Refer to the [subscription page](https://www.elastic.co/subscriptions) to learn more about the required subscription. (Also known as ProblemChild).
 
-To download, refer to the [documentation](integration-docs://docs/reference/problemchild.md).
+To download, refer to the [documentation](integration-docs://reference/problemchild.md).
 
 | Name | Description |
 | --- | --- |
@@ -179,7 +179,7 @@ The job configurations and datafeeds can be found [here](https://github.com/elas
 
 {{ml-cap}} package to detect data exfiltration in your network and file data. Refer to the [subscription page](https://www.elastic.co/subscriptions) to learn more about the required subscription.
 
-To download, refer to the [documentation](integration-docs://docs/reference/ded.md).
+To download, refer to the [documentation](integration-docs://reference/ded.md).
 
 | Name | Description |
 | --- | --- |
@@ -197,7 +197,7 @@ The job configurations and datafeeds can be found [here](https://github.com/elas
 
 {{ml-cap}} package to detect lateral movement based on file transfer activity and Windows RDP events. Refer to the [subscription page](https://www.elastic.co/subscriptions) to learn more about the required subscription.
 
-To download, refer to the [documentation](integration-docs://docs/reference/lmd.md).
+To download, refer to the [documentation](integration-docs://reference/lmd.md).
 
 | Name | Description |
 | --- | --- |

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-0-13-3-default-cobalt-strike-team-server-certificate.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-0-13-3-default-cobalt-strike-team-server-certificate.md
@@ -30,7 +30,7 @@ This rule detects the use of the default Cobalt Strike Team Server TLS certifica
 
 * [https://attack.mitre.org/software/S0154/](https://attack.mitre.org/software/S0154/)
 * [https://www.cobaltstrike.com/help-setup-collaboration](https://www.cobaltstrike.com/help-setup-collaboration)
-* [/beats/docs/reference/ingestion-tools/beats-packetbeat/configuration-tls.md](beats://docs/reference/packetbeat/configuration-tls.md)
+* [/beats/docs/reference/ingestion-tools/beats-packetbeat/configuration-tls.md](beats://reference/packetbeat/configuration-tls.md)
 * [https://www.elastic.co/guide/en/beats/filebeat/7.9/filebeat-module-suricata.html](https://www.elastic.co/guide/en/beats/filebeat/7.9/filebeat-module-suricata.html)
 * [https://www.elastic.co/guide/en/beats/filebeat/7.9/filebeat-module-zeek.html](https://www.elastic.co/guide/en/beats/filebeat/7.9/filebeat-module-zeek.html)
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-0-13-3-inbound-connection-to-an-unsecure-elasticsearch-node.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-0-13-3-inbound-connection-to-an-unsecure-elasticsearch-node.md
@@ -29,7 +29,7 @@ Identifies Elasticsearch nodes that do not have Transport Layer Security (TLS), 
 **References**:
 
 * [docs-content://deploy-manage/deploy/self-managed/installing-elasticsearch.md](docs-content://deploy-manage/deploy/self-managed/installing-elasticsearch.md)
-* [/beats/docs/reference/ingestion-tools/beats-packetbeat/packetbeat-http-options.md#_send_all_headers](beats://docs/reference/packetbeat/packetbeat-http-options.md#_send_all_headers)
+* [/beats/docs/reference/ingestion-tools/beats-packetbeat/packetbeat-http-options.md#_send_all_headers](beats://reference/packetbeat/packetbeat-http-options.md#_send_all_headers)
 
 **Tags**:
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-0-14-1-default-cobalt-strike-team-server-certificate.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-0-14-1-default-cobalt-strike-team-server-certificate.md
@@ -30,7 +30,7 @@ This rule detects the use of the default Cobalt Strike Team Server TLS certifica
 
 * [https://attack.mitre.org/software/S0154/](https://attack.mitre.org/software/S0154/)
 * [https://www.cobaltstrike.com/help-setup-collaboration](https://www.cobaltstrike.com/help-setup-collaboration)
-* [/beats/docs/reference/ingestion-tools/beats-packetbeat/configuration-tls.md](beats://docs/reference/packetbeat/configuration-tls.md)
+* [/beats/docs/reference/ingestion-tools/beats-packetbeat/configuration-tls.md](beats://reference/packetbeat/configuration-tls.md)
 * [https://www.elastic.co/guide/en/beats/filebeat/7.9/filebeat-module-suricata.html](https://www.elastic.co/guide/en/beats/filebeat/7.9/filebeat-module-suricata.html)
 * [https://www.elastic.co/guide/en/beats/filebeat/7.9/filebeat-module-zeek.html](https://www.elastic.co/guide/en/beats/filebeat/7.9/filebeat-module-zeek.html)
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-0-14-2-threat-intel-filebeat-module-indicator-match.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-0-14-2-threat-intel-filebeat-module-indicator-match.md
@@ -30,7 +30,7 @@ This rule is triggered when indicators from the Threat Intel Filebeat module has
 
 **References**:
 
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://docs/reference/filebeat/filebeat-module-threatintel.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://reference/filebeat/filebeat-module-threatintel.md)
 
 **Tags**:
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-0-14-3-hosts-file-modified.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-0-14-3-hosts-file-modified.md
@@ -28,7 +28,7 @@ The hosts file on endpoints is used to control manual IP address to hostname res
 
 **References**:
 
-* [/beats/docs/reference/ingestion-tools/beats-auditbeat/auditbeat-reference-yml.md](beats://docs/reference/auditbeat/auditbeat-reference-yml.md)
+* [/beats/docs/reference/ingestion-tools/beats-auditbeat/auditbeat-reference-yml.md](beats://reference/auditbeat/auditbeat-reference-yml.md)
 
 **Tags**:
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-0-14-3-threat-intel-filebeat-module-v7-x-indicator-match.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-0-14-3-threat-intel-filebeat-module-v7-x-indicator-match.md
@@ -30,7 +30,7 @@ This rule is triggered when indicators from the Threat Intel Filebeat module (v7
 
 **References**:
 
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://docs/reference/filebeat/filebeat-module-threatintel.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://reference/filebeat/filebeat-module-threatintel.md)
 
 **Tags**:
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-1-0-2-hosts-file-modified.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-1-0-2-hosts-file-modified.md
@@ -28,7 +28,7 @@ The hosts file on endpoints is used to control manual IP-address-to-hostname res
 
 **References**:
 
-* [/beats/docs/reference/ingestion-tools/beats-auditbeat/auditbeat-reference-yml.md](beats://docs/reference/auditbeat/auditbeat-reference-yml.md)
+* [/beats/docs/reference/ingestion-tools/beats-auditbeat/auditbeat-reference-yml.md](beats://reference/auditbeat/auditbeat-reference-yml.md)
 
 **Tags**:
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-1-0-2-threat-intel-filebeat-module-v8-x-indicator-match.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-1-0-2-threat-intel-filebeat-module-v8-x-indicator-match.md
@@ -30,7 +30,7 @@ This rule is triggered when indicators from the Threat Intel Filebeat module (v8
 
 **References**:
 
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://docs/reference/filebeat/filebeat-module-threatintel.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://reference/filebeat/filebeat-module-threatintel.md)
 
 **Tags**:
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-1-0-2-threat-intel-indicator-match.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-1-0-2-threat-intel-indicator-match.md
@@ -30,7 +30,7 @@ This rule is triggered when indicators from the Threat Intel integrations have a
 
 **References**:
 
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://docs/reference/filebeat/filebeat-module-threatintel.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://reference/filebeat/filebeat-module-threatintel.md)
 
 **Tags**:
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-1-1-hosts-file-modified.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-1-1-hosts-file-modified.md
@@ -28,7 +28,7 @@ The hosts file on endpoints is used to control manual IP address to hostname res
 
 **References**:
 
-* [/beats/docs/reference/ingestion-tools/beats-auditbeat/auditbeat-reference-yml.md](beats://docs/reference/auditbeat/auditbeat-reference-yml.md)
+* [/beats/docs/reference/ingestion-tools/beats-auditbeat/auditbeat-reference-yml.md](beats://reference/auditbeat/auditbeat-reference-yml.md)
 
 **Tags**:
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-2-login-via-unusual-system-user.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-2-login-via-unusual-system-user.md
@@ -59,17 +59,17 @@ Filebeat is a lightweight shipper for forwarding and centralizing log data. Inst
 **The following steps should be executed in order to add the Filebeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/filebeat/setup-repositories.md).
-* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-docker.md).
-* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-kubernetes.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/filebeat/setup-repositories.md).
+* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-docker.md).
+* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-kubernetes.md).
 * For quick start information for Filebeat refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/8.11/filebeat-installation-configuration.html).
-* For complete “Setup and Run Filebeat” information refer to the [helper guide](beats://docs/reference/filebeat/setting-up-running.md).
+* For complete “Setup and Run Filebeat” information refer to the [helper guide](beats://reference/filebeat/setting-up-running.md).
 
 **Rule Specific Setup Note**
 
 * This rule requires the “Filebeat System Module” to be enabled.
 * The system module collects and parses logs created by the system logging service of common Unix/Linux based distributions.
-* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/filebeat-module-system.md).
+* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://reference/filebeat/filebeat-module-system.md).
 
 
 ## Rule query [_rule_query_4807]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-attempt-to-disable-syslog-service.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-attempt-to-disable-syslog-service.md
@@ -85,10 +85,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_4866]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-base16-or-base32-encoding-decoding-activity.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-base16-or-base32-encoding-decoding-activity.md
@@ -85,10 +85,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_4867]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-connection-to-external-network-via-telnet.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-connection-to-external-network-via-telnet.md
@@ -80,10 +80,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_4923]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-connection-to-internal-network-via-telnet.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-connection-to-internal-network-via-telnet.md
@@ -80,10 +80,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_4924]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-creation-of-hidden-shared-object-file.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-creation-of-hidden-shared-object-file.md
@@ -81,10 +81,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Custom Ingest Pipeline**
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-file-made-immutable-by-chattr.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-file-made-immutable-by-chattr.md
@@ -81,10 +81,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Custom Ingest Pipeline**
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-file-transfer-or-listener-established-via-netcat.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-file-transfer-or-listener-established-via-netcat.md
@@ -128,10 +128,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_4907]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-hping-process-activity.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-hping-process-activity.md
@@ -87,10 +87,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_4893]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-namespace-manipulation-using-unshare.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-namespace-manipulation-using-unshare.md
@@ -84,10 +84,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_4954]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-nping-process-activity.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-nping-process-activity.md
@@ -87,10 +87,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_4894]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-persistence-via-kde-autostart-script-or-desktop-file-modification.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-persistence-via-kde-autostart-script-or-desktop-file-modification.md
@@ -148,10 +148,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Custom Ingest Pipeline**
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-potential-disabling-of-selinux.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-potential-disabling-of-selinux.md
@@ -85,10 +85,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_4873]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-potential-openssh-backdoor-logging-activity.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-potential-openssh-backdoor-logging-activity.md
@@ -85,10 +85,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Custom Ingest Pipeline**
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-potential-protocol-tunneling-via-earthworm.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-potential-protocol-tunneling-via-earthworm.md
@@ -147,10 +147,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Custom Ingest Pipeline**
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-process-started-with-executable-stack.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-process-started-with-executable-stack.md
@@ -54,17 +54,17 @@ Filebeat is a lightweight shipper for forwarding and centralizing log data. Inst
 **The following steps should be executed in order to add the Filebeat for the Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/filebeat/setup-repositories.md).
-* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-docker.md).
-* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-kubernetes.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/filebeat/setup-repositories.md).
+* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-docker.md).
+* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-kubernetes.md).
 * For quick start information for Filebeat refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/8.11/filebeat-installation-configuration.html).
-* For complete Setup and Run Filebeat information refer to the [helper guide](beats://docs/reference/filebeat/setting-up-running.md).
+* For complete Setup and Run Filebeat information refer to the [helper guide](beats://reference/filebeat/setting-up-running.md).
 
 **Rule Specific Setup Note**
 
 * This rule requires the Filebeat System Module to be enabled.
 * The system module collects and parses logs created by the system logging service of common Unix/Linux based distributions.
-* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/filebeat-module-system.md).
+* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://reference/filebeat/filebeat-module-system.md).
 
 
 ## Rule query [_rule_query_4829]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-system-log-file-deletion.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-system-log-file-deletion.md
@@ -84,10 +84,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Custom Ingest Pipeline**
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-unusual-pkexec-execution.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-3-unusual-pkexec-execution.md
@@ -83,10 +83,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_4832]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-attempt-to-disable-syslog-service.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-attempt-to-disable-syslog-service.md
@@ -122,10 +122,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_5322]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-base16-or-base32-encoding-decoding-activity.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-base16-or-base32-encoding-decoding-activity.md
@@ -123,10 +123,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_5323]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-connection-to-external-network-via-telnet.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-connection-to-external-network-via-telnet.md
@@ -117,10 +117,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_5425]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-connection-to-internal-network-via-telnet.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-connection-to-internal-network-via-telnet.md
@@ -118,10 +118,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_5426]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-creation-of-hidden-files-and-directories-via-commandline.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-creation-of-hidden-files-and-directories-via-commandline.md
@@ -114,10 +114,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Custom Ingest Pipeline**
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-creation-of-hidden-shared-object-file.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-creation-of-hidden-shared-object-file.md
@@ -118,10 +118,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Custom Ingest Pipeline**
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-default-cobalt-strike-team-server-certificate.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-default-cobalt-strike-team-server-certificate.md
@@ -30,7 +30,7 @@ This rule detects the use of the default Cobalt Strike Team Server TLS certifica
 
 * [https://attack.mitre.org/software/S0154/](https://attack.mitre.org/software/S0154/)
 * [https://www.cobaltstrike.com/help-setup-collaboration](https://www.cobaltstrike.com/help-setup-collaboration)
-* [/beats/docs/reference/ingestion-tools/beats-packetbeat/configuration-tls.md](beats://docs/reference/packetbeat/configuration-tls.md)
+* [/beats/docs/reference/ingestion-tools/beats-packetbeat/configuration-tls.md](beats://reference/packetbeat/configuration-tls.md)
 * [https://www.elastic.co/guide/en/beats/filebeat/7.9/filebeat-module-suricata.html](https://www.elastic.co/guide/en/beats/filebeat/7.9/filebeat-module-suricata.html)
 * [https://www.elastic.co/guide/en/beats/filebeat/7.9/filebeat-module-zeek.html](https://www.elastic.co/guide/en/beats/filebeat/7.9/filebeat-module-zeek.html)
 * [https://www.elastic.co/security-labs/collecting-cobalt-strike-beacons-with-the-elastic-stack](https://www.elastic.co/security-labs/collecting-cobalt-strike-beacons-with-the-elastic-stack)

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-file-made-immutable-by-chattr.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-file-made-immutable-by-chattr.md
@@ -118,10 +118,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Custom Ingest Pipeline**
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-file-permission-modification-in-writable-directory.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-file-permission-modification-in-writable-directory.md
@@ -113,10 +113,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_5335]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-file-transfer-or-listener-established-via-netcat.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-file-transfer-or-listener-established-via-netcat.md
@@ -128,10 +128,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_5387]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-first-time-seen-google-workspace-oauth-login-from-third-party-application.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-first-time-seen-google-workspace-oauth-login-from-third-party-application.md
@@ -92,7 +92,7 @@ OAuth is a protocol that allows third-party applications to access user data wit
 * By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 * See the following references for further information:
 * [https://support.google.com/a/answer/7061566](https://support.google.com/a/answer/7061566)
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://docs/reference/filebeat/filebeat-module-google_workspace.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://reference/filebeat/filebeat-module-google_workspace.md)
 
 
 ## Setup [_setup_1052]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-google-workspace-drive-encryption-key-s-accessed-from-anonymous-user.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-google-workspace-drive-encryption-key-s-accessed-from-anonymous-user.md
@@ -90,7 +90,7 @@ Google Workspace Drive allows users to store and share files, including sensitiv
 * By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 * See the following references for further information:
 * [https://support.google.com/a/answer/7061566](https://support.google.com/a/answer/7061566)
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://docs/reference/filebeat/filebeat-module-google_workspace.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://reference/filebeat/filebeat-module-google_workspace.md)
 
 
 ## Setup [_setup_1051]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-google-workspace-suspended-user-account-renewed.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-google-workspace-suspended-user-account-renewed.md
@@ -87,7 +87,7 @@ Google Workspace manages user identities and access, crucial for organizational 
 * By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 * See the following references for further information:
 * [https://support.google.com/a/answer/7061566](https://support.google.com/a/answer/7061566)
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://docs/reference/filebeat/filebeat-module-google_workspace.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://reference/filebeat/filebeat-module-google_workspace.md)
 
 
 ## Setup [_setup_1054]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-hping-process-activity.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-hping-process-activity.md
@@ -125,10 +125,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_5361]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-inbound-connection-to-an-unsecure-elasticsearch-node.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-inbound-connection-to-an-unsecure-elasticsearch-node.md
@@ -27,7 +27,7 @@ Identifies Elasticsearch nodes that do not have Transport Layer Security (TLS), 
 **References**:
 
 * [docs-content://deploy-manage/deploy/self-managed/installing-elasticsearch.md](docs-content://deploy-manage/deploy/self-managed/installing-elasticsearch.md)
-* [/beats/docs/reference/ingestion-tools/beats-packetbeat/packetbeat-http-options.md#_send_all_headers](beats://docs/reference/packetbeat/packetbeat-http-options.md#_send_all_headers)
+* [/beats/docs/reference/ingestion-tools/beats-packetbeat/packetbeat-http-options.md#_send_all_headers](beats://reference/packetbeat/packetbeat-http-options.md#_send_all_headers)
 
 **Tags**:
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-interactive-terminal-spawned-via-perl.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-interactive-terminal-spawned-via-perl.md
@@ -116,10 +116,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_5392]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-linux-group-creation.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-linux-group-creation.md
@@ -104,17 +104,17 @@ Filebeat is a lightweight shipper for forwarding and centralizing log data. Inst
 **The following steps should be executed in order to add the Filebeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/filebeat/setup-repositories.md).
-* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-docker.md).
-* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-kubernetes.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/filebeat/setup-repositories.md).
+* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-docker.md).
+* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-kubernetes.md).
 * For quick start information for Filebeat refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/8.11/filebeat-installation-configuration.html).
-* For complete “Setup and Run Filebeat” information refer to the [helper guide](beats://docs/reference/filebeat/setting-up-running.md).
+* For complete “Setup and Run Filebeat” information refer to the [helper guide](beats://reference/filebeat/setting-up-running.md).
 
 **Rule Specific Setup Note**
 
 * This rule requires the “Filebeat System Module” to be enabled.
 * The system module collects and parses logs created by the system logging service of common Unix/Linux based distributions.
-* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/filebeat-module-system.md).
+* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://reference/filebeat/filebeat-module-system.md).
 
 
 ## Rule query [_rule_query_5458]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-linux-user-account-creation.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-linux-user-account-creation.md
@@ -103,17 +103,17 @@ Filebeat is a lightweight shipper for forwarding and centralizing log data. Inst
 **The following steps should be executed in order to add the Filebeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/filebeat/setup-repositories.md).
-* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-docker.md).
-* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-kubernetes.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/filebeat/setup-repositories.md).
+* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-docker.md).
+* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-kubernetes.md).
 * For quick start information for Filebeat refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/8.11/filebeat-installation-configuration.html).
-* For complete “Setup and Run Filebeat” information refer to the [helper guide](beats://docs/reference/filebeat/setting-up-running.md).
+* For complete “Setup and Run Filebeat” information refer to the [helper guide](beats://reference/filebeat/setting-up-running.md).
 
 **Rule Specific Setup Note**
 
 * This rule requires the “Filebeat System Module” to be enabled.
 * The system module collects and parses logs created by the system logging service of common Unix/Linux based distributions.
-* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/filebeat-module-system.md).
+* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://reference/filebeat/filebeat-module-system.md).
 
 
 ## Rule query [_rule_query_5460]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-login-via-unusual-system-user.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-login-via-unusual-system-user.md
@@ -97,17 +97,17 @@ Filebeat is a lightweight shipper for forwarding and centralizing log data. Inst
 **The following steps should be executed in order to add the Filebeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/filebeat/setup-repositories.md).
-* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-docker.md).
-* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-kubernetes.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/filebeat/setup-repositories.md).
+* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-docker.md).
+* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-kubernetes.md).
 * For quick start information for Filebeat refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/8.11/filebeat-installation-configuration.html).
-* For complete “Setup and Run Filebeat” information refer to the [helper guide](beats://docs/reference/filebeat/setting-up-running.md).
+* For complete “Setup and Run Filebeat” information refer to the [helper guide](beats://reference/filebeat/setting-up-running.md).
 
 **Rule Specific Setup Note**
 
 * This rule requires the “Filebeat System Module” to be enabled.
 * The system module collects and parses logs created by the system logging service of common Unix/Linux based distributions.
-* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/filebeat-module-system.md).
+* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://reference/filebeat/filebeat-module-system.md).
 
 
 ## Rule query [_rule_query_5486]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-machine-learning-detected-a-dns-request-predicted-to-be-a-dga-domain.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-machine-learning-detected-a-dns-request-predicted-to-be-a-dga-domain.md
@@ -100,10 +100,10 @@ The DGA Detection integration consists of an ML-based framework to detect DGA ac
 
 * Fleet is required for DGA Detection.
 * To configure Fleet Server refer to the [documentation](docs-content://reference/ingestion-tools/fleet/fleet-server.md).
-* DNS events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint), [Network Packet Capture](https://docs.elastic.co/integrations/network_traffic) integration, or [Packetbeat](beats://docs/reference/packetbeat/packetbeat-overview.md).
+* DNS events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint), [Network Packet Capture](https://docs.elastic.co/integrations/network_traffic) integration, or [Packetbeat](beats://reference/packetbeat/packetbeat-overview.md).
 * To install Elastic Defend, refer to the [documentation](docs-content://solutions/security/configure-elastic-defend/install-elastic-defend.md).
 * To add the Network Packet Capture integration to an Elastic Agent policy, refer to [this](docs-content://reference/ingestion-tools/fleet/add-integration-to-policy.md) guide.
-* To set up and run Packetbeat, follow [this](beats://docs/reference/packetbeat/setting-up-running.md) guide.
+* To set up and run Packetbeat, follow [this](beats://reference/packetbeat/setting-up-running.md) guide.
 
 **The following steps should be executed to install assets associated with the DGA Detection integration:**
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-machine-learning-detected-a-dns-request-with-a-high-dga-probability-score.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-machine-learning-detected-a-dns-request-with-a-high-dga-probability-score.md
@@ -99,10 +99,10 @@ The DGA Detection integration consists of an ML-based framework to detect DGA ac
 
 * Fleet is required for DGA Detection.
 * To configure Fleet Server refer to the [documentation](docs-content://reference/ingestion-tools/fleet/fleet-server.md).
-* DNS events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint), [Network Packet Capture](https://docs.elastic.co/integrations/network_traffic) integration, or [Packetbeat](beats://docs/reference/packetbeat/packetbeat-overview.md).
+* DNS events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint), [Network Packet Capture](https://docs.elastic.co/integrations/network_traffic) integration, or [Packetbeat](beats://reference/packetbeat/packetbeat-overview.md).
 * To install Elastic Defend, refer to the [documentation](docs-content://solutions/security/configure-elastic-defend/install-elastic-defend.md).
 * To add the Network Packet Capture integration to an Elastic Agent policy, refer to [this](docs-content://reference/ingestion-tools/fleet/add-integration-to-policy.md) guide.
-* To set up and run Packetbeat, follow [this](beats://docs/reference/packetbeat/setting-up-running.md) guide.
+* To set up and run Packetbeat, follow [this](beats://reference/packetbeat/setting-up-running.md) guide.
 
 **The following steps should be executed to install assets associated with the DGA Detection integration:**
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-machine-learning-detected-a-suspicious-windows-event-with-a-high-malicious-probability-score.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-machine-learning-detected-a-suspicious-windows-event-with-a-high-malicious-probability-score.md
@@ -101,9 +101,9 @@ The LotL Attack Detection integration detects living-off-the-land activity in Wi
 
 * Fleet is required for LotL Attack Detection.
 * To configure Fleet Server refer to the [documentation](docs-content://reference/ingestion-tools/fleet/fleet-server.md).
-* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://docs/reference/winlogbeat/_winlogbeat_overview.md)).
+* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://reference/winlogbeat/_winlogbeat_overview.md)).
 * To install Elastic Defend, refer to the [documentation](docs-content://solutions/security/configure-elastic-defend/install-elastic-defend.md).
-* To set up and run Winlogbeat, follow [this](beats://docs/reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
+* To set up and run Winlogbeat, follow [this](beats://reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
 
 **The following steps should be executed to install assets associated with the LotL Attack Detection integration:**
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-machine-learning-detected-a-suspicious-windows-event-with-a-low-malicious-probability-score.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-machine-learning-detected-a-suspicious-windows-event-with-a-low-malicious-probability-score.md
@@ -101,9 +101,9 @@ The LotL Attack Detection integration detects living-off-the-land activity in Wi
 
 * Fleet is required for LotL Attack Detection.
 * To configure Fleet Server refer to the [documentation](docs-content://reference/ingestion-tools/fleet/fleet-server.md).
-* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://docs/reference/winlogbeat/_winlogbeat_overview.md)).
+* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://reference/winlogbeat/_winlogbeat_overview.md)).
 * To install Elastic Defend, refer to the [documentation](docs-content://solutions/security/configure-elastic-defend/install-elastic-defend.md).
-* To set up and run Winlogbeat, follow [this](beats://docs/reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
+* To set up and run Winlogbeat, follow [this](beats://reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
 
 **The following steps should be executed to install assets associated with the LotL Attack Detection integration:**
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-machine-learning-detected-dga-activity-using-a-known-sunburst-dns-domain.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-machine-learning-detected-dga-activity-using-a-known-sunburst-dns-domain.md
@@ -100,10 +100,10 @@ The DGA Detection integration consists of an ML-based framework to detect DGA ac
 
 * Fleet is required for DGA Detection.
 * To configure Fleet Server refer to the [documentation](docs-content://reference/ingestion-tools/fleet/fleet-server.md).
-* DNS events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint), [Network Packet Capture](https://docs.elastic.co/integrations/network_traffic) integration, or [Packetbeat](beats://docs/reference/packetbeat/packetbeat-overview.md).
+* DNS events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint), [Network Packet Capture](https://docs.elastic.co/integrations/network_traffic) integration, or [Packetbeat](beats://reference/packetbeat/packetbeat-overview.md).
 * To install Elastic Defend, refer to the [documentation](docs-content://solutions/security/configure-elastic-defend/install-elastic-defend.md).
 * To add the Network Packet Capture integration to an Elastic Agent policy, refer to [this](docs-content://reference/ingestion-tools/fleet/add-integration-to-policy.md) guide.
-* To set up and run Packetbeat, follow [this](beats://docs/reference/packetbeat/setting-up-running.md) guide.
+* To set up and run Packetbeat, follow [this](beats://reference/packetbeat/setting-up-running.md) guide.
 
 **The following steps should be executed to install assets associated with the DGA Detection integration:**
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-modification-of-dynamic-linker-preload-shared-object.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-modification-of-dynamic-linker-preload-shared-object.md
@@ -119,10 +119,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_5513]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-modification-of-openssh-binaries.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-modification-of-openssh-binaries.md
@@ -143,10 +143,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_5433]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-namespace-manipulation-using-unshare.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-namespace-manipulation-using-unshare.md
@@ -120,10 +120,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_5535]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-network-connections-initiated-through-xdg-autostart-entry.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-network-connections-initiated-through-xdg-autostart-entry.md
@@ -117,10 +117,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Custom Ingest Pipeline**
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-nping-process-activity.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-nping-process-activity.md
@@ -125,10 +125,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_5362]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-persistence-via-kde-autostart-script-or-desktop-file-modification.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-persistence-via-kde-autostart-script-or-desktop-file-modification.md
@@ -149,10 +149,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Custom Ingest Pipeline**
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-potential-dga-activity.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-potential-dga-activity.md
@@ -93,10 +93,10 @@ The DGA Detection integration consists of an ML-based framework to detect DGA ac
 
 * Fleet is required for DGA Detection.
 * To configure Fleet Server refer to the [documentation](docs-content://reference/ingestion-tools/fleet/fleet-server.md).
-* DNS events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint), [Network Packet Capture](https://docs.elastic.co/integrations/network_traffic) integration, or [Packetbeat](beats://docs/reference/packetbeat/packetbeat-overview.md).
+* DNS events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint), [Network Packet Capture](https://docs.elastic.co/integrations/network_traffic) integration, or [Packetbeat](beats://reference/packetbeat/packetbeat-overview.md).
 * To install Elastic Defend, refer to the [documentation](docs-content://solutions/security/configure-elastic-defend/install-elastic-defend.md).
 * To add the Network Packet Capture integration to an Elastic Agent policy, refer to [this](docs-content://reference/ingestion-tools/fleet/add-integration-to-policy.md) guide.
-* To set up and run Packetbeat, follow [this](beats://docs/reference/packetbeat/setting-up-running.md) guide.
+* To set up and run Packetbeat, follow [this](beats://reference/packetbeat/setting-up-running.md) guide.
 
 **The following steps should be executed to install assets associated with the DGA Detection integration:**
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-potential-disabling-of-selinux.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-potential-disabling-of-selinux.md
@@ -122,10 +122,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_5330]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-potential-external-linux-ssh-brute-force-detected.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-potential-external-linux-ssh-brute-force-detected.md
@@ -95,17 +95,17 @@ Filebeat is a lightweight shipper for forwarding and centralizing log data. Inst
 **The following steps should be executed in order to add the Filebeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/filebeat/setup-repositories.md).
-* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-docker.md).
-* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-kubernetes.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/filebeat/setup-repositories.md).
+* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-docker.md).
+* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-kubernetes.md).
 * For quick start information for Filebeat refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/8.11/filebeat-installation-configuration.html).
-* For complete “Setup and Run Filebeat” information refer to the [helper guide](beats://docs/reference/filebeat/setting-up-running.md).
+* For complete “Setup and Run Filebeat” information refer to the [helper guide](beats://reference/filebeat/setting-up-running.md).
 
 **Rule Specific Setup Note**
 
 * This rule requires the “Filebeat System Module” to be enabled.
 * The system module collects and parses logs created by the system logging service of common Unix/Linux based distributions.
-* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/filebeat-module-system.md).
+* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://reference/filebeat/filebeat-module-system.md).
 
 
 ## Rule query [_rule_query_5311]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-potential-internal-linux-ssh-brute-force-detected.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-potential-internal-linux-ssh-brute-force-detected.md
@@ -91,17 +91,17 @@ Filebeat is a lightweight shipper for forwarding and centralizing log data. Inst
 **The following steps should be executed in order to add the Filebeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/filebeat/setup-repositories.md).
-* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-docker.md).
-* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-kubernetes.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/filebeat/setup-repositories.md).
+* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-docker.md).
+* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-kubernetes.md).
 * For quick start information for Filebeat refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/8.11/filebeat-installation-configuration.html).
-* For complete “Setup and Run Filebeat” information refer to the [helper guide](beats://docs/reference/filebeat/setting-up-running.md).
+* For complete “Setup and Run Filebeat” information refer to the [helper guide](beats://reference/filebeat/setting-up-running.md).
 
 **Rule Specific Setup Note**
 
 * This rule requires the “Filebeat System Module” to be enabled.
 * The system module collects and parses logs created by the system logging service of common Unix/Linux based distributions.
-* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/filebeat-module-system.md).
+* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://reference/filebeat/filebeat-module-system.md).
 
 
 ## Rule query [_rule_query_5312]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-potential-meterpreter-reverse-shell.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-potential-meterpreter-reverse-shell.md
@@ -95,10 +95,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Auditd Manager Integration Setup**
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-potential-openssh-backdoor-logging-activity.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-potential-openssh-backdoor-logging-activity.md
@@ -123,10 +123,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Custom Ingest Pipeline**
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-potential-protocol-tunneling-via-earthworm.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-potential-protocol-tunneling-via-earthworm.md
@@ -148,10 +148,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Custom Ingest Pipeline**
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-potential-reverse-shell-via-udp.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-potential-reverse-shell-via-udp.md
@@ -97,10 +97,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Auditd Manager Integration Setup**
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-potential-successful-linux-ftp-brute-force-attack-detected.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-potential-successful-linux-ftp-brute-force-attack-detected.md
@@ -91,10 +91,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Auditd Manager Integration Setup**
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-potential-successful-linux-rdp-brute-force-attack-detected.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-potential-successful-linux-rdp-brute-force-attack-detected.md
@@ -92,10 +92,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Auditd Manager Integration Setup**
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-potential-successful-ssh-brute-force-attack.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-potential-successful-ssh-brute-force-attack.md
@@ -88,10 +88,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Filebeat Setup**
 
@@ -100,17 +100,17 @@ Filebeat is a lightweight shipper for forwarding and centralizing log data. Inst
 **The following steps should be executed in order to add the Filebeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/filebeat/setup-repositories.md).
-* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-docker.md).
-* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-kubernetes.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/filebeat/setup-repositories.md).
+* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-docker.md).
+* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-kubernetes.md).
 * For quick start information for Filebeat refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/8.11/filebeat-installation-configuration.html).
-* For complete “Setup and Run Filebeat” information refer to the [helper guide](beats://docs/reference/filebeat/setting-up-running.md).
+* For complete “Setup and Run Filebeat” information refer to the [helper guide](beats://reference/filebeat/setting-up-running.md).
 
 **Rule Specific Setup Note**
 
 * This rule requires the “Filebeat System Module” to be enabled.
 * The system module collects and parses logs created by the system logging service of common Unix/Linux based distributions.
-* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/filebeat-module-system.md).
+* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://reference/filebeat/filebeat-module-system.md).
 
 
 ## Rule query [_rule_query_5315]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-process-backgrounded-by-unusual-parent.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-process-backgrounded-by-unusual-parent.md
@@ -120,10 +120,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_4959]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-process-started-with-executable-stack.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-process-started-with-executable-stack.md
@@ -91,17 +91,17 @@ Filebeat is a lightweight shipper for forwarding and centralizing log data. Inst
 **The following steps should be executed in order to add the Filebeat for the Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/filebeat/setup-repositories.md).
-* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-docker.md).
-* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-kubernetes.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/filebeat/setup-repositories.md).
+* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-docker.md).
+* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-kubernetes.md).
 * For quick start information for Filebeat refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/8.11/filebeat-installation-configuration.html).
-* For complete Setup and Run Filebeat information refer to the [helper guide](beats://docs/reference/filebeat/setting-up-running.md).
+* For complete Setup and Run Filebeat information refer to the [helper guide](beats://reference/filebeat/setting-up-running.md).
 
 **Rule Specific Setup Note**
 
 * This rule requires the Filebeat System Module to be enabled.
 * The system module collects and parses logs created by the system logging service of common Unix/Linux based distributions.
-* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/filebeat-module-system.md).
+* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://reference/filebeat/filebeat-module-system.md).
 
 
 ## Rule query [_rule_query_5385]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-rapid7-threat-command-cves-correlation.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-rapid7-threat-command-cves-correlation.md
@@ -30,7 +30,7 @@ This rule is triggered when CVEs collected from the Rapid7 Threat Command Integr
 
 **References**:
 
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://docs/reference/filebeat/filebeat-module-threatintel.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://reference/filebeat/filebeat-module-threatintel.md)
 * [https://docs.elastic.co/integrations/ti_rapid7_threat_command](https://docs.elastic.co/integrations/ti_rapid7_threat_command)
 
 **Tags**:

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-sensitive-files-compression.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-sensitive-files-compression.md
@@ -119,10 +119,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_5306]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-suspicious-network-activity-to-the-internet-by-previously-unknown-executable.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-suspicious-network-activity-to-the-internet-by-previously-unknown-executable.md
@@ -140,10 +140,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Filebeat Setup**
 
@@ -152,11 +152,11 @@ Filebeat is a lightweight shipper for forwarding and centralizing log data. Inst
 **The following steps should be executed in order to add the Filebeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/filebeat/setup-repositories.md).
-* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-docker.md).
-* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-kubernetes.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/filebeat/setup-repositories.md).
+* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-docker.md).
+* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-kubernetes.md).
 * For quick start information for Filebeat refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/8.11/filebeat-installation-configuration.html).
-* For complete “Setup and Run Filebeat” information refer to the [helper guide](beats://docs/reference/filebeat/setting-up-running.md).
+* For complete “Setup and Run Filebeat” information refer to the [helper guide](beats://reference/filebeat/setting-up-running.md).
 
 **Packetbeat Setup**
 
@@ -165,10 +165,10 @@ Packetbeat is a real-time network packet analyzer that you can use for applicati
 **The following steps should be executed in order to add the Packetbeat on a  Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/packetbeat/setup-repositories.md).
-* To run Packetbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/packetbeat/running-on-docker.md).
-* For quick start information for Packetbeat refer to the [helper guide](beats://docs/reference/packetbeat/packetbeat-installation-configuration.md).
-* For complete “Setup and Run Packetbeat” information refer to the [helper guide](beats://docs/reference/packetbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/packetbeat/setup-repositories.md).
+* To run Packetbeat on Docker follow the setup instructions in the [helper guide](beats://reference/packetbeat/running-on-docker.md).
+* For quick start information for Packetbeat refer to the [helper guide](beats://reference/packetbeat/packetbeat-installation-configuration.md).
+* For complete “Setup and Run Packetbeat” information refer to the [helper guide](beats://reference/packetbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_5304]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-suspicious-rc-local-error-message.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-suspicious-rc-local-error-message.md
@@ -94,17 +94,17 @@ Filebeat is a lightweight shipper for forwarding and centralizing log data. Inst
 **The following steps should be executed in order to add the Filebeat for the Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/filebeat/setup-repositories.md).
-* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-docker.md).
-* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-kubernetes.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/filebeat/setup-repositories.md).
+* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-docker.md).
+* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-kubernetes.md).
 * For quick start information for Filebeat refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/8.11/filebeat-installation-configuration.html).
-* For complete Setup and Run Filebeat information refer to the [helper guide](beats://docs/reference/filebeat/setting-up-running.md).
+* For complete Setup and Run Filebeat information refer to the [helper guide](beats://reference/filebeat/setting-up-running.md).
 
 **Rule Specific Setup Note**
 
 * This rule requires the Filebeat System Module to be enabled.
 * The system module collects and parses logs created by the system logging service of common Unix/Linux based distributions.
-* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/filebeat-module-system.md).
+* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://reference/filebeat/filebeat-module-system.md).
 
 
 ## Rule query [_rule_query_5474]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-suspicious-usage-of-bpf-probe-write-user-helper.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-suspicious-usage-of-bpf-probe-write-user-helper.md
@@ -92,17 +92,17 @@ Filebeat is a lightweight shipper for forwarding and centralizing log data. Inst
 **The following steps should be executed in order to add the Filebeat for the Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/filebeat/setup-repositories.md).
-* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-docker.md).
-* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-kubernetes.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/filebeat/setup-repositories.md).
+* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-docker.md).
+* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-kubernetes.md).
 * For quick start information for Filebeat refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/8.11/filebeat-installation-configuration.html).
-* For complete Setup and Run Filebeat information refer to the [helper guide](beats://docs/reference/filebeat/setting-up-running.md).
+* For complete Setup and Run Filebeat information refer to the [helper guide](beats://reference/filebeat/setting-up-running.md).
 
 **Rule Specific Setup Note**
 
 * This rule requires the Filebeat System Module to be enabled.
 * The system module collects and parses logs created by the system logging service of common Unix/Linux based distributions.
-* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/filebeat-module-system.md).
+* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://reference/filebeat/filebeat-module-system.md).
 
 
 ## Rule query [_rule_query_4960]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-suspicious-windows-process-cluster-spawned-by-a-host.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-suspicious-windows-process-cluster-spawned-by-a-host.md
@@ -94,9 +94,9 @@ The LotL Attack Detection integration detects living-off-the-land activity in Wi
 
 * Fleet is required for LotL Attack Detection.
 * To configure Fleet Server refer to the [documentation](docs-content://reference/ingestion-tools/fleet/fleet-server.md).
-* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://docs/reference/winlogbeat/_winlogbeat_overview.md)).
+* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://reference/winlogbeat/_winlogbeat_overview.md)).
 * To install Elastic Defend, refer to the [documentation](docs-content://solutions/security/configure-elastic-defend/install-elastic-defend.md).
-* To set up and run Winlogbeat, follow [this](beats://docs/reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
+* To set up and run Winlogbeat, follow [this](beats://reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
 
 **The following steps should be executed to install assets associated with the LotL Attack Detection integration:**
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-suspicious-windows-process-cluster-spawned-by-a-parent-process.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-suspicious-windows-process-cluster-spawned-by-a-parent-process.md
@@ -96,9 +96,9 @@ The LotL Attack Detection integration detects living-off-the-land activity in Wi
 
 * Fleet is required for LotL Attack Detection.
 * To configure Fleet Server refer to the [documentation](docs-content://reference/ingestion-tools/fleet/fleet-server.md).
-* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://docs/reference/winlogbeat/_winlogbeat_overview.md)).
+* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://reference/winlogbeat/_winlogbeat_overview.md)).
 * To install Elastic Defend, refer to the [documentation](docs-content://solutions/security/configure-elastic-defend/install-elastic-defend.md).
-* To set up and run Winlogbeat, follow [this](beats://docs/reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
+* To set up and run Winlogbeat, follow [this](beats://reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
 
 **The following steps should be executed to install assets associated with the LotL Attack Detection integration:**
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-suspicious-windows-process-cluster-spawned-by-a-user.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-suspicious-windows-process-cluster-spawned-by-a-user.md
@@ -96,9 +96,9 @@ The LotL Attack Detection integration detects living-off-the-land activity in Wi
 
 * Fleet is required for LotL Attack Detection.
 * To configure Fleet Server refer to the [documentation](docs-content://reference/ingestion-tools/fleet/fleet-server.md).
-* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://docs/reference/winlogbeat/_winlogbeat_overview.md)).
+* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://reference/winlogbeat/_winlogbeat_overview.md)).
 * To install Elastic Defend, refer to the [documentation](docs-content://solutions/security/configure-elastic-defend/install-elastic-defend.md).
-* To set up and run Winlogbeat, follow [this](beats://docs/reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
+* To set up and run Winlogbeat, follow [this](beats://reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
 
 **The following steps should be executed to install assets associated with the LotL Attack Detection integration:**
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-system-log-file-deletion.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-system-log-file-deletion.md
@@ -122,10 +122,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Custom Ingest Pipeline**
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-tainted-kernel-module-load.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-tainted-kernel-module-load.md
@@ -91,17 +91,17 @@ Filebeat is a lightweight shipper for forwarding and centralizing log data. Inst
 **The following steps should be executed in order to add the Filebeat for the Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/filebeat/setup-repositories.md).
-* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-docker.md).
-* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-kubernetes.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/filebeat/setup-repositories.md).
+* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-docker.md).
+* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-kubernetes.md).
 * For quick start information for Filebeat refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/8.11/filebeat-installation-configuration.html).
-* For complete Setup and Run Filebeat information refer to the [helper guide](beats://docs/reference/filebeat/setting-up-running.md).
+* For complete Setup and Run Filebeat information refer to the [helper guide](beats://reference/filebeat/setting-up-running.md).
 
 **Rule Specific Setup Note**
 
 * This rule requires the Filebeat System Module to be enabled.
 * The system module collects and parses logs created by the system logging service of common Unix/Linux based distributions.
-* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/filebeat-module-system.md).
+* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://reference/filebeat/filebeat-module-system.md).
 
 
 ## Rule query [_rule_query_5495]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-tainted-out-of-tree-kernel-module-load.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-tainted-out-of-tree-kernel-module-load.md
@@ -92,17 +92,17 @@ Filebeat is a lightweight shipper for forwarding and centralizing log data. Inst
 **The following steps should be executed in order to add the Filebeat for the Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/filebeat/setup-repositories.md).
-* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-docker.md).
-* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-kubernetes.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/filebeat/setup-repositories.md).
+* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-docker.md).
+* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-kubernetes.md).
 * For quick start information for Filebeat refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/8.11/filebeat-installation-configuration.html).
-* For complete Setup and Run Filebeat information refer to the [helper guide](beats://docs/reference/filebeat/setting-up-running.md).
+* For complete Setup and Run Filebeat information refer to the [helper guide](beats://reference/filebeat/setting-up-running.md).
 
 **Rule Specific Setup Note**
 
 * This rule requires the Filebeat System Module to be enabled.
 * The system module collects and parses logs created by the system logging service of common Unix/Linux based distributions.
-* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/filebeat-module-system.md).
+* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://reference/filebeat/filebeat-module-system.md).
 
 
 ## Rule query [_rule_query_5496]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-threat-intel-hash-indicator-match.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-threat-intel-hash-indicator-match.md
@@ -29,7 +29,7 @@ This rule is triggered when a hash indicator from the Threat Intel Filebeat modu
 
 **References**:
 
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://docs/reference/filebeat/filebeat-module-threatintel.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://reference/filebeat/filebeat-module-threatintel.md)
 * [docs-content://solutions/security/get-started/enable-threat-intelligence-integrations.md](docs-content://solutions/security/get-started/enable-threat-intelligence-integrations.md)
 * [https://www.elastic.co/security/tip](https://www.elastic.co/security/tip)
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-threat-intel-ip-address-indicator-match.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-threat-intel-ip-address-indicator-match.md
@@ -30,7 +30,7 @@ This rule is triggered when an IP address indicator from the Threat Intel Filebe
 
 **References**:
 
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://docs/reference/filebeat/filebeat-module-threatintel.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://reference/filebeat/filebeat-module-threatintel.md)
 * [docs-content://solutions/security/get-started/enable-threat-intelligence-integrations.md](docs-content://solutions/security/get-started/enable-threat-intelligence-integrations.md)
 * [https://www.elastic.co/security/tip](https://www.elastic.co/security/tip)
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-threat-intel-url-indicator-match.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-threat-intel-url-indicator-match.md
@@ -30,7 +30,7 @@ This rule is triggered when a URL indicator from the Threat Intel Filebeat modul
 
 **References**:
 
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://docs/reference/filebeat/filebeat-module-threatintel.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://reference/filebeat/filebeat-module-threatintel.md)
 * [docs-content://solutions/security/get-started/enable-threat-intelligence-integrations.md](docs-content://solutions/security/get-started/enable-threat-intelligence-integrations.md)
 * [https://www.elastic.co/security/tip](https://www.elastic.co/security/tip)
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-threat-intel-windows-registry-indicator-match.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-threat-intel-windows-registry-indicator-match.md
@@ -29,7 +29,7 @@ This rule is triggered when a Windows registry indicator from the Threat Intel F
 
 **References**:
 
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://docs/reference/filebeat/filebeat-module-threatintel.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://reference/filebeat/filebeat-module-threatintel.md)
 * [docs-content://solutions/security/get-started/enable-threat-intelligence-integrations.md](docs-content://solutions/security/get-started/enable-threat-intelligence-integrations.md)
 * [https://www.elastic.co/security/tip](https://www.elastic.co/security/tip)
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-unusual-pkexec-execution.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-unusual-pkexec-execution.md
@@ -121,10 +121,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_5418]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-unusual-process-spawned-by-a-host.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-unusual-process-spawned-by-a-host.md
@@ -95,9 +95,9 @@ The LotL Attack Detection integration detects living-off-the-land activity in Wi
 
 * Fleet is required for LotL Attack Detection.
 * To configure Fleet Server refer to the [documentation](docs-content://reference/ingestion-tools/fleet/fleet-server.md).
-* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://docs/reference/winlogbeat/_winlogbeat_overview.md)).
+* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://reference/winlogbeat/_winlogbeat_overview.md)).
 * To install Elastic Defend, refer to the [documentation](docs-content://solutions/security/configure-elastic-defend/install-elastic-defend.md).
-* To set up and run Winlogbeat, follow [this](beats://docs/reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
+* To set up and run Winlogbeat, follow [this](beats://reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
 
 **The following steps should be executed to install assets associated with the LotL Attack Detection integration:**
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-unusual-process-spawned-by-a-parent-process.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-unusual-process-spawned-by-a-parent-process.md
@@ -97,9 +97,9 @@ The LotL Attack Detection integration detects living-off-the-land activity in Wi
 
 * Fleet is required for LotL Attack Detection.
 * To configure Fleet Server refer to the [documentation](docs-content://reference/ingestion-tools/fleet/fleet-server.md).
-* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://docs/reference/winlogbeat/_winlogbeat_overview.md)).
+* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://reference/winlogbeat/_winlogbeat_overview.md)).
 * To install Elastic Defend, refer to the [documentation](docs-content://solutions/security/configure-elastic-defend/install-elastic-defend.md).
-* To set up and run Winlogbeat, follow [this](beats://docs/reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
+* To set up and run Winlogbeat, follow [this](beats://reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
 
 **The following steps should be executed to install assets associated with the LotL Attack Detection integration:**
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-unusual-process-spawned-by-a-user.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-unusual-process-spawned-by-a-user.md
@@ -96,9 +96,9 @@ The LotL Attack Detection integration detects living-off-the-land activity in Wi
 
 * Fleet is required for LotL Attack Detection.
 * To configure Fleet Server refer to the [documentation](docs-content://reference/ingestion-tools/fleet/fleet-server.md).
-* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://docs/reference/winlogbeat/_winlogbeat_overview.md)).
+* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://reference/winlogbeat/_winlogbeat_overview.md)).
 * To install Elastic Defend, refer to the [documentation](docs-content://solutions/security/configure-elastic-defend/install-elastic-defend.md).
-* To set up and run Winlogbeat, follow [this](beats://docs/reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
+* To set up and run Winlogbeat, follow [this](beats://reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
 
 **The following steps should be executed to install assets associated with the LotL Attack Detection integration:**
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-virtual-machine-fingerprinting.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-17-4-virtual-machine-fingerprinting.md
@@ -117,10 +117,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_5376]

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-2-1-hosts-file-modified.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-2-1-hosts-file-modified.md
@@ -28,7 +28,7 @@ The hosts file on endpoints is used to control manual IP address to hostname res
 
 **References**:
 
-* [/beats/docs/reference/ingestion-tools/beats-auditbeat/auditbeat-reference-yml.md](beats://docs/reference/auditbeat/auditbeat-reference-yml.md)
+* [/beats/docs/reference/ingestion-tools/beats-auditbeat/auditbeat-reference-yml.md](beats://reference/auditbeat/auditbeat-reference-yml.md)
 
 **Tags**:
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-2-1-inbound-connection-to-an-unsecure-elasticsearch-node.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-2-1-inbound-connection-to-an-unsecure-elasticsearch-node.md
@@ -29,7 +29,7 @@ Identifies Elasticsearch nodes that do not have Transport Layer Security (TLS), 
 **References**:
 
 * [docs-content://deploy-manage/deploy/self-managed/installing-elasticsearch.md](docs-content://deploy-manage/deploy/self-managed/installing-elasticsearch.md)
-* [/beats/docs/reference/ingestion-tools/beats-packetbeat/packetbeat-http-options.md#_send_all_headers](beats://docs/reference/packetbeat/packetbeat-http-options.md#_send_all_headers)
+* [/beats/docs/reference/ingestion-tools/beats-packetbeat/packetbeat-http-options.md#_send_all_headers](beats://reference/packetbeat/packetbeat-http-options.md#_send_all_headers)
 
 **Tags**:
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-3-2-hosts-file-modified.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-3-2-hosts-file-modified.md
@@ -28,7 +28,7 @@ The hosts file on endpoints is used to control manual IP address to hostname res
 
 **References**:
 
-* [/beats/docs/reference/ingestion-tools/beats-auditbeat/auditbeat-reference-yml.md](beats://docs/reference/auditbeat/auditbeat-reference-yml.md)
+* [/beats/docs/reference/ingestion-tools/beats-auditbeat/auditbeat-reference-yml.md](beats://reference/auditbeat/auditbeat-reference-yml.md)
 
 **Tags**:
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-3-2-threat-intel-filebeat-module-v8-x-indicator-match.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-3-2-threat-intel-filebeat-module-v8-x-indicator-match.md
@@ -30,7 +30,7 @@ This rule is triggered when indicators from the Threat Intel Filebeat module (v8
 
 **References**:
 
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://docs/reference/filebeat/filebeat-module-threatintel.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://reference/filebeat/filebeat-module-threatintel.md)
 
 **Tags**:
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-3-2-threat-intel-indicator-match.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-3-2-threat-intel-indicator-match.md
@@ -30,7 +30,7 @@ This rule is triggered when indicators from the Threat Intel integrations have a
 
 **References**:
 
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://docs/reference/filebeat/filebeat-module-threatintel.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://reference/filebeat/filebeat-module-threatintel.md)
 
 **Tags**:
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-3-3-default-cobalt-strike-team-server-certificate.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-3-3-default-cobalt-strike-team-server-certificate.md
@@ -30,7 +30,7 @@ This rule detects the use of the default Cobalt Strike Team Server TLS certifica
 
 * [https://attack.mitre.org/software/S0154/](https://attack.mitre.org/software/S0154/)
 * [https://www.cobaltstrike.com/help-setup-collaboration](https://www.cobaltstrike.com/help-setup-collaboration)
-* [/beats/docs/reference/ingestion-tools/beats-packetbeat/configuration-tls.md](beats://docs/reference/packetbeat/configuration-tls.md)
+* [/beats/docs/reference/ingestion-tools/beats-packetbeat/configuration-tls.md](beats://reference/packetbeat/configuration-tls.md)
 * [https://www.elastic.co/guide/en/beats/filebeat/7.9/filebeat-module-suricata.html](https://www.elastic.co/guide/en/beats/filebeat/7.9/filebeat-module-suricata.html)
 * [https://www.elastic.co/guide/en/beats/filebeat/7.9/filebeat-module-zeek.html](https://www.elastic.co/guide/en/beats/filebeat/7.9/filebeat-module-zeek.html)
 * [https://www.elastic.co/security-labs/collecting-cobalt-strike-beacons-with-the-elastic-stack](https://www.elastic.co/security-labs/collecting-cobalt-strike-beacons-with-the-elastic-stack)

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-3-3-hosts-file-modified.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-3-3-hosts-file-modified.md
@@ -28,7 +28,7 @@ The hosts file on endpoints is used to control manual IP address to hostname res
 
 **References**:
 
-* [/beats/docs/reference/ingestion-tools/beats-auditbeat/auditbeat-reference-yml.md](beats://docs/reference/auditbeat/auditbeat-reference-yml.md)
+* [/beats/docs/reference/ingestion-tools/beats-auditbeat/auditbeat-reference-yml.md](beats://reference/auditbeat/auditbeat-reference-yml.md)
 
 **Tags**:
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-3-3-inbound-connection-to-an-unsecure-elasticsearch-node.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-3-3-inbound-connection-to-an-unsecure-elasticsearch-node.md
@@ -29,7 +29,7 @@ Identifies Elasticsearch nodes that do not have Transport Layer Security (TLS), 
 **References**:
 
 * [docs-content://deploy-manage/deploy/self-managed/installing-elasticsearch.md](docs-content://deploy-manage/deploy/self-managed/installing-elasticsearch.md)
-* [/beats/docs/reference/ingestion-tools/beats-packetbeat/packetbeat-http-options.md#_send_all_headers](beats://docs/reference/packetbeat/packetbeat-http-options.md#_send_all_headers)
+* [/beats/docs/reference/ingestion-tools/beats-packetbeat/packetbeat-http-options.md#_send_all_headers](beats://reference/packetbeat/packetbeat-http-options.md#_send_all_headers)
 
 **Tags**:
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-3-3-threat-intel-filebeat-module-v8-x-indicator-match.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-3-3-threat-intel-filebeat-module-v8-x-indicator-match.md
@@ -30,7 +30,7 @@ This rule is triggered when indicators from the Threat Intel Filebeat module (v8
 
 **References**:
 
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://docs/reference/filebeat/filebeat-module-threatintel.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://reference/filebeat/filebeat-module-threatintel.md)
 
 **Tags**:
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-3-3-threat-intel-indicator-match.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-3-3-threat-intel-indicator-match.md
@@ -30,7 +30,7 @@ This rule is triggered when indicators from the Threat Intel integrations have a
 
 **References**:
 
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://docs/reference/filebeat/filebeat-module-threatintel.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://reference/filebeat/filebeat-module-threatintel.md)
 
 **Tags**:
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-4-1-default-cobalt-strike-team-server-certificate.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-4-1-default-cobalt-strike-team-server-certificate.md
@@ -30,7 +30,7 @@ This rule detects the use of the default Cobalt Strike Team Server TLS certifica
 
 * [https://attack.mitre.org/software/S0154/](https://attack.mitre.org/software/S0154/)
 * [https://www.cobaltstrike.com/help-setup-collaboration](https://www.cobaltstrike.com/help-setup-collaboration)
-* [/beats/docs/reference/ingestion-tools/beats-packetbeat/configuration-tls.md](beats://docs/reference/packetbeat/configuration-tls.md)
+* [/beats/docs/reference/ingestion-tools/beats-packetbeat/configuration-tls.md](beats://reference/packetbeat/configuration-tls.md)
 * [https://www.elastic.co/guide/en/beats/filebeat/7.9/filebeat-module-suricata.html](https://www.elastic.co/guide/en/beats/filebeat/7.9/filebeat-module-suricata.html)
 * [https://www.elastic.co/guide/en/beats/filebeat/7.9/filebeat-module-zeek.html](https://www.elastic.co/guide/en/beats/filebeat/7.9/filebeat-module-zeek.html)
 * [https://www.elastic.co/security-labs/collecting-cobalt-strike-beacons-with-the-elastic-stack](https://www.elastic.co/security-labs/collecting-cobalt-strike-beacons-with-the-elastic-stack)

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-4-1-hosts-file-modified.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-4-1-hosts-file-modified.md
@@ -28,7 +28,7 @@ The hosts file on endpoints is used to control manual IP address to hostname res
 
 **References**:
 
-* [/beats/docs/reference/ingestion-tools/beats-auditbeat/auditbeat-reference-yml.md](beats://docs/reference/auditbeat/auditbeat-reference-yml.md)
+* [/beats/docs/reference/ingestion-tools/beats-auditbeat/auditbeat-reference-yml.md](beats://reference/auditbeat/auditbeat-reference-yml.md)
 
 **Tags**:
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-4-1-threat-intel-filebeat-module-v8-x-indicator-match.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-4-1-threat-intel-filebeat-module-v8-x-indicator-match.md
@@ -30,7 +30,7 @@ This rule is triggered when indicators from the Threat Intel Filebeat module (v8
 
 **References**:
 
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://docs/reference/filebeat/filebeat-module-threatintel.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://reference/filebeat/filebeat-module-threatintel.md)
 
 **Tags**:
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-4-1-threat-intel-indicator-match.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-4-1-threat-intel-indicator-match.md
@@ -30,7 +30,7 @@ This rule is triggered when indicators from the Threat Intel integrations have a
 
 **References**:
 
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://docs/reference/filebeat/filebeat-module-threatintel.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://reference/filebeat/filebeat-module-threatintel.md)
 
 **Tags**:
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-4-2-default-cobalt-strike-team-server-certificate.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-4-2-default-cobalt-strike-team-server-certificate.md
@@ -30,7 +30,7 @@ This rule detects the use of the default Cobalt Strike Team Server TLS certifica
 
 * [https://attack.mitre.org/software/S0154/](https://attack.mitre.org/software/S0154/)
 * [https://www.cobaltstrike.com/help-setup-collaboration](https://www.cobaltstrike.com/help-setup-collaboration)
-* [/beats/docs/reference/ingestion-tools/beats-packetbeat/configuration-tls.md](beats://docs/reference/packetbeat/configuration-tls.md)
+* [/beats/docs/reference/ingestion-tools/beats-packetbeat/configuration-tls.md](beats://reference/packetbeat/configuration-tls.md)
 * [https://www.elastic.co/guide/en/beats/filebeat/7.9/filebeat-module-suricata.html](https://www.elastic.co/guide/en/beats/filebeat/7.9/filebeat-module-suricata.html)
 * [https://www.elastic.co/guide/en/beats/filebeat/7.9/filebeat-module-zeek.html](https://www.elastic.co/guide/en/beats/filebeat/7.9/filebeat-module-zeek.html)
 * [https://www.elastic.co/security-labs/collecting-cobalt-strike-beacons-with-the-elastic-stack](https://www.elastic.co/security-labs/collecting-cobalt-strike-beacons-with-the-elastic-stack)

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-4-2-hosts-file-modified.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-4-2-hosts-file-modified.md
@@ -28,7 +28,7 @@ The hosts file on endpoints is used to control manual IP address to hostname res
 
 **References**:
 
-* [/beats/docs/reference/ingestion-tools/beats-auditbeat/auditbeat-reference-yml.md](beats://docs/reference/auditbeat/auditbeat-reference-yml.md)
+* [/beats/docs/reference/ingestion-tools/beats-auditbeat/auditbeat-reference-yml.md](beats://reference/auditbeat/auditbeat-reference-yml.md)
 
 **Tags**:
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-4-2-inbound-connection-to-an-unsecure-elasticsearch-node.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-4-2-inbound-connection-to-an-unsecure-elasticsearch-node.md
@@ -29,7 +29,7 @@ Identifies Elasticsearch nodes that do not have Transport Layer Security (TLS), 
 **References**:
 
 * [docs-content://deploy-manage/deploy/self-managed/installing-elasticsearch.md](docs-content://deploy-manage/deploy/self-managed/installing-elasticsearch.md)
-* [/beats/docs/reference/ingestion-tools/beats-packetbeat/packetbeat-http-options.md#_send_all_headers](beats://docs/reference/packetbeat/packetbeat-http-options.md#_send_all_headers)
+* [/beats/docs/reference/ingestion-tools/beats-packetbeat/packetbeat-http-options.md#_send_all_headers](beats://reference/packetbeat/packetbeat-http-options.md#_send_all_headers)
 
 **Tags**:
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-4-2-threat-intel-filebeat-module-v8-x-indicator-match.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-4-2-threat-intel-filebeat-module-v8-x-indicator-match.md
@@ -30,7 +30,7 @@ This rule is triggered when indicators from the Threat Intel Filebeat module (v8
 
 **References**:
 
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://docs/reference/filebeat/filebeat-module-threatintel.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://reference/filebeat/filebeat-module-threatintel.md)
 
 **Tags**:
 

--- a/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-4-2-threat-intel-indicator-match.md
+++ b/docs/reference/prebuilt-rules-downloadable-updates/prebuilt-rule-8-4-2-threat-intel-indicator-match.md
@@ -30,7 +30,7 @@ This rule is triggered when indicators from the Threat Intel integrations have a
 
 **References**:
 
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://docs/reference/filebeat/filebeat-module-threatintel.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://reference/filebeat/filebeat-module-threatintel.md)
 
 **Tags**:
 

--- a/docs/reference/prebuilt-rules/application-added-to-google-workspace-domain.md
+++ b/docs/reference/prebuilt-rules/application-added-to-google-workspace-domain.md
@@ -99,7 +99,7 @@ This rule checks for applications that were manually added to the Marketplace by
 * By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 * See the following references for further information:
 * [https://support.google.com/a/answer/7061566](https://support.google.com/a/answer/7061566)
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://docs/reference/filebeat/filebeat-module-google_workspace.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://reference/filebeat/filebeat-module-google_workspace.md)
 
 
 ## Setup [_setup_78]

--- a/docs/reference/prebuilt-rules/application-removed-from-blocklist-in-google-workspace.md
+++ b/docs/reference/prebuilt-rules/application-removed-from-blocklist-in-google-workspace.md
@@ -99,7 +99,7 @@ This rule identifies a Marketplace blocklist update that consists of a Google Wo
 * By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 * See the following references for further information:
 * [https://support.google.com/a/answer/7061566](https://support.google.com/a/answer/7061566)
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://docs/reference/filebeat/filebeat-module-google_workspace.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://reference/filebeat/filebeat-module-google_workspace.md)
 
 
 ## Setup [_setup_79]

--- a/docs/reference/prebuilt-rules/attempt-to-disable-syslog-service.md
+++ b/docs/reference/prebuilt-rules/attempt-to-disable-syslog-service.md
@@ -122,10 +122,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_158]

--- a/docs/reference/prebuilt-rules/base16-or-base32-encoding-decoding-activity.md
+++ b/docs/reference/prebuilt-rules/base16-or-base32-encoding-decoding-activity.md
@@ -123,10 +123,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_214]

--- a/docs/reference/prebuilt-rules/connection-to-external-network-via-telnet.md
+++ b/docs/reference/prebuilt-rules/connection-to-external-network-via-telnet.md
@@ -117,10 +117,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_241]

--- a/docs/reference/prebuilt-rules/connection-to-internal-network-via-telnet.md
+++ b/docs/reference/prebuilt-rules/connection-to-internal-network-via-telnet.md
@@ -118,10 +118,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_242]

--- a/docs/reference/prebuilt-rules/creation-of-hidden-files-and-directories-via-commandline.md
+++ b/docs/reference/prebuilt-rules/creation-of-hidden-files-and-directories-via-commandline.md
@@ -114,10 +114,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Custom Ingest Pipeline**
 

--- a/docs/reference/prebuilt-rules/creation-of-hidden-shared-object-file.md
+++ b/docs/reference/prebuilt-rules/creation-of-hidden-shared-object-file.md
@@ -118,10 +118,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Custom Ingest Pipeline**
 

--- a/docs/reference/prebuilt-rules/default-cobalt-strike-team-server-certificate.md
+++ b/docs/reference/prebuilt-rules/default-cobalt-strike-team-server-certificate.md
@@ -30,7 +30,7 @@ This rule detects the use of the default Cobalt Strike Team Server TLS certifica
 
 * [https://attack.mitre.org/software/S0154/](https://attack.mitre.org/software/S0154/)
 * [https://www.cobaltstrike.com/help-setup-collaboration](https://www.cobaltstrike.com/help-setup-collaboration)
-* [/beats/docs/reference/ingestion-tools/beats-packetbeat/configuration-tls.md](beats://docs/reference/packetbeat/configuration-tls.md)
+* [/beats/docs/reference/ingestion-tools/beats-packetbeat/configuration-tls.md](beats://reference/packetbeat/configuration-tls.md)
 * [https://www.elastic.co/guide/en/beats/filebeat/7.9/filebeat-module-suricata.html](https://www.elastic.co/guide/en/beats/filebeat/7.9/filebeat-module-suricata.html)
 * [https://www.elastic.co/guide/en/beats/filebeat/7.9/filebeat-module-zeek.html](https://www.elastic.co/guide/en/beats/filebeat/7.9/filebeat-module-zeek.html)
 * [https://www.elastic.co/security-labs/collecting-cobalt-strike-beacons-with-the-elastic-stack](https://www.elastic.co/security-labs/collecting-cobalt-strike-beacons-with-the-elastic-stack)

--- a/docs/reference/prebuilt-rules/domain-added-to-google-workspace-trusted-domains.md
+++ b/docs/reference/prebuilt-rules/domain-added-to-google-workspace-trusted-domains.md
@@ -96,7 +96,7 @@ This rule detects when a third-party domain is added to the list of trusted doma
 * By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 * See the following references for further information:
 * [https://support.google.com/a/answer/7061566](https://support.google.com/a/answer/7061566)
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://docs/reference/filebeat/filebeat-module-google_workspace.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://reference/filebeat/filebeat-module-google_workspace.md)
 
 
 ## Setup [_setup_176]

--- a/docs/reference/prebuilt-rules/external-user-added-to-google-workspace-group.md
+++ b/docs/reference/prebuilt-rules/external-user-added-to-google-workspace-group.md
@@ -102,7 +102,7 @@ This rule identifies when an external user account is added to an organizationâ€
 * By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 * See the following references for further information:
 * [https://support.google.com/a/answer/7061566](https://support.google.com/a/answer/7061566)
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://docs/reference/filebeat/filebeat-module-google_workspace.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://reference/filebeat/filebeat-module-google_workspace.md)
 
 
 ## Setup [_setup_204]

--- a/docs/reference/prebuilt-rules/file-made-immutable-by-chattr.md
+++ b/docs/reference/prebuilt-rules/file-made-immutable-by-chattr.md
@@ -118,10 +118,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Custom Ingest Pipeline**
 

--- a/docs/reference/prebuilt-rules/file-permission-modification-in-writable-directory.md
+++ b/docs/reference/prebuilt-rules/file-permission-modification-in-writable-directory.md
@@ -113,10 +113,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_353]

--- a/docs/reference/prebuilt-rules/file-transfer-or-listener-established-via-netcat.md
+++ b/docs/reference/prebuilt-rules/file-transfer-or-listener-established-via-netcat.md
@@ -128,10 +128,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_356]

--- a/docs/reference/prebuilt-rules/first-time-seen-google-workspace-oauth-login-from-third-party-application.md
+++ b/docs/reference/prebuilt-rules/first-time-seen-google-workspace-oauth-login-from-third-party-application.md
@@ -92,7 +92,7 @@ OAuth is a protocol that allows third-party applications to access user data wit
 * By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 * See the following references for further information:
 * [https://support.google.com/a/answer/7061566](https://support.google.com/a/answer/7061566)
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://docs/reference/filebeat/filebeat-module-google_workspace.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://reference/filebeat/filebeat-module-google_workspace.md)
 
 
 ## Setup [_setup_214]

--- a/docs/reference/prebuilt-rules/google-drive-ownership-transferred-via-google-workspace.md
+++ b/docs/reference/prebuilt-rules/google-drive-ownership-transferred-via-google-workspace.md
@@ -95,7 +95,7 @@ This rule identifies when the ownership of a shared drive within a Google Worksp
 * By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 * See the following references for further information:
 * [https://support.google.com/a/answer/7061566](https://support.google.com/a/answer/7061566)
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://docs/reference/filebeat/filebeat-module-google_workspace.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://reference/filebeat/filebeat-module-google_workspace.md)
 
 
 ## Setup [_setup_246]

--- a/docs/reference/prebuilt-rules/google-workspace-2sv-policy-disabled.md
+++ b/docs/reference/prebuilt-rules/google-workspace-2sv-policy-disabled.md
@@ -97,7 +97,7 @@ This rule detects when a 2SV policy is disabled in Google Workspace.
 * By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 * See the following references for further information:
 * [https://support.google.com/a/answer/7061566](https://support.google.com/a/answer/7061566)
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://docs/reference/filebeat/filebeat-module-google_workspace.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://reference/filebeat/filebeat-module-google_workspace.md)
 
 
 ## Setup [_setup_247]

--- a/docs/reference/prebuilt-rules/google-workspace-admin-role-assigned-to-a-user.md
+++ b/docs/reference/prebuilt-rules/google-workspace-admin-role-assigned-to-a-user.md
@@ -101,7 +101,7 @@ This rule identifies when a Google Workspace administrative role is assigned to 
 * By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 * See the following references for further information:
 * [https://support.google.com/a/answer/7061566](https://support.google.com/a/answer/7061566)
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://docs/reference/filebeat/filebeat-module-google_workspace.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://reference/filebeat/filebeat-module-google_workspace.md)
 
 
 ## Setup [_setup_249]

--- a/docs/reference/prebuilt-rules/google-workspace-admin-role-deletion.md
+++ b/docs/reference/prebuilt-rules/google-workspace-admin-role-deletion.md
@@ -96,7 +96,7 @@ This rule identifies when a Google Workspace administrative role is deleted with
 * By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 * See the following references for further information:
 * [https://support.google.com/a/answer/7061566](https://support.google.com/a/answer/7061566)
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://docs/reference/filebeat/filebeat-module-google_workspace.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://reference/filebeat/filebeat-module-google_workspace.md)
 
 
 ## Setup [_setup_250]

--- a/docs/reference/prebuilt-rules/google-workspace-api-access-granted-via-domain-wide-delegation.md
+++ b/docs/reference/prebuilt-rules/google-workspace-api-access-granted-via-domain-wide-delegation.md
@@ -97,7 +97,7 @@ This rule identifies when an application is authorized API client access.
 * By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 * See the following references for further information:
 * [https://support.google.com/a/answer/7061566](https://support.google.com/a/answer/7061566)
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://docs/reference/filebeat/filebeat-module-google_workspace.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://reference/filebeat/filebeat-module-google_workspace.md)
 
 
 ## Setup [_setup_248]

--- a/docs/reference/prebuilt-rules/google-workspace-bitlocker-setting-disabled.md
+++ b/docs/reference/prebuilt-rules/google-workspace-bitlocker-setting-disabled.md
@@ -94,7 +94,7 @@ This rule identifies a user with administrative privileges and access to the adm
 * By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 * See the following references for further information:
 * [https://support.google.com/a/answer/7061566](https://support.google.com/a/answer/7061566)
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://docs/reference/filebeat/filebeat-module-google_workspace.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://reference/filebeat/filebeat-module-google_workspace.md)
 
 
 ## Setup [_setup_251]

--- a/docs/reference/prebuilt-rules/google-workspace-custom-admin-role-created.md
+++ b/docs/reference/prebuilt-rules/google-workspace-custom-admin-role-created.md
@@ -101,7 +101,7 @@ This rule identifies when a Google Workspace administrative role is added within
 * By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 * See the following references for further information:
 * [https://support.google.com/a/answer/7061566](https://support.google.com/a/answer/7061566)
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://docs/reference/filebeat/filebeat-module-google_workspace.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://reference/filebeat/filebeat-module-google_workspace.md)
 
 
 ## Setup [_setup_252]

--- a/docs/reference/prebuilt-rules/google-workspace-custom-gmail-route-created-or-modified.md
+++ b/docs/reference/prebuilt-rules/google-workspace-custom-gmail-route-created-or-modified.md
@@ -94,7 +94,7 @@ This rule identifies the creation of a custom global Gmail route by an administr
 * By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 * See the following references for further information:
 * [https://support.google.com/a/answer/7061566](https://support.google.com/a/answer/7061566)
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://docs/reference/filebeat/filebeat-module-google_workspace.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://reference/filebeat/filebeat-module-google_workspace.md)
 
 
 ## Setup [_setup_253]

--- a/docs/reference/prebuilt-rules/google-workspace-drive-encryption-key-s-accessed-from-anonymous-user.md
+++ b/docs/reference/prebuilt-rules/google-workspace-drive-encryption-key-s-accessed-from-anonymous-user.md
@@ -90,7 +90,7 @@ Google Workspace Drive allows users to store and share files, including sensitiv
 * By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 * See the following references for further information:
 * [https://support.google.com/a/answer/7061566](https://support.google.com/a/answer/7061566)
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://docs/reference/filebeat/filebeat-module-google_workspace.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://reference/filebeat/filebeat-module-google_workspace.md)
 
 
 ## Setup [_setup_254]

--- a/docs/reference/prebuilt-rules/google-workspace-mfa-enforcement-disabled.md
+++ b/docs/reference/prebuilt-rules/google-workspace-mfa-enforcement-disabled.md
@@ -97,7 +97,7 @@ This rule identifies the disabling of MFA enforcement in Google Workspace. This 
 * By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 * See the following references for further information:
 * [https://support.google.com/a/answer/7061566](https://support.google.com/a/answer/7061566)
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://docs/reference/filebeat/filebeat-module-google_workspace.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://reference/filebeat/filebeat-module-google_workspace.md)
 
 
 ## Setup [_setup_255]

--- a/docs/reference/prebuilt-rules/google-workspace-object-copied-to-external-drive-with-app-consent.md
+++ b/docs/reference/prebuilt-rules/google-workspace-object-copied-to-external-drive-with-app-consent.md
@@ -102,7 +102,7 @@ This rule aims to detect when a user copies an external Drive object to their Dr
 * By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 * See the following references for further information:
 * [https://support.google.com/a/answer/7061566](https://support.google.com/a/answer/7061566)
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://docs/reference/filebeat/filebeat-module-google_workspace.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://reference/filebeat/filebeat-module-google_workspace.md)
 
 
 ## Setup [_setup_256]

--- a/docs/reference/prebuilt-rules/google-workspace-password-policy-modified.md
+++ b/docs/reference/prebuilt-rules/google-workspace-password-policy-modified.md
@@ -99,7 +99,7 @@ This rule detects when a Google Workspace password policy is modified to decreas
 * By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 * See the following references for further information:
 * [https://support.google.com/a/answer/7061566](https://support.google.com/a/answer/7061566)
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://docs/reference/filebeat/filebeat-module-google_workspace.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://reference/filebeat/filebeat-module-google_workspace.md)
 
 
 ## Setup [_setup_257]

--- a/docs/reference/prebuilt-rules/google-workspace-restrictions-for-marketplace-modified-to-allow-any-app.md
+++ b/docs/reference/prebuilt-rules/google-workspace-restrictions-for-marketplace-modified-to-allow-any-app.md
@@ -100,7 +100,7 @@ This rule identifies when the global allow-all setting is enabled for Google Wor
 * By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 * See the following references for further information:
 * [https://support.google.com/a/answer/7061566](https://support.google.com/a/answer/7061566)
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://docs/reference/filebeat/filebeat-module-google_workspace.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://reference/filebeat/filebeat-module-google_workspace.md)
 
 
 ## Setup [_setup_258]

--- a/docs/reference/prebuilt-rules/google-workspace-role-modified.md
+++ b/docs/reference/prebuilt-rules/google-workspace-role-modified.md
@@ -103,7 +103,7 @@ This rule identifies when a Google Workspace role is modified.
 * By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 * See the following references for further information:
 * [https://support.google.com/a/answer/7061566](https://support.google.com/a/answer/7061566)
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://docs/reference/filebeat/filebeat-module-google_workspace.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://reference/filebeat/filebeat-module-google_workspace.md)
 
 
 ## Setup [_setup_259]

--- a/docs/reference/prebuilt-rules/google-workspace-suspended-user-account-renewed.md
+++ b/docs/reference/prebuilt-rules/google-workspace-suspended-user-account-renewed.md
@@ -87,7 +87,7 @@ Google Workspace manages user identities and access, crucial for organizational 
 * By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 * See the following references for further information:
 * [https://support.google.com/a/answer/7061566](https://support.google.com/a/answer/7061566)
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://docs/reference/filebeat/filebeat-module-google_workspace.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://reference/filebeat/filebeat-module-google_workspace.md)
 
 
 ## Setup [_setup_260]

--- a/docs/reference/prebuilt-rules/google-workspace-user-organizational-unit-changed.md
+++ b/docs/reference/prebuilt-rules/google-workspace-user-organizational-unit-changed.md
@@ -100,7 +100,7 @@ This rule identifies when a user has been moved to a different organizational un
 * By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 * See the following references for further information:
 * [https://support.google.com/a/answer/7061566](https://support.google.com/a/answer/7061566)
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://docs/reference/filebeat/filebeat-module-google_workspace.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://reference/filebeat/filebeat-module-google_workspace.md)
 
 
 ## Setup [_setup_261]

--- a/docs/reference/prebuilt-rules/hosts-file-modified.md
+++ b/docs/reference/prebuilt-rules/hosts-file-modified.md
@@ -28,7 +28,7 @@ The hosts file on endpoints is used to control manual IP address to hostname res
 
 **References**:
 
-* [/beats/docs/reference/ingestion-tools/beats-auditbeat/auditbeat-reference-yml.md](beats://docs/reference/auditbeat/auditbeat-reference-yml.md)
+* [/beats/docs/reference/ingestion-tools/beats-auditbeat/auditbeat-reference-yml.md](beats://reference/auditbeat/auditbeat-reference-yml.md)
 
 **Tags**:
 

--- a/docs/reference/prebuilt-rules/hping-process-activity.md
+++ b/docs/reference/prebuilt-rules/hping-process-activity.md
@@ -125,10 +125,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_450]

--- a/docs/reference/prebuilt-rules/inbound-connection-to-an-unsecure-elasticsearch-node.md
+++ b/docs/reference/prebuilt-rules/inbound-connection-to-an-unsecure-elasticsearch-node.md
@@ -27,7 +27,7 @@ Identifies Elasticsearch nodes that do not have Transport Layer Security (TLS), 
 **References**:
 
 * [docs-content://deploy-manage/deploy/self-managed/installing-elasticsearch.md](docs-content://deploy-manage/deploy/self-managed/installing-elasticsearch.md)
-* [/beats/docs/reference/ingestion-tools/beats-packetbeat/packetbeat-http-options.md#_send_all_headers](beats://docs/reference/packetbeat/packetbeat-http-options.md#_send_all_headers)
+* [/beats/docs/reference/ingestion-tools/beats-packetbeat/packetbeat-http-options.md#_send_all_headers](beats://reference/packetbeat/packetbeat-http-options.md#_send_all_headers)
 
 **Tags**:
 

--- a/docs/reference/prebuilt-rules/interactive-terminal-spawned-via-perl.md
+++ b/docs/reference/prebuilt-rules/interactive-terminal-spawned-via-perl.md
@@ -116,10 +116,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_474]

--- a/docs/reference/prebuilt-rules/linux-group-creation.md
+++ b/docs/reference/prebuilt-rules/linux-group-creation.md
@@ -104,17 +104,17 @@ Filebeat is a lightweight shipper for forwarding and centralizing log data. Inst
 **The following steps should be executed in order to add the Filebeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/filebeat/setup-repositories.md).
-* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-docker.md).
-* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-kubernetes.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/filebeat/setup-repositories.md).
+* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-docker.md).
+* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-kubernetes.md).
 * For quick start information for Filebeat refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/8.11/filebeat-installation-configuration.html).
-* For complete “Setup and Run Filebeat” information refer to the [helper guide](beats://docs/reference/filebeat/setting-up-running.md).
+* For complete “Setup and Run Filebeat” information refer to the [helper guide](beats://reference/filebeat/setting-up-running.md).
 
 **Rule Specific Setup Note**
 
 * This rule requires the “Filebeat System Module” to be enabled.
 * The system module collects and parses logs created by the system logging service of common Unix/Linux based distributions.
-* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/filebeat-module-system.md).
+* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://reference/filebeat/filebeat-module-system.md).
 
 
 ## Rule query [_rule_query_509]

--- a/docs/reference/prebuilt-rules/linux-user-account-creation.md
+++ b/docs/reference/prebuilt-rules/linux-user-account-creation.md
@@ -103,17 +103,17 @@ Filebeat is a lightweight shipper for forwarding and centralizing log data. Inst
 **The following steps should be executed in order to add the Filebeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/filebeat/setup-repositories.md).
-* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-docker.md).
-* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-kubernetes.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/filebeat/setup-repositories.md).
+* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-docker.md).
+* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-kubernetes.md).
 * For quick start information for Filebeat refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/8.11/filebeat-installation-configuration.html).
-* For complete “Setup and Run Filebeat” information refer to the [helper guide](beats://docs/reference/filebeat/setting-up-running.md).
+* For complete “Setup and Run Filebeat” information refer to the [helper guide](beats://reference/filebeat/setting-up-running.md).
 
 **Rule Specific Setup Note**
 
 * This rule requires the “Filebeat System Module” to be enabled.
 * The system module collects and parses logs created by the system logging service of common Unix/Linux based distributions.
-* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/filebeat-module-system.md).
+* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://reference/filebeat/filebeat-module-system.md).
 
 
 ## Rule query [_rule_query_515]

--- a/docs/reference/prebuilt-rules/login-via-unusual-system-user.md
+++ b/docs/reference/prebuilt-rules/login-via-unusual-system-user.md
@@ -97,17 +97,17 @@ Filebeat is a lightweight shipper for forwarding and centralizing log data. Inst
 **The following steps should be executed in order to add the Filebeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/filebeat/setup-repositories.md).
-* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-docker.md).
-* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-kubernetes.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/filebeat/setup-repositories.md).
+* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-docker.md).
+* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-kubernetes.md).
 * For quick start information for Filebeat refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/8.11/filebeat-installation-configuration.html).
-* For complete “Setup and Run Filebeat” information refer to the [helper guide](beats://docs/reference/filebeat/setting-up-running.md).
+* For complete “Setup and Run Filebeat” information refer to the [helper guide](beats://reference/filebeat/setting-up-running.md).
 
 **Rule Specific Setup Note**
 
 * This rule requires the “Filebeat System Module” to be enabled.
 * The system module collects and parses logs created by the system logging service of common Unix/Linux based distributions.
-* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/filebeat-module-system.md).
+* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://reference/filebeat/filebeat-module-system.md).
 
 
 ## Rule query [_rule_query_521]

--- a/docs/reference/prebuilt-rules/machine-learning-detected-a-dns-request-predicted-to-be-a-dga-domain.md
+++ b/docs/reference/prebuilt-rules/machine-learning-detected-a-dns-request-predicted-to-be-a-dga-domain.md
@@ -100,10 +100,10 @@ The DGA Detection integration consists of an ML-based framework to detect DGA ac
 
 * Fleet is required for DGA Detection.
 * To configure Fleet Server refer to the [documentation](docs-content://reference/ingestion-tools/fleet/fleet-server.md).
-* DNS events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint), [Network Packet Capture](https://docs.elastic.co/integrations/network_traffic) integration, or [Packetbeat](beats://docs/reference/packetbeat/packetbeat-overview.md).
+* DNS events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint), [Network Packet Capture](https://docs.elastic.co/integrations/network_traffic) integration, or [Packetbeat](beats://reference/packetbeat/packetbeat-overview.md).
 * To install Elastic Defend, refer to the [documentation](docs-content://solutions/security/configure-elastic-defend/install-elastic-defend.md).
 * To add the Network Packet Capture integration to an Elastic Agent policy, refer to [this](docs-content://reference/ingestion-tools/fleet/add-integration-to-policy.md) guide.
-* To set up and run Packetbeat, follow [this](beats://docs/reference/packetbeat/setting-up-running.md) guide.
+* To set up and run Packetbeat, follow [this](beats://reference/packetbeat/setting-up-running.md) guide.
 
 **The following steps should be executed to install assets associated with the DGA Detection integration:**
 

--- a/docs/reference/prebuilt-rules/machine-learning-detected-a-dns-request-with-a-high-dga-probability-score.md
+++ b/docs/reference/prebuilt-rules/machine-learning-detected-a-dns-request-with-a-high-dga-probability-score.md
@@ -99,10 +99,10 @@ The DGA Detection integration consists of an ML-based framework to detect DGA ac
 
 * Fleet is required for DGA Detection.
 * To configure Fleet Server refer to the [documentation](docs-content://reference/ingestion-tools/fleet/fleet-server.md).
-* DNS events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint), [Network Packet Capture](https://docs.elastic.co/integrations/network_traffic) integration, or [Packetbeat](beats://docs/reference/packetbeat/packetbeat-overview.md).
+* DNS events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint), [Network Packet Capture](https://docs.elastic.co/integrations/network_traffic) integration, or [Packetbeat](beats://reference/packetbeat/packetbeat-overview.md).
 * To install Elastic Defend, refer to the [documentation](docs-content://solutions/security/configure-elastic-defend/install-elastic-defend.md).
 * To add the Network Packet Capture integration to an Elastic Agent policy, refer to [this](docs-content://reference/ingestion-tools/fleet/add-integration-to-policy.md) guide.
-* To set up and run Packetbeat, follow [this](beats://docs/reference/packetbeat/setting-up-running.md) guide.
+* To set up and run Packetbeat, follow [this](beats://reference/packetbeat/setting-up-running.md) guide.
 
 **The following steps should be executed to install assets associated with the DGA Detection integration:**
 

--- a/docs/reference/prebuilt-rules/machine-learning-detected-a-suspicious-windows-event-with-a-high-malicious-probability-score.md
+++ b/docs/reference/prebuilt-rules/machine-learning-detected-a-suspicious-windows-event-with-a-high-malicious-probability-score.md
@@ -101,9 +101,9 @@ The LotL Attack Detection integration detects living-off-the-land activity in Wi
 
 * Fleet is required for LotL Attack Detection.
 * To configure Fleet Server refer to the [documentation](docs-content://reference/ingestion-tools/fleet/fleet-server.md).
-* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://docs/reference/winlogbeat/_winlogbeat_overview.md)).
+* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://reference/winlogbeat/_winlogbeat_overview.md)).
 * To install Elastic Defend, refer to the [documentation](docs-content://solutions/security/configure-elastic-defend/install-elastic-defend.md).
-* To set up and run Winlogbeat, follow [this](beats://docs/reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
+* To set up and run Winlogbeat, follow [this](beats://reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
 
 **The following steps should be executed to install assets associated with the LotL Attack Detection integration:**
 

--- a/docs/reference/prebuilt-rules/machine-learning-detected-a-suspicious-windows-event-with-a-low-malicious-probability-score.md
+++ b/docs/reference/prebuilt-rules/machine-learning-detected-a-suspicious-windows-event-with-a-low-malicious-probability-score.md
@@ -101,9 +101,9 @@ The LotL Attack Detection integration detects living-off-the-land activity in Wi
 
 * Fleet is required for LotL Attack Detection.
 * To configure Fleet Server refer to the [documentation](docs-content://reference/ingestion-tools/fleet/fleet-server.md).
-* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://docs/reference/winlogbeat/_winlogbeat_overview.md)).
+* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://reference/winlogbeat/_winlogbeat_overview.md)).
 * To install Elastic Defend, refer to the [documentation](docs-content://solutions/security/configure-elastic-defend/install-elastic-defend.md).
-* To set up and run Winlogbeat, follow [this](beats://docs/reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
+* To set up and run Winlogbeat, follow [this](beats://reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
 
 **The following steps should be executed to install assets associated with the LotL Attack Detection integration:**
 

--- a/docs/reference/prebuilt-rules/machine-learning-detected-dga-activity-using-a-known-sunburst-dns-domain.md
+++ b/docs/reference/prebuilt-rules/machine-learning-detected-dga-activity-using-a-known-sunburst-dns-domain.md
@@ -100,10 +100,10 @@ The DGA Detection integration consists of an ML-based framework to detect DGA ac
 
 * Fleet is required for DGA Detection.
 * To configure Fleet Server refer to the [documentation](docs-content://reference/ingestion-tools/fleet/fleet-server.md).
-* DNS events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint), [Network Packet Capture](https://docs.elastic.co/integrations/network_traffic) integration, or [Packetbeat](beats://docs/reference/packetbeat/packetbeat-overview.md).
+* DNS events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint), [Network Packet Capture](https://docs.elastic.co/integrations/network_traffic) integration, or [Packetbeat](beats://reference/packetbeat/packetbeat-overview.md).
 * To install Elastic Defend, refer to the [documentation](docs-content://solutions/security/configure-elastic-defend/install-elastic-defend.md).
 * To add the Network Packet Capture integration to an Elastic Agent policy, refer to [this](docs-content://reference/ingestion-tools/fleet/add-integration-to-policy.md) guide.
-* To set up and run Packetbeat, follow [this](beats://docs/reference/packetbeat/setting-up-running.md) guide.
+* To set up and run Packetbeat, follow [this](beats://reference/packetbeat/setting-up-running.md) guide.
 
 **The following steps should be executed to install assets associated with the DGA Detection integration:**
 

--- a/docs/reference/prebuilt-rules/mfa-disabled-for-google-workspace-organization.md
+++ b/docs/reference/prebuilt-rules/mfa-disabled-for-google-workspace-organization.md
@@ -97,7 +97,7 @@ This rule identifies when MFA enforcement is turned off in Google Workspace. Thi
 * By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 * See the following references for further information:
 * [https://support.google.com/a/answer/7061566](https://support.google.com/a/answer/7061566)
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://docs/reference/filebeat/filebeat-module-google_workspace.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-google_workspace.md](beats://reference/filebeat/filebeat-module-google_workspace.md)
 
 
 ## Setup [_setup_312]

--- a/docs/reference/prebuilt-rules/modification-of-dynamic-linker-preload-shared-object.md
+++ b/docs/reference/prebuilt-rules/modification-of-dynamic-linker-preload-shared-object.md
@@ -119,10 +119,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_580]

--- a/docs/reference/prebuilt-rules/modification-of-openssh-binaries.md
+++ b/docs/reference/prebuilt-rules/modification-of-openssh-binaries.md
@@ -143,10 +143,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_583]

--- a/docs/reference/prebuilt-rules/namespace-manipulation-using-unshare.md
+++ b/docs/reference/prebuilt-rules/namespace-manipulation-using-unshare.md
@@ -120,10 +120,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_609]

--- a/docs/reference/prebuilt-rules/network-connections-initiated-through-xdg-autostart-entry.md
+++ b/docs/reference/prebuilt-rules/network-connections-initiated-through-xdg-autostart-entry.md
@@ -117,10 +117,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Custom Ingest Pipeline**
 

--- a/docs/reference/prebuilt-rules/nping-process-activity.md
+++ b/docs/reference/prebuilt-rules/nping-process-activity.md
@@ -125,10 +125,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_637]

--- a/docs/reference/prebuilt-rules/persistence-via-kde-autostart-script-or-desktop-file-modification.md
+++ b/docs/reference/prebuilt-rules/persistence-via-kde-autostart-script-or-desktop-file-modification.md
@@ -149,10 +149,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Custom Ingest Pipeline**
 

--- a/docs/reference/prebuilt-rules/potential-dga-activity.md
+++ b/docs/reference/prebuilt-rules/potential-dga-activity.md
@@ -93,10 +93,10 @@ The DGA Detection integration consists of an ML-based framework to detect DGA ac
 
 * Fleet is required for DGA Detection.
 * To configure Fleet Server refer to the [documentation](docs-content://reference/ingestion-tools/fleet/fleet-server.md).
-* DNS events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint), [Network Packet Capture](https://docs.elastic.co/integrations/network_traffic) integration, or [Packetbeat](beats://docs/reference/packetbeat/packetbeat-overview.md).
+* DNS events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint), [Network Packet Capture](https://docs.elastic.co/integrations/network_traffic) integration, or [Packetbeat](beats://reference/packetbeat/packetbeat-overview.md).
 * To install Elastic Defend, refer to the [documentation](docs-content://solutions/security/configure-elastic-defend/install-elastic-defend.md).
 * To add the Network Packet Capture integration to an Elastic Agent policy, refer to [this](docs-content://reference/ingestion-tools/fleet/add-integration-to-policy.md) guide.
-* To set up and run Packetbeat, follow [this](beats://docs/reference/packetbeat/setting-up-running.md) guide.
+* To set up and run Packetbeat, follow [this](beats://reference/packetbeat/setting-up-running.md) guide.
 
 **The following steps should be executed to install assets associated with the DGA Detection integration:**
 

--- a/docs/reference/prebuilt-rules/potential-disabling-of-selinux.md
+++ b/docs/reference/prebuilt-rules/potential-disabling-of-selinux.md
@@ -122,10 +122,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_715]

--- a/docs/reference/prebuilt-rules/potential-external-linux-ssh-brute-force-detected.md
+++ b/docs/reference/prebuilt-rules/potential-external-linux-ssh-brute-force-detected.md
@@ -95,17 +95,17 @@ Filebeat is a lightweight shipper for forwarding and centralizing log data. Inst
 **The following steps should be executed in order to add the Filebeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/filebeat/setup-repositories.md).
-* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-docker.md).
-* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-kubernetes.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/filebeat/setup-repositories.md).
+* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-docker.md).
+* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-kubernetes.md).
 * For quick start information for Filebeat refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/8.11/filebeat-installation-configuration.html).
-* For complete “Setup and Run Filebeat” information refer to the [helper guide](beats://docs/reference/filebeat/setting-up-running.md).
+* For complete “Setup and Run Filebeat” information refer to the [helper guide](beats://reference/filebeat/setting-up-running.md).
 
 **Rule Specific Setup Note**
 
 * This rule requires the “Filebeat System Module” to be enabled.
 * The system module collects and parses logs created by the system logging service of common Unix/Linux based distributions.
-* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/filebeat-module-system.md).
+* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://reference/filebeat/filebeat-module-system.md).
 
 
 ## Rule query [_rule_query_723]

--- a/docs/reference/prebuilt-rules/potential-internal-linux-ssh-brute-force-detected.md
+++ b/docs/reference/prebuilt-rules/potential-internal-linux-ssh-brute-force-detected.md
@@ -91,17 +91,17 @@ Filebeat is a lightweight shipper for forwarding and centralizing log data. Inst
 **The following steps should be executed in order to add the Filebeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/filebeat/setup-repositories.md).
-* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-docker.md).
-* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-kubernetes.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/filebeat/setup-repositories.md).
+* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-docker.md).
+* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-kubernetes.md).
 * For quick start information for Filebeat refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/8.11/filebeat-installation-configuration.html).
-* For complete “Setup and Run Filebeat” information refer to the [helper guide](beats://docs/reference/filebeat/setting-up-running.md).
+* For complete “Setup and Run Filebeat” information refer to the [helper guide](beats://reference/filebeat/setting-up-running.md).
 
 **Rule Specific Setup Note**
 
 * This rule requires the “Filebeat System Module” to be enabled.
 * The system module collects and parses logs created by the system logging service of common Unix/Linux based distributions.
-* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/filebeat-module-system.md).
+* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://reference/filebeat/filebeat-module-system.md).
 
 
 ## Rule query [_rule_query_731]

--- a/docs/reference/prebuilt-rules/potential-meterpreter-reverse-shell.md
+++ b/docs/reference/prebuilt-rules/potential-meterpreter-reverse-shell.md
@@ -95,10 +95,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Auditd Manager Integration Setup**
 

--- a/docs/reference/prebuilt-rules/potential-openssh-backdoor-logging-activity.md
+++ b/docs/reference/prebuilt-rules/potential-openssh-backdoor-logging-activity.md
@@ -123,10 +123,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Custom Ingest Pipeline**
 

--- a/docs/reference/prebuilt-rules/potential-protocol-tunneling-via-earthworm.md
+++ b/docs/reference/prebuilt-rules/potential-protocol-tunneling-via-earthworm.md
@@ -148,10 +148,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Custom Ingest Pipeline**
 

--- a/docs/reference/prebuilt-rules/potential-reverse-shell-via-udp.md
+++ b/docs/reference/prebuilt-rules/potential-reverse-shell-via-udp.md
@@ -97,10 +97,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Auditd Manager Integration Setup**
 

--- a/docs/reference/prebuilt-rules/potential-successful-linux-ftp-brute-force-attack-detected.md
+++ b/docs/reference/prebuilt-rules/potential-successful-linux-ftp-brute-force-attack-detected.md
@@ -91,10 +91,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Auditd Manager Integration Setup**
 

--- a/docs/reference/prebuilt-rules/potential-successful-linux-rdp-brute-force-attack-detected.md
+++ b/docs/reference/prebuilt-rules/potential-successful-linux-rdp-brute-force-attack-detected.md
@@ -92,10 +92,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Auditd Manager Integration Setup**
 

--- a/docs/reference/prebuilt-rules/potential-successful-ssh-brute-force-attack.md
+++ b/docs/reference/prebuilt-rules/potential-successful-ssh-brute-force-attack.md
@@ -88,10 +88,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Filebeat Setup**
 
@@ -100,17 +100,17 @@ Filebeat is a lightweight shipper for forwarding and centralizing log data. Inst
 **The following steps should be executed in order to add the Filebeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/filebeat/setup-repositories.md).
-* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-docker.md).
-* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-kubernetes.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/filebeat/setup-repositories.md).
+* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-docker.md).
+* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-kubernetes.md).
 * For quick start information for Filebeat refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/8.11/filebeat-installation-configuration.html).
-* For complete “Setup and Run Filebeat” information refer to the [helper guide](beats://docs/reference/filebeat/setting-up-running.md).
+* For complete “Setup and Run Filebeat” information refer to the [helper guide](beats://reference/filebeat/setting-up-running.md).
 
 **Rule Specific Setup Note**
 
 * This rule requires the “Filebeat System Module” to be enabled.
 * The system module collects and parses logs created by the system logging service of common Unix/Linux based distributions.
-* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/filebeat-module-system.md).
+* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://reference/filebeat/filebeat-module-system.md).
 
 
 ## Rule query [_rule_query_825]

--- a/docs/reference/prebuilt-rules/process-backgrounded-by-unusual-parent.md
+++ b/docs/reference/prebuilt-rules/process-backgrounded-by-unusual-parent.md
@@ -120,10 +120,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_882]

--- a/docs/reference/prebuilt-rules/process-started-with-executable-stack.md
+++ b/docs/reference/prebuilt-rules/process-started-with-executable-stack.md
@@ -91,17 +91,17 @@ Filebeat is a lightweight shipper for forwarding and centralizing log data. Inst
 **The following steps should be executed in order to add the Filebeat for the Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/filebeat/setup-repositories.md).
-* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-docker.md).
-* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-kubernetes.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/filebeat/setup-repositories.md).
+* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-docker.md).
+* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-kubernetes.md).
 * For quick start information for Filebeat refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/8.11/filebeat-installation-configuration.html).
-* For complete Setup and Run Filebeat information refer to the [helper guide](beats://docs/reference/filebeat/setting-up-running.md).
+* For complete Setup and Run Filebeat information refer to the [helper guide](beats://reference/filebeat/setting-up-running.md).
 
 **Rule Specific Setup Note**
 
 * This rule requires the Filebeat System Module to be enabled.
 * The system module collects and parses logs created by the system logging service of common Unix/Linux based distributions.
-* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/filebeat-module-system.md).
+* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://reference/filebeat/filebeat-module-system.md).
 
 
 ## Rule query [_rule_query_896]

--- a/docs/reference/prebuilt-rules/rapid7-threat-command-cves-correlation.md
+++ b/docs/reference/prebuilt-rules/rapid7-threat-command-cves-correlation.md
@@ -30,7 +30,7 @@ This rule is triggered when CVEs collected from the Rapid7 Threat Command Integr
 
 **References**:
 
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://docs/reference/filebeat/filebeat-module-threatintel.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://reference/filebeat/filebeat-module-threatintel.md)
 * [https://docs.elastic.co/integrations/ti_rapid7_threat_command](https://docs.elastic.co/integrations/ti_rapid7_threat_command)
 
 **Tags**:

--- a/docs/reference/prebuilt-rules/segfault-detected.md
+++ b/docs/reference/prebuilt-rules/segfault-detected.md
@@ -54,17 +54,17 @@ Filebeat is a lightweight shipper for forwarding and centralizing log data. Inst
 **The following steps should be executed in order to add the Filebeat for the Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/filebeat/setup-repositories.md).
-* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-docker.md).
-* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-kubernetes.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/filebeat/setup-repositories.md).
+* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-docker.md).
+* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-kubernetes.md).
 * For quick start information for Filebeat refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/8.11/filebeat-installation-configuration.html).
-* For complete Setup and Run Filebeat information refer to the [helper guide](beats://docs/reference/filebeat/setting-up-running.md).
+* For complete Setup and Run Filebeat information refer to the [helper guide](beats://reference/filebeat/setting-up-running.md).
 
 **Rule Specific Setup Note**
 
 * This rule requires the Filebeat System Module to be enabled.
 * The system module collects and parses logs created by the system logging service of common Unix/Linux based distributions.
-* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/filebeat-module-system.md).
+* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://reference/filebeat/filebeat-module-system.md).
 
 
 ## Rule query [_rule_query_970]

--- a/docs/reference/prebuilt-rules/sensitive-files-compression.md
+++ b/docs/reference/prebuilt-rules/sensitive-files-compression.md
@@ -119,10 +119,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_972]

--- a/docs/reference/prebuilt-rules/suspicious-network-activity-to-the-internet-by-previously-unknown-executable.md
+++ b/docs/reference/prebuilt-rules/suspicious-network-activity-to-the-internet-by-previously-unknown-executable.md
@@ -140,10 +140,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Filebeat Setup**
 
@@ -152,11 +152,11 @@ Filebeat is a lightweight shipper for forwarding and centralizing log data. Inst
 **The following steps should be executed in order to add the Filebeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/filebeat/setup-repositories.md).
-* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-docker.md).
-* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-kubernetes.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/filebeat/setup-repositories.md).
+* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-docker.md).
+* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-kubernetes.md).
 * For quick start information for Filebeat refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/8.11/filebeat-installation-configuration.html).
-* For complete “Setup and Run Filebeat” information refer to the [helper guide](beats://docs/reference/filebeat/setting-up-running.md).
+* For complete “Setup and Run Filebeat” information refer to the [helper guide](beats://reference/filebeat/setting-up-running.md).
 
 **Packetbeat Setup**
 
@@ -165,10 +165,10 @@ Packetbeat is a real-time network packet analyzer that you can use for applicati
 **The following steps should be executed in order to add the Packetbeat on a  Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/packetbeat/setup-repositories.md).
-* To run Packetbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/packetbeat/running-on-docker.md).
-* For quick start information for Packetbeat refer to the [helper guide](beats://docs/reference/packetbeat/packetbeat-installation-configuration.md).
-* For complete “Setup and Run Packetbeat” information refer to the [helper guide](beats://docs/reference/packetbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/packetbeat/setup-repositories.md).
+* To run Packetbeat on Docker follow the setup instructions in the [helper guide](beats://reference/packetbeat/running-on-docker.md).
+* For quick start information for Packetbeat refer to the [helper guide](beats://reference/packetbeat/packetbeat-installation-configuration.md).
+* For complete “Setup and Run Packetbeat” information refer to the [helper guide](beats://reference/packetbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_1060]

--- a/docs/reference/prebuilt-rules/suspicious-rc-local-error-message.md
+++ b/docs/reference/prebuilt-rules/suspicious-rc-local-error-message.md
@@ -94,17 +94,17 @@ Filebeat is a lightweight shipper for forwarding and centralizing log data. Inst
 **The following steps should be executed in order to add the Filebeat for the Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/filebeat/setup-repositories.md).
-* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-docker.md).
-* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-kubernetes.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/filebeat/setup-repositories.md).
+* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-docker.md).
+* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-kubernetes.md).
 * For quick start information for Filebeat refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/8.11/filebeat-installation-configuration.html).
-* For complete Setup and Run Filebeat information refer to the [helper guide](beats://docs/reference/filebeat/setting-up-running.md).
+* For complete Setup and Run Filebeat information refer to the [helper guide](beats://reference/filebeat/setting-up-running.md).
 
 **Rule Specific Setup Note**
 
 * This rule requires the Filebeat System Module to be enabled.
 * The system module collects and parses logs created by the system logging service of common Unix/Linux based distributions.
-* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/filebeat-module-system.md).
+* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://reference/filebeat/filebeat-module-system.md).
 
 
 ## Rule query [_rule_query_1103]

--- a/docs/reference/prebuilt-rules/suspicious-usage-of-bpf-probe-write-user-helper.md
+++ b/docs/reference/prebuilt-rules/suspicious-usage-of-bpf-probe-write-user-helper.md
@@ -92,17 +92,17 @@ Filebeat is a lightweight shipper for forwarding and centralizing log data. Inst
 **The following steps should be executed in order to add the Filebeat for the Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/filebeat/setup-repositories.md).
-* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-docker.md).
-* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-kubernetes.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/filebeat/setup-repositories.md).
+* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-docker.md).
+* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-kubernetes.md).
 * For quick start information for Filebeat refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/8.11/filebeat-installation-configuration.html).
-* For complete Setup and Run Filebeat information refer to the [helper guide](beats://docs/reference/filebeat/setting-up-running.md).
+* For complete Setup and Run Filebeat information refer to the [helper guide](beats://reference/filebeat/setting-up-running.md).
 
 **Rule Specific Setup Note**
 
 * This rule requires the Filebeat System Module to be enabled.
 * The system module collects and parses logs created by the system logging service of common Unix/Linux based distributions.
-* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/filebeat-module-system.md).
+* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://reference/filebeat/filebeat-module-system.md).
 
 
 ## Rule query [_rule_query_1091]

--- a/docs/reference/prebuilt-rules/suspicious-windows-process-cluster-spawned-by-a-host.md
+++ b/docs/reference/prebuilt-rules/suspicious-windows-process-cluster-spawned-by-a-host.md
@@ -94,9 +94,9 @@ The LotL Attack Detection integration detects living-off-the-land activity in Wi
 
 * Fleet is required for LotL Attack Detection.
 * To configure Fleet Server refer to the [documentation](docs-content://reference/ingestion-tools/fleet/fleet-server.md).
-* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://docs/reference/winlogbeat/_winlogbeat_overview.md)).
+* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://reference/winlogbeat/_winlogbeat_overview.md)).
 * To install Elastic Defend, refer to the [documentation](docs-content://solutions/security/configure-elastic-defend/install-elastic-defend.md).
-* To set up and run Winlogbeat, follow [this](beats://docs/reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
+* To set up and run Winlogbeat, follow [this](beats://reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
 
 **The following steps should be executed to install assets associated with the LotL Attack Detection integration:**
 

--- a/docs/reference/prebuilt-rules/suspicious-windows-process-cluster-spawned-by-a-parent-process.md
+++ b/docs/reference/prebuilt-rules/suspicious-windows-process-cluster-spawned-by-a-parent-process.md
@@ -96,9 +96,9 @@ The LotL Attack Detection integration detects living-off-the-land activity in Wi
 
 * Fleet is required for LotL Attack Detection.
 * To configure Fleet Server refer to the [documentation](docs-content://reference/ingestion-tools/fleet/fleet-server.md).
-* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://docs/reference/winlogbeat/_winlogbeat_overview.md)).
+* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://reference/winlogbeat/_winlogbeat_overview.md)).
 * To install Elastic Defend, refer to the [documentation](docs-content://solutions/security/configure-elastic-defend/install-elastic-defend.md).
-* To set up and run Winlogbeat, follow [this](beats://docs/reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
+* To set up and run Winlogbeat, follow [this](beats://reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
 
 **The following steps should be executed to install assets associated with the LotL Attack Detection integration:**
 

--- a/docs/reference/prebuilt-rules/suspicious-windows-process-cluster-spawned-by-a-user.md
+++ b/docs/reference/prebuilt-rules/suspicious-windows-process-cluster-spawned-by-a-user.md
@@ -96,9 +96,9 @@ The LotL Attack Detection integration detects living-off-the-land activity in Wi
 
 * Fleet is required for LotL Attack Detection.
 * To configure Fleet Server refer to the [documentation](docs-content://reference/ingestion-tools/fleet/fleet-server.md).
-* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://docs/reference/winlogbeat/_winlogbeat_overview.md)).
+* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://reference/winlogbeat/_winlogbeat_overview.md)).
 * To install Elastic Defend, refer to the [documentation](docs-content://solutions/security/configure-elastic-defend/install-elastic-defend.md).
-* To set up and run Winlogbeat, follow [this](beats://docs/reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
+* To set up and run Winlogbeat, follow [this](beats://reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
 
 **The following steps should be executed to install assets associated with the LotL Attack Detection integration:**
 

--- a/docs/reference/prebuilt-rules/system-log-file-deletion.md
+++ b/docs/reference/prebuilt-rules/system-log-file-deletion.md
@@ -122,10 +122,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 **Custom Ingest Pipeline**
 

--- a/docs/reference/prebuilt-rules/tainted-kernel-module-load.md
+++ b/docs/reference/prebuilt-rules/tainted-kernel-module-load.md
@@ -91,17 +91,17 @@ Filebeat is a lightweight shipper for forwarding and centralizing log data. Inst
 **The following steps should be executed in order to add the Filebeat for the Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/filebeat/setup-repositories.md).
-* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-docker.md).
-* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-kubernetes.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/filebeat/setup-repositories.md).
+* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-docker.md).
+* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-kubernetes.md).
 * For quick start information for Filebeat refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/8.11/filebeat-installation-configuration.html).
-* For complete Setup and Run Filebeat information refer to the [helper guide](beats://docs/reference/filebeat/setting-up-running.md).
+* For complete Setup and Run Filebeat information refer to the [helper guide](beats://reference/filebeat/setting-up-running.md).
 
 **Rule Specific Setup Note**
 
 * This rule requires the Filebeat System Module to be enabled.
 * The system module collects and parses logs created by the system logging service of common Unix/Linux based distributions.
-* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/filebeat-module-system.md).
+* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://reference/filebeat/filebeat-module-system.md).
 
 
 ## Rule query [_rule_query_1126]

--- a/docs/reference/prebuilt-rules/tainted-out-of-tree-kernel-module-load.md
+++ b/docs/reference/prebuilt-rules/tainted-out-of-tree-kernel-module-load.md
@@ -92,17 +92,17 @@ Filebeat is a lightweight shipper for forwarding and centralizing log data. Inst
 **The following steps should be executed in order to add the Filebeat for the Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/filebeat/setup-repositories.md).
-* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-docker.md).
-* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/running-on-kubernetes.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/filebeat/setup-repositories.md).
+* To run Filebeat on Docker follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-docker.md).
+* To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/filebeat/running-on-kubernetes.md).
 * For quick start information for Filebeat refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/8.11/filebeat-installation-configuration.html).
-* For complete Setup and Run Filebeat information refer to the [helper guide](beats://docs/reference/filebeat/setting-up-running.md).
+* For complete Setup and Run Filebeat information refer to the [helper guide](beats://reference/filebeat/setting-up-running.md).
 
 **Rule Specific Setup Note**
 
 * This rule requires the Filebeat System Module to be enabled.
 * The system module collects and parses logs created by the system logging service of common Unix/Linux based distributions.
-* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://docs/reference/filebeat/filebeat-module-system.md).
+* To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](beats://reference/filebeat/filebeat-module-system.md).
 
 
 ## Rule query [_rule_query_1127]

--- a/docs/reference/prebuilt-rules/threat-intel-hash-indicator-match.md
+++ b/docs/reference/prebuilt-rules/threat-intel-hash-indicator-match.md
@@ -29,7 +29,7 @@ This rule is triggered when a hash indicator from the Threat Intel Filebeat modu
 
 **References**:
 
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://docs/reference/filebeat/filebeat-module-threatintel.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://reference/filebeat/filebeat-module-threatintel.md)
 * [docs-content://solutions/security/get-started/enable-threat-intelligence-integrations.md](docs-content://solutions/security/get-started/enable-threat-intelligence-integrations.md)
 * [https://www.elastic.co/security/tip](https://www.elastic.co/security/tip)
 

--- a/docs/reference/prebuilt-rules/threat-intel-ip-address-indicator-match.md
+++ b/docs/reference/prebuilt-rules/threat-intel-ip-address-indicator-match.md
@@ -30,7 +30,7 @@ This rule is triggered when an IP address indicator from the Threat Intel Filebe
 
 **References**:
 
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://docs/reference/filebeat/filebeat-module-threatintel.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://reference/filebeat/filebeat-module-threatintel.md)
 * [docs-content://solutions/security/get-started/enable-threat-intelligence-integrations.md](docs-content://solutions/security/get-started/enable-threat-intelligence-integrations.md)
 * [https://www.elastic.co/security/tip](https://www.elastic.co/security/tip)
 

--- a/docs/reference/prebuilt-rules/threat-intel-url-indicator-match.md
+++ b/docs/reference/prebuilt-rules/threat-intel-url-indicator-match.md
@@ -30,7 +30,7 @@ This rule is triggered when a URL indicator from the Threat Intel Filebeat modul
 
 **References**:
 
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://docs/reference/filebeat/filebeat-module-threatintel.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://reference/filebeat/filebeat-module-threatintel.md)
 * [docs-content://solutions/security/get-started/enable-threat-intelligence-integrations.md](docs-content://solutions/security/get-started/enable-threat-intelligence-integrations.md)
 * [https://www.elastic.co/security/tip](https://www.elastic.co/security/tip)
 

--- a/docs/reference/prebuilt-rules/threat-intel-windows-registry-indicator-match.md
+++ b/docs/reference/prebuilt-rules/threat-intel-windows-registry-indicator-match.md
@@ -29,7 +29,7 @@ This rule is triggered when a Windows registry indicator from the Threat Intel F
 
 **References**:
 
-* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://docs/reference/filebeat/filebeat-module-threatintel.md)
+* [/beats/docs/reference/ingestion-tools/beats-filebeat/filebeat-module-threatintel.md](beats://reference/filebeat/filebeat-module-threatintel.md)
 * [docs-content://solutions/security/get-started/enable-threat-intelligence-integrations.md](docs-content://solutions/security/get-started/enable-threat-intelligence-integrations.md)
 * [https://www.elastic.co/security/tip](https://www.elastic.co/security/tip)
 

--- a/docs/reference/prebuilt-rules/unusual-pkexec-execution.md
+++ b/docs/reference/prebuilt-rules/unusual-pkexec-execution.md
@@ -121,10 +121,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_1183]

--- a/docs/reference/prebuilt-rules/unusual-process-spawned-by-a-host.md
+++ b/docs/reference/prebuilt-rules/unusual-process-spawned-by-a-host.md
@@ -95,9 +95,9 @@ The LotL Attack Detection integration detects living-off-the-land activity in Wi
 
 * Fleet is required for LotL Attack Detection.
 * To configure Fleet Server refer to the [documentation](docs-content://reference/ingestion-tools/fleet/fleet-server.md).
-* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://docs/reference/winlogbeat/_winlogbeat_overview.md)).
+* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://reference/winlogbeat/_winlogbeat_overview.md)).
 * To install Elastic Defend, refer to the [documentation](docs-content://solutions/security/configure-elastic-defend/install-elastic-defend.md).
-* To set up and run Winlogbeat, follow [this](beats://docs/reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
+* To set up and run Winlogbeat, follow [this](beats://reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
 
 **The following steps should be executed to install assets associated with the LotL Attack Detection integration:**
 

--- a/docs/reference/prebuilt-rules/unusual-process-spawned-by-a-parent-process.md
+++ b/docs/reference/prebuilt-rules/unusual-process-spawned-by-a-parent-process.md
@@ -97,9 +97,9 @@ The LotL Attack Detection integration detects living-off-the-land activity in Wi
 
 * Fleet is required for LotL Attack Detection.
 * To configure Fleet Server refer to the [documentation](docs-content://reference/ingestion-tools/fleet/fleet-server.md).
-* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://docs/reference/winlogbeat/_winlogbeat_overview.md)).
+* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://reference/winlogbeat/_winlogbeat_overview.md)).
 * To install Elastic Defend, refer to the [documentation](docs-content://solutions/security/configure-elastic-defend/install-elastic-defend.md).
-* To set up and run Winlogbeat, follow [this](beats://docs/reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
+* To set up and run Winlogbeat, follow [this](beats://reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
 
 **The following steps should be executed to install assets associated with the LotL Attack Detection integration:**
 

--- a/docs/reference/prebuilt-rules/unusual-process-spawned-by-a-user.md
+++ b/docs/reference/prebuilt-rules/unusual-process-spawned-by-a-user.md
@@ -96,9 +96,9 @@ The LotL Attack Detection integration detects living-off-the-land activity in Wi
 
 * Fleet is required for LotL Attack Detection.
 * To configure Fleet Server refer to the [documentation](docs-content://reference/ingestion-tools/fleet/fleet-server.md).
-* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://docs/reference/winlogbeat/_winlogbeat_overview.md)).
+* Windows process events collected by the [Elastic Defend](https://docs.elastic.co/en/integrations/endpoint) integration or Winlogbeat([/beats/docs/reference/ingestion-tools/beats-winlogbeat/_winlogbeat_overview.md](beats://reference/winlogbeat/_winlogbeat_overview.md)).
 * To install Elastic Defend, refer to the [documentation](docs-content://solutions/security/configure-elastic-defend/install-elastic-defend.md).
-* To set up and run Winlogbeat, follow [this](beats://docs/reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
+* To set up and run Winlogbeat, follow [this](beats://reference/winlogbeat/winlogbeat-installation-configuration.md) guide.
 
 **The following steps should be executed to install assets associated with the LotL Attack Detection integration:**
 

--- a/docs/reference/prebuilt-rules/virtual-machine-fingerprinting.md
+++ b/docs/reference/prebuilt-rules/virtual-machine-fingerprinting.md
@@ -117,10 +117,10 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 **The following steps should be executed in order to add the Auditbeat on a Linux System:**
 
 * Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://docs/reference/auditbeat/setup-repositories.md).
-* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-docker.md).
-* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://docs/reference/auditbeat/running-on-kubernetes.md).
-* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://docs/reference/auditbeat/setting-up-running.md).
+* To install the APT and YUM repositories follow the setup instructions in this [helper guide](beats://reference/auditbeat/setup-repositories.md).
+* To run Auditbeat on Docker follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-docker.md).
+* To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](beats://reference/auditbeat/running-on-kubernetes.md).
+* For complete “Setup and Run Auditbeat” information refer to the [helper guide](beats://reference/auditbeat/setting-up-running.md).
 
 
 ## Rule query [_rule_query_1204]


### PR DESCRIPTION
Follow up to #6554 

When using cross-repo links, the path should be relative to the `docset.yml` not the full path within the repo ([updated docs-builder docs](https://elastic.github.io/docs-builder/syntax/links/#cross-repository-links)).