### PR TITLE
Adds 212130 to the 8.17.3 release notes

### DIFF
--- a/docs/release-notes/8.17.asciidoc
+++ b/docs/release-notes/8.17.asciidoc
@@ -32,6 +32,7 @@ On November 12, 2024, it was discovered that manually running a custom query rul
 [discrete]
 [[bug-fixes-8.17.3]]
 ==== Bug fixes
+* Fixes an issue with the Event Rendered View in the Alerts table where the table would sometimes have a height of zero and become unusable ({kibana-pull}212130[#212130]).
 * Removes the option to sort IP ranges in the value list modal ({kibana-pull}210922[#210922]).
 * Fixes package name validation on the Automatic Import data stream page ({kibana-pull}210916[#210916], {kibana-pull}210770[#210770]).
 * Improves the way Automatic Import handles empty categorization results from LLMs ({kibana-pull}210420[#210420]).


### PR DESCRIPTION
Adds 212130 to the 8.17.3 release notes. This PR was initially skipped because it has the `release_notes:skip` label.

Preview: [8.17.3 release notes](https://security-docs_bk_6570.docs-preview.app.elstc.co/guide/en/security/8.x/release-notes-header-8.17.0.html#release-notes-8.17.3) - Added 212130 to the bug fixes section