### PR TITLE
Adds 212130 to the 8.16.5 release notes

### DIFF
--- a/docs/release-notes/8.16.asciidoc
+++ b/docs/release-notes/8.16.asciidoc
@@ -32,6 +32,7 @@ On November 12, 2024, it was discovered that manually running a custom query rul
 [discrete]
 [[bug-fixes-8.16.5]]
 ==== Bug fixes
+* Fixes an issue with the Event Rendered View in the Alerts table where the table would sometimes have a height of zero and become unusable ({kibana-pull}212130[#212130]).
 * Fixes a bug in {elastic-defend} for Linux where tty capture limit defaults were ignored.
 * Fixes a potential {elastic-defend} crash when generating multiple ransomware alerts on Windows. This issue was simultaneously mitigated by a cloud artifact update (manifest version 1.0.1381) on February 24, 2025. Internet-connected instances of {elastic-defend} will automatically receive this update -- no user intervention required. Air-gapped customers hosting their own artifacts should follow <<offline-endpoint,these instructions>>. We would like to acknowledge https://www.todyl.com[Todyl] for their assistance with this issue.
 * Updated the `allocate_shellcode` {elastic-defend} API event behavior to explicitly only apply to unbacked memory.


### PR DESCRIPTION
Adds 212130 to the 8.16.5 release notes. This PR was initially skipped because it has the `release_notes:skip` label.

Preview: [8.16.5 release notes](https://security-docs_bk_6571.docs-preview.app.elstc.co/guide/en/security/8.x/release-notes-header-8.16.0.html#release-notes-8.16.5) - Added 212130 to the bug fixes section