### PR TITLE
[serverless] Use `current` attributes in serverless docs

### DIFF
--- a/docs/serverless/index.asciidoc
+++ b/docs/serverless/index.asciidoc
@@ -1,6 +1,6 @@
 :doctype: book
 
-include::{asciidoc-dir}/../../shared/versions/stack/master.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions/stack/current.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 [[what-is-security-serverless]]


### PR DESCRIPTION
🧀  Pairs with https://github.com/elastic/docs-content/pull/665

Use `current` attributes in serverless docs to avoid 404s to `master` pages.