### PR TITLE
CSPM agentless goes GA

### DIFF
--- a/docs/cloud-native-security/cspm-get-started-aws.asciidoc
+++ b/docs/cloud-native-security/cspm-get-started-aws.asciidoc
@@ -26,7 +26,6 @@ You can set up CSPM for AWS either by enrolling a single cloud account, or by en
 [discrete]
 [[cspm-aws-agentless]]
 == Agentless deployment 
-beta::[]
 
 . Find **Integrations** in the navigation menu or use the {kibana-ref}/introduction.html#kibana-navigation-search[global search field].
 . Search for `CSPM`, then click on the result.

--- a/docs/cloud-native-security/cspm-get-started-azure.asciidoc
+++ b/docs/cloud-native-security/cspm-get-started-azure.asciidoc
@@ -26,7 +26,6 @@ You can set up CSPM for Azure by by enrolling an Azure organization (management 
 [discrete]
 [[cspm-azure-agentless]]
 == Agentless deployment 
-beta::[]
 
 . Find **Integrations** in the navigation menu or use the {kibana-ref}/introduction.html#kibana-navigation-search[global search field].
 . Search for `CSPM`, then click on the result.

--- a/docs/cloud-native-security/cspm-get-started-gcp.asciidoc
+++ b/docs/cloud-native-security/cspm-get-started-gcp.asciidoc
@@ -26,7 +26,6 @@ You can set up CSPM for GCP either by enrolling a single project, or by enrollin
 [discrete]
 [[cspm-gcp-agentless]]
 == Agentless deployment
-beta::[]
 
 . Find **Integrations** in the navigation menu or use the {kibana-ref}/introduction.html#kibana-navigation-search[global search field].
 . Search for `CSPM`, then click on the result.

--- a/docs/getting-started/agentless-integrations.asciidoc
+++ b/docs/getting-started/agentless-integrations.asciidoc
@@ -1,8 +1,6 @@
 [[agentless-integrations]]
 = Agentless integrations
 
-beta::[]
-
 Agentless integrations provide a means to ingest data while avoiding the orchestration, management, and maintenance needs associated with standard ingest infrastructure. Using agentless integrations makes manual agent deployment unnecessary, allowing you to focus on your data instead of the agent that collects it. 
 
 We currently support one agentless integration: cloud security posture management (CSPM). Using this integration's agentless deployment option, you can enable Elastic's CSPM capabilities just by providing the necessary credentials. Agentless CSPM deployments support AWS, Azure, and GCP accounts.


### PR DESCRIPTION
Fixes #[277](https://github.com/elastic/docs-content/issues/277) by removing all references to agentless CSPM being in beta. 