### PR TITLE
Removes outdated timeline reference from AI Assistant page

### DIFF
--- a/docs/AI-for-security/ai-security-assistant.asciidoc
+++ b/docs/AI-for-security/ai-security-assistant.asciidoc
@@ -66,7 +66,6 @@ You can also chat with AI Assistant from several particular pages in {elastic-se
 * <<view-alert-details, Alert details>> or Event details flyout: Click *Chat* while viewing the details of an alert or event.
 * <<rules-ui-management, Rules page>>: Use AI Assistant to help create or correct rule queries.
 * <<data-quality-dash, Data Quality dashboard>>: Select the *Incompatible fields* tab, then click *Chat*. (This is only available for fields marked red, indicating they're incompatible).
-* <<timelines-ui, Timeline>>: Select the *Security Assistant* tab.
 
 NOTE: Each user's chat history (up to the 99 most recent conversations) and custom Quick Prompts are automatically saved, so you can leave {elastic-sec} and return to a conversation later. Chat history appears to the left of the AI Assistant chat window, and on the **Conversations** tab of the **AI Assistant settings** menu. To access the settings menu, use the global search field to search for "AI Assistant for Security".
 
@@ -106,7 +105,7 @@ The *Security AI settings* page allows you to configure AI Assistant. To access 
 
 It has the following tabs:
 
-* **Conversations:** When you open AI Assistant from certain pages, such as **Timeline** or **Alerts**, it defaults to the relevant conversation type. For each conversation type, choose the default System Prompt, the default connector, and the default model (if applicable). The **Streaming** setting controls whether AI Assistant's responses appear word-by-word (streamed), or as a complete block of text. Streaming is currently only available for OpenAI models.
+* **Conversations:** When you open AI Assistant from certain pages, such as **Alerts**, it defaults to the relevant conversation type. For each conversation type, choose the default System Prompt, the default connector, and the default model (if applicable). The **Streaming** setting controls whether AI Assistant's responses appear word-by-word (streamed), or as a complete block of text. Streaming is currently only available for OpenAI models.
 * **Connectors:** Manage all LLM connectors.
 * **System Prompts:** Edit existing System Prompts or create new ones. To create a new System Prompt, type a unique name in the *Name* field, then press *enter*. Under *Prompt*, enter or update the System Prompt's text. Under *Contexts*, select where the System Prompt should appear.
 * **Quick Prompts:** Modify existing Quick Prompts or create new ones. To create a new Quick Prompt, type a unique name in the *Name* field, then press *enter*. Under *Prompt*, enter or update the Quick Prompt's text. 


### PR DESCRIPTION
Fixes docs-content/267, minor edit to remove references to an AI Assistant tab in Timeline.