### PR TITLE
Entity store GA in 8.18

### DIFF
--- a/docs/advanced-entity-analytics/entity-store.asciidoc
+++ b/docs/advanced-entity-analytics/entity-store.asciidoc
@@ -1,8 +1,6 @@
 [[entity-store]]
 = Entity store
 
-preview::[]
-
 .Requirements
 [sidebar]
 --

--- a/docs/dashboards/entity-dashboard.asciidoc
+++ b/docs/dashboards/entity-dashboard.asciidoc
@@ -84,8 +84,6 @@ For more information about host risk scores, refer to <<entity-risk-scoring>>.
 [float]
 == Entities
 
-preview::[]
-
 .Requirements
 [sidebar]
 -- 


### PR DESCRIPTION
Resolves https://github.com/elastic/docs-content/issues/268 by removing the tech preview label for entity store feature.

Previews:

- [Entity store](https://security-docs_bk_6622.docs-preview.app.elstc.co/guide/en/security/8.x/entity-store.html)
- [Entity Analytics dashboard | Entities](https://security-docs_bk_6622.docs-preview.app.elstc.co/guide/en/security/8.x/detection-entity-dashboard.htmlentity-entities)
