### PR TITLE
Adds placeholder pages for in-app linking purposes

### DIFF
--- a/docs/getting-started/index.asciidoc
+++ b/docs/getting-started/index.asciidoc
@@ -11,6 +11,7 @@ include::sec-app-requirements.asciidoc[leveloffset=+1]
 include::security-ui.asciidoc[leveloffset=+1]
 
 include::ingest-data.asciidoc[leveloffset=+1]
+include::siem-migration.asciidoc[leveloffset=+2]
 include::threat-intel-integrations.asciidoc[leveloffset=+2]
 include::automatic-import.asciidoc[leveloffset=+2]
 include::agentless-integrations.asciidoc[leveloffset=+2]

--- a/docs/getting-started/siem-migration.asciidoc
+++ b/docs/getting-started/siem-migration.asciidoc
@@ -1,0 +1,5 @@
+[[siem-migration]]
+[chapter]
+= AI-powered SIEM migration
+
+This page is a placeholder 


### PR DESCRIPTION
This PR creates a blank page in 8.x and 8.18 for the SIEM migrations feature, so that in-app links can point to it. This will enable Sergi to merge some PRs that are currently failing because the doc links don't exist yet. I will add content to these pages before the 8.18 release.

