### PR TITLE
[8.18] CCS and ES|QL rule reqs

### DIFF
--- a/docs/detections/rules-cross-cluster-search.asciidoc
+++ b/docs/detections/rules-cross-cluster-search.asciidoc
@@ -6,7 +6,7 @@
 .Requirements
 [sidebar]
 --
-Using cross-cluster search for {esql} rules requires an https://www.elastic.co/pricing[Enterprise subscription]. To learn more about the other requirements, refer to {ref}/modules-cross-cluster-search.html[Search across clusters].
+Using cross-cluster search for {esql} rules requires an https://www.elastic.co/pricing[Enterprise subscription]. Refer to {ref}/modules-cross-cluster-search.html[Search across clusters] to learn more about cross-cluster search requirements.
 --
 
 [discrete]

--- a/docs/detections/rules-cross-cluster-search.asciidoc
+++ b/docs/detections/rules-cross-cluster-search.asciidoc
@@ -8,7 +8,7 @@
 --
 
 * To learn about the requirements for using cross-cluster search, refer to {ref}/modules-cross-cluster-search.html[Search across clusters].
-* Using cross-cluster search for {esql} rules requires an [Enterprise subscription](https://www.elastic.co/pricing). 
+* Using cross-cluster search for {esql} rules requires an (https://www.elastic.co/pricing)[Enterprise subscription]. 
 
 --
 

--- a/docs/detections/rules-cross-cluster-search.asciidoc
+++ b/docs/detections/rules-cross-cluster-search.asciidoc
@@ -6,7 +6,10 @@
 .Requirements
 [sidebar]
 --
-Using cross-cluster search for {esql} rules requires an https://www.elastic.co/pricing[Enterprise subscription]. Refer to {ref}/modules-cross-cluster-search.html[Search across clusters] to learn more about cross-cluster search requirements.
+
+* To learn about the requirements for using cross-cluster search, refer to {ref}/modules-cross-cluster-search.html[Search across clusters].
+* Using cross-cluster search for {esql} rules requires an [Enterprise subscription](https://www.elastic.co/pricing). 
+
 --
 
 [discrete]

--- a/docs/detections/rules-cross-cluster-search.asciidoc
+++ b/docs/detections/rules-cross-cluster-search.asciidoc
@@ -3,6 +3,12 @@
 
 {ref}/modules-cross-cluster-search.html[Cross-cluster search] is an {es} feature that allows one cluster (the _local_ cluster) to query data in a separate cluster (the _remote_ cluster). {elastic-sec}'s detection rules can perform a cross-cluster search to query data in remote clusters.
 
+.Requirements
+[sidebar]
+--
+Using cross-cluster search for {esql} rules requires an https://www.elastic.co/pricing[Enterprise subscription]. To learn more about the other requirements, refer  to {ref}/modules-cross-cluster-search.html[Cross-cluster search prerequisites].
+--
+
 [discrete]
 [[set-up-ccs-rules]]
 === Set up cross-cluster search in detection rules

--- a/docs/detections/rules-cross-cluster-search.asciidoc
+++ b/docs/detections/rules-cross-cluster-search.asciidoc
@@ -6,7 +6,7 @@
 .Requirements
 [sidebar]
 --
-Using cross-cluster search for {esql} rules requires an https://www.elastic.co/pricing[Enterprise subscription]. To learn more about the other requirements, refer  to {ref}/modules-cross-cluster-search.html[Cross-cluster search prerequisites].
+Using cross-cluster search for {esql} rules requires an https://www.elastic.co/pricing[Enterprise subscription]. To learn more about the other requirements, refer to {ref}/modules-cross-cluster-search.html[Search across clusters].
 --
 
 [discrete]


### PR DESCRIPTION
Partially addresses https://github.com/elastic/docs-content/issues/346 by adding a note describing the reqs for using CCS with ES|QL rules.

Preview: [Cross-cluster search and detection rules](https://security-docs_bk_6640.docs-preview.app.elstc.co/guide/en/security/8.x/rules-cross-cluster-search.html)

Corresponding 9.0 and Serverless docs: https://github.com/elastic/docs-content/pull/828