### PR TITLE
[8.18] New sub-feature priv for case assignees

### DIFF
--- a/docs/cases/cases-req.asciidoc
+++ b/docs/cases/cases-req.asciidoc
@@ -42,7 +42,7 @@ a|
 ====
 Roles without **All** privileges for the *{connectors-feature}* feature cannot create, add, delete, or modify case connectors.
 
-By default, **All** for the *Cases* feature allows you to delete cases, delete alerts and comments from cases, and edit case settings. You can customize the sub-feature privileges to limit feature access.
+By default, **All** for the *Cases* feature allows you to have full control over cases, including deleting them, editing case settings, and more. You can customize the sub-feature privileges to limit feature access.
 ====
 
 | Give assignee access to cases


### PR DESCRIPTION
Partially addresses https://github.com/elastic/docs-content/issues/333. Makes minor changes to future-proof docs for giving full access to manage cases and settings.

Preview: [Cases requirements](https://security-docs_bk_6641.docs-preview.app.elstc.co/guide/en/security/8.x/case-permissions.html)

- 9.0 and Serverless docs (all): https://github.com/elastic/docs-content/pull/831
- Kibana docs: https://github.com/elastic/kibana/pull/215162
- Observability docs: https://github.com/elastic/observability-docs/pull/4850