### PR TITLE
updates LLM performance matrix

### DIFF
--- a/docs/AI-for-security/llm-performance-matrix.asciidoc
+++ b/docs/AI-for-security/llm-performance-matrix.asciidoc
@@ -3,26 +3,36 @@
 
 This page describes the performance of various large language models (LLMs) for different use cases in {elastic-sec}, based on our internal testing. To learn more about these use cases, refer to <<attack-discovery, Attack discovery>> or <<security-assistant, AI Assistant>>. 
 
-NOTE: `Excellent` is the best rating, followed by `Great`, then by `Good`, and finally by `Poor`.
-
+IMPORTANT: `Excellent` is the best rating, followed by `Great`, then by `Good`, and finally by `Poor`. Models rated `Excellent` or `Great` should produce quality results. Models rated `Good` or `Poor` are not recommended for that use case.
 [discrete]
 == Proprietary models
 Models from third-party LLM providers.  
 
 [cols="1,1,1,1,1,1,1", options="header"]
 |===
-| *Feature* |           | *Assistant - General* | *Assistant - {esql} generation* | *Assistant - Alert questions* | *Assistant - Knowledge retrieval* | *Attack Discovery*
-| *Model*   |*Claude 3: Opus*       | Excellent | Excellent                       | Excellent                     | Good                          | Great
-|           |*Claude 3.5: Sonnet v2*| Excellent | Excellent                       |  Excellent                    | Excellent                     | Great
-|           |*Claude 3.5: Sonnet*   | Excellent| Excellent                        | Excellent                     | Excellent                     | Excellent
-|           |*Claude 3.5: Haiku*    | Excellent| Excellent                        | Excellent                     | Excellent                     | Poor
-|           |*Claude 3: Haiku*      | Excellent| Excellent                        | Excellent                     | Excellent                     | Poor
-|           |*GPT-4o*               | Excellent| Excellent                        | Excellent                     | Excellent                     | Great
-|           |*GPT-4o-mini*          | Excellent| Great                            | Great                         | Great                         | Poor
-|           |**Gemini 1.5 Pro 002** | Excellent| Excellent                        | Excellent                     | Excellent                     | Excellent
-|           |**Gemini 1.5 Flash 002**|Excellent| Poor                             | Good                          | Excellent                     | Poor
+| *Feature* |           | *Assistant - General* | *Assistant - {esql} generation* | *Assistant - Alert questions* | *Assistant - Knowledge retrieval* | *Attack Discovery* | *AI-powered SIEM migration* 
+| *Model*   |*Claude 3: Opus*       | Excellent | Excellent                       | Excellent                     | Good                          | Great     | Good
+|           |*Claude 3.7: Sonnet*   | Excellent |  Excellent                      | Excellent                     | Excellent                     | Excellent | Excellent
+|           |*Claude 3.5: Sonnet v2*| Excellent | Excellent                       |  Excellent                    | Excellent                     | Great     | Excellent
+|           |*Claude 3.5: Sonnet*   | Excellent| Excellent                        | Excellent                     | Excellent                     | Excellent | Excellent
+|           |*Claude 3.5: Haiku*    | Excellent| Excellent                        | Excellent                     | Excellent                     | Poor      | Poor
+|           |*Claude 3: Haiku*      | Excellent| Excellent                        | Excellent                     | Excellent                     | Poor      |Poor
+|           |*GPT-4o*               | Excellent| Excellent                        | Excellent                     | Excellent                     | Great     |Great
+|           |*GPT-4o-mini*          | Excellent| Great                            | Great                         | Great                         | Poor      |Good
+|           |**Gemini 1.5 Pro 002** | Excellent| Excellent                        | Excellent                     | Excellent                     | Excellent | Great
+|           |**Gemini 1.5 Flash 002**|Excellent| Poor                             | Good                          | Excellent                     | Poor      | Excellent
 |===
 
+| Good
+| Excellent
+| Excellent
+| Excellent
+| Poor
+| Poor
+| Great
+| Good
+| Great
+| Excellent
 [discrete]
 == Open-source models
 Models you can <<connect-to-byo-llm, deploy yourself>>.

--- a/docs/AI-for-security/llm-performance-matrix.asciidoc
+++ b/docs/AI-for-security/llm-performance-matrix.asciidoc
@@ -25,16 +25,6 @@ Models from third-party LLM providers.
 |           |**Gemini 2.0 Flash 001**|Excellent| Excellent                        | Excellent                     | Excellent                     | Excellent | Excellent
 |===
 
-| Good
-| Excellent
-| Excellent
-| Excellent
-| Poor
-| Poor
-| Great
-| Good
-| Great
-| Excellent
 [discrete]
 == Open-source models
 Models you can <<connect-to-byo-llm, deploy yourself>>.

--- a/docs/AI-for-security/llm-performance-matrix.asciidoc
+++ b/docs/AI-for-security/llm-performance-matrix.asciidoc
@@ -9,7 +9,7 @@ IMPORTANT: `Excellent` is the best rating, followed by `Great`, then by `Good`, 
 == Proprietary models
 Models from third-party LLM providers.  
 
-[cols="1,1,1,1,1,1,1", options="header"]
+[cols="1,1,1,1,1,1,1,1", options="header"]
 |===
 | *Feature* |           | *Assistant - General* | *Assistant - {esql} generation* | *Assistant - Alert questions* | *Assistant - Knowledge retrieval* | *Attack Discovery* | *AI-powered SIEM migration* 
 | *Model*   |*Claude 3: Opus*       | Excellent | Excellent                       | Excellent                     | Good                          | Great     | Good

--- a/docs/AI-for-security/llm-performance-matrix.asciidoc
+++ b/docs/AI-for-security/llm-performance-matrix.asciidoc
@@ -4,6 +4,7 @@
 This page describes the performance of various large language models (LLMs) for different use cases in {elastic-sec}, based on our internal testing. To learn more about these use cases, refer to <<attack-discovery, Attack discovery>> or <<security-assistant, AI Assistant>>. 
 
 IMPORTANT: `Excellent` is the best rating, followed by `Great`, then by `Good`, and finally by `Poor`. Models rated `Excellent` or `Great` should produce quality results. Models rated `Good` or `Poor` are not recommended for that use case.
+
 [discrete]
 == Proprietary models
 Models from third-party LLM providers.  
@@ -21,6 +22,7 @@ Models from third-party LLM providers.
 |           |*GPT-4o-mini*          | Excellent| Great                            | Great                         | Great                         | Poor      |Good
 |           |**Gemini 1.5 Pro 002** | Excellent| Excellent                        | Excellent                     | Excellent                     | Excellent | Great
 |           |**Gemini 1.5 Flash 002**|Excellent| Poor                             | Good                          | Excellent                     | Poor      | Excellent
+|           |**Gemini 2.0 Flash 001**|Excellent| Excellent                        | Excellent                     | Excellent                     | Excellent | Excellent
 |===
 
 | Good


### PR DESCRIPTION
Fixes docs-content/#738. Updates the LLM performance matrix to reflect new testing.

Preview: [LLM Performance matrix](https://security-docs_bk_6648.docs-preview.app.elstc.co/guide/en/security/8.x/llm-performance-matrix.html)