### PR TITLE
Removes 214495 from the 8.17.4 release notes

### DIFF
--- a/docs/release-notes/8.17.asciidoc
+++ b/docs/release-notes/8.17.asciidoc
@@ -26,11 +26,6 @@ On November 12, 2024, it was discovered that manually running a custom query rul
 // end::known-issue[]
 
 [discrete]
-[[enhancements-8.17.4]]
-==== Enhancements
-* When creating a new rule, the data view selector now shows data view names instead of their defined indices ({kibana-pull}214495[#214495]).
-
-[discrete]
 [[bug-fixes-8.17.4]]
 ==== Bug fixes
 * Fixes the Bedrock region URL ({kibana-pull}214251[#214251]).


### PR DESCRIPTION
What the title says.

Preview: [8.17.4 release notes](https://security-docs_bk_6667.docs-preview.app.elstc.co/guide/en/security/8.x/release-notes-header-8.17.0.html)