### PR TITLE
[8.16-8.18] Change upper limit for max unassociated notes 

### DIFF
--- a/docs/getting-started/advanced-setting.asciidoc
+++ b/docs/getting-started/advanced-setting.asciidoc
@@ -183,7 +183,7 @@ The `securitySolution:alertTags` field determines which options display in the a
 [[max-notes-alerts-events]]
 == Set the maximum notes limit for alerts and events 
 
-The `securitySolution:maxUnassociatedNotes` field determines the maximum number of <<add-manage-notes,notes>> that you can attach to alerts and events. The maximum limit and default value is 1000. 
+The `securitySolution:maxUnassociatedNotes` field determines the maximum number of <<add-manage-notes,notes>> that you can attach to alerts and events. The maximum limit and default value is 10000. 
 
 [discrete]
 [[exclude-cold-frozen-data-rule-executions]]


### PR DESCRIPTION
### Description
Partially addresses https://github.com/elastic/docs-content/issues/915 by updating docs for 8.16-8.18. Twin 9.0 and Serverless PR is at: https://github.com/elastic/docs-content/pull/940

### Preview 
[Configure advanced settings | Set the maximum notes limit for alerts and events](https://security-docs_bk_6671.docs-preview.app.elstc.co/guide/en/security/8.x/advanced-settings.html#max-notes-alerts-events): The updated maximum limit and default value is 10,000. 
