### PR TITLE
Updates risk scoring requirements

### DIFF
--- a/docs/advanced-entity-analytics/ers-req.asciidoc
+++ b/docs/advanced-entity-analytics/ers-req.asciidoc
@@ -11,20 +11,32 @@ This page covers the requirements and guidelines for using the entity risk scori
 [discrete]
 === Privileges
 
-To turn on the risk scoring engine, you need the following privileges:
+To install or run the risk scoring engine, you need the following privileges:
 
 [discrete]
 [width="100%",options="header"]
 |==============================================
 
-| Cluster      | Index | {kib} 
+| Action | Cluster privileges | Index privileges | {kib} privileges
+
+| Install the risk engine
+
 a| 
 * `manage_index_templates`
 * `manage_transform`
+* `manage_ingest_pipelines`
 
 | `all` privilege for `risk-score.risk-score-*`
 
 | **Read** for the **Security** feature 
+
+| Run the risk engine
+
+| `manage_transform`
+
+| N/A
+
+| **Read** for the **Security** feature
 
 |==============================================
 


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/847 by updating the requirements for installing the risk scoring engine, and adding requirements for running the risk engine.

Preview: [Entity risk scoring requirements](https://security-docs_bk_6674.docs-preview.app.elstc.co/guide/en/security/8.x/ers-requirements.html)