### PR TITLE
Deletes reference to asciidoc Osquery API page

### DIFF
--- a/docs/detections/api/rules/rules-api-create.asciidoc
+++ b/docs/detections/api/rules/rules-api-create.asciidoc
@@ -735,7 +735,7 @@ For Osquery (`.osquery`), use a single query, a saved query, or a query pack:
 * `ecs_mapping` (object, required): Map Osquery results columns or static values to Elastic Common Schema (ECS) fields. Example: `"ecs_mapping": {"process.pid": {"field": "pid"}}`
 * `timeout` (number, optional): A timeout period, in seconds, after which the query will stop running. Overwriting the default timeout allows you to support queries that require more time to complete. The default and minimum supported value is `60`. The maximum supported value is `86400` (24 hours). Example: `"timeout": 120`.
 
-NOTE: Refer to {kibana-ref}/osquery-manager-live-queries-api-create.html[Create live query API] for more information about running Osquery queries and packs.
+NOTE: Refer to {api-kibana}/operation/operation-osquerycreatelivequery[Create live query API] for more information about running Osquery queries and packs.
 
 *Endpoint Security* 
 


### PR DESCRIPTION
Contributes to https://github.com/elastic/security-docs-internal/issues/59. 
Related PR that deletes the asciidoc Osquery API docs from the kibana repo: https://github.com/elastic/kibana/pull/216269.
This PR needs to be merged first before the kibana PR can pass.