### PR TITLE
Updates connect to Bedrock guide

### DIFF
--- a/docs/AI-for-security/connect-to-bedrock.asciidoc
+++ b/docs/AI-for-security/connect-to-bedrock.asciidoc
@@ -3,7 +3,7 @@
 
 This page provides step-by-step instructions for setting up an Amazon Bedrock connector for the first time. This connector type enables you to leverage large language models (LLMs) within {kib}. You'll first need to configure AWS, then configure the connector in {kib}.
 
-NOTE: Only Amazon Bedrock's `Anthropic` models are supported: `Claude` and `Claude instant`.
+NOTE: All models in Amazon Bedrock's `Claude` model group are supported.
 
 [discrete]
 == Configure AWS
@@ -121,7 +121,7 @@ Make sure the supported Amazon Bedrock LLMs are enabled:
 . Search the AWS console for Amazon Bedrock. 
 . From the Amazon Bedrock page, click **Get started**.
 . Select **Model access** from the left navigation menu, then click **Manage model access**.
-. Check the boxes for **Claude** and/or **Claude Instant**, depending which model or models you plan to use.
+. Check the box for the model or models you plan to use.
 . Click **Save changes**.
 
 The following video demonstrates these steps.
@@ -150,10 +150,17 @@ Finally, configure the connector in {kib}:
 . . Find the **Connectors** page in the navigation menu or use the {kibana-ref}/introduction.html#kibana-navigation-search[global search field]. Then click **Create Connector**, and select **Amazon Bedrock**.
 . Name your connector. 
 . (Optional) Configure the Amazon Bedrock connector to use a different AWS region where Anthropic models are supported by editing the **URL** field, for example by changing `us-east-1` to `eu-central-1`.
-. (Optional) Add one of the following strings if you want to use a model other than the default:
-.. For Haiku: `anthropic.claude-3-haiku-20240307-v1:0`
-.. For Sonnet: `anthropic.claude-3-sonnet-20240229-v1:0`
-.. For Opus: `anthropic.claude-3-opus-20240229-v1:0`
+. (Optional) Add one of the following strings if you want to use a model other than the default. Note that these URLs should have a prefix of `us.` or `eu.`, depending on your region, for example `us.anthropic.claude-3-5-sonnet-20240620-v1:0` or `eu.anthropic.claude-3-5-sonnet-20240620-v1:0`.
++
+  * For Haiku: `anthropic.claude-3-haiku-20240307-v1:0`
+  * For Sonnet: `anthropic.claude-3-sonnet-20240229-v1:0`
+  * For Opus: `anthropic.claude-3-opus-20240229-v1:0`
+  * Sonnet 3.5: `us.anthropic.claude-3-5-sonnet-20240620-v1:0` or `eu.anthropic.claude-3-5-sonnet-20240620-v1:0`
+  * Sonnet 3.5 v2: `us.anthropic.claude-3-5-sonnet-20241022-v2:0` or `eu.anthropiclaude-3-5-sonnet-20241022-v2:0`
+  * Sonnet 3.7: `us.anthropic.claude-3-7-sonnet-20250219-v1:0` or `eu.anthropic.claude-3-7-sonnet-20250219-v1:0`
+  * Haiku 3.5: `us.anthropic.claude-3-5-haiku-20241022-v1:0` or `eu.anthropic.claude-3-5-haiku-20241022-v1:0`
+  * Opus: `us.anthropic.claude-3-opus-20240229-v1:0` or `eu.anthropic.claude-3-opus-20240229-v1:0`
++
 . Enter the **Access Key** and **Secret** that you generated earlier, then click **Save**.
 +
 Your LLM connector is now configured. For more information on using Elastic AI Assistant, refer to <<security-assistant, AI Assistant>>.

--- a/docs/AI-for-security/connect-to-bedrock.asciidoc
+++ b/docs/AI-for-security/connect-to-bedrock.asciidoc
@@ -152,9 +152,6 @@ Finally, configure the connector in {kib}:
 . (Optional) Configure the Amazon Bedrock connector to use a different AWS region where Anthropic models are supported by editing the **URL** field, for example by changing `us-east-1` to `eu-central-1`.
 . (Optional) Add one of the following strings if you want to use a model other than the default. Note that these URLs should have a prefix of `us.` or `eu.`, depending on your region, for example `us.anthropic.claude-3-5-sonnet-20240620-v1:0` or `eu.anthropic.claude-3-5-sonnet-20240620-v1:0`.
 +
-  * For Haiku: `anthropic.claude-3-haiku-20240307-v1:0`
-  * For Sonnet: `anthropic.claude-3-sonnet-20240229-v1:0`
-  * For Opus: `anthropic.claude-3-opus-20240229-v1:0`
   * Sonnet 3.5: `us.anthropic.claude-3-5-sonnet-20240620-v1:0` or `eu.anthropic.claude-3-5-sonnet-20240620-v1:0`
   * Sonnet 3.5 v2: `us.anthropic.claude-3-5-sonnet-20241022-v2:0` or `eu.anthropiclaude-3-5-sonnet-20241022-v2:0`
   * Sonnet 3.7: `us.anthropic.claude-3-7-sonnet-20250219-v1:0` or `eu.anthropic.claude-3-7-sonnet-20250219-v1:0`


### PR DESCRIPTION
Applies some updates to the Connect to Bedrock guide. These were already applied to the 9.0 docs.

[Preview](https://security-docs_bk_6692.docs-preview.app.elstc.co/guide/en/security/8.x/assistant-connect-to-bedrock.html) 