### PR TITLE
Fixed typo in DaC docs

### DIFF
--- a/docs/detections/detection-engine-intro.asciidoc
+++ b/docs/detections/detection-engine-intro.asciidoc
@@ -130,6 +130,6 @@ To learn how your rules and alerts are affected by using the {ref}/logs-data-str
 
 Utilize the https://dac-reference.readthedocs.io/en/latest/dac_concept_and_workflows.html[Detection-as-Code] (DaC) principles to externally manage your detection rules. 
 
-The {elastic-sec} Labs team uses the https://github.com/elastic/detection-rules[detection-rules] repo to develop, test, and release {elastic-sec}'s <<prebuilt-rules, prebuilt rules>>. The repo provides DaC features and allows you to customize settings to simplify the setup for managing user rules with the DaCe pipeline.
+The {elastic-sec} Labs team uses the https://github.com/elastic/detection-rules[detection-rules] repo to develop, test, and release {elastic-sec}'s <<prebuilt-rules, prebuilt rules>>. The repo provides DaC features and allows you to customize settings to simplify the setup for managing user rules with the DaC pipeline.
 
 To get started, refer to the https://github.com/elastic/detection-rules/blob/main/README.md#detections-as-code-dac[DaC documentation].


### PR DESCRIPTION
Removed the "e" at the end of DaC acronym.

Preview: 