### PR TITLE
Adds note about max file size for get-file command

### DIFF
--- a/docs/management/admin/response-actions.asciidoc
+++ b/docs/management/admin/response-actions.asciidoc
@@ -132,6 +132,8 @@ Required privilege: *File Operations*
 
 Example: `get-file --path "/full/path/to/file.txt" --comment "Possible malware"`
 
+NOTE: The maximum file size that can be retrieved using `get-file` is `104857600` bytes, or 100 MB.
+
 TIP: You can use the <<use-osquery,Osquery manager integration>> to query a host's operating system and gain insight into its files and directories, then use `get-file` to retrieve specific files.
 
 [NOTE]


### PR DESCRIPTION
Fixes #5130 

Adds a note about the maximum file size for files retrieved using the get-file command.