### PR TITLE
[bug][8.x] Adds Automatic Troubleshooting guide

### DIFF
--- a/docs/management/admin/identify-antivirus-software-on-hosts.asciidoc
+++ b/docs/management/admin/identify-antivirus-software-on-hosts.asciidoc
@@ -22,7 +22,7 @@ After you've installed {elastic-defend} on one or more hosts, you can use *Autom
 
 1. Find **Endpoints** in the navigation menu or use the global search field.
 2. Click on an endpoint to open its details flyout.
-3. Under **Automatic Troubleshooting**, select an LLM connector, or [add](../ai/set-up-connectors-for-large-language-models-llm.md) a new one.
+3. Under **Automatic Troubleshooting**, select an LLM connector, or <<llm-connector-guides, add>> a new one.
 4. Click **Scan**. After a brief processing period, any detected AV products will appear under **Insights**.
 
 [discrete]

--- a/docs/management/admin/identify-antivirus-software-on-hosts.asciidoc
+++ b/docs/management/admin/identify-antivirus-software-on-hosts.asciidoc
@@ -1,0 +1,34 @@
+
+[[identify-third-party-av-products]]
+= Identify antivirus software on your hosts
+
+preview::["This feature is in technical preview. It may change in the future, and you should exercise caution when using it in production environments. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of GA features."]
+
+
+Third-party antivirus (AV) software installed on your hosts can interfere with {elastic-defend}. To mitigate issues with running third-party AV alongside {elastic-defend}, you first have to identify which AV is present.
+
+After you've installed {elastic-defend} on one or more hosts, you can use *Automatic Troubleshooting* to check whether your endpoints have third-party AV software installed. Using the same large language model (LLM) connectors as Elastic AI Assistant, Automatic Troubleshooting can analyze file event logs from your hosts to determine whether antivirus software is present. From there, you can address any incompatibilities to make sure your endpoints are protected.
+
+.Requirements
+[sidebar]
+--
+* The **Endpoint Insights: Read** or **Endpoint Insights: All** security sub-feature privilege.
+* A working <<llm-connector-guides, LLM connector>>.
+--
+
+
+[discrete]
+== Scan your hosts for AV software 
+
+1. Find **Endpoints** in the navigation menu or use the global search field.
+2. Click on an endpoint to open its details flyout.
+3. Under **Automatic Troubleshooting**, select an LLM connector, or [add](../ai/set-up-connectors-for-large-language-models-llm.md) a new one.
+4. Click **Scan**. After a brief processing period, any detected AV products will appear under **Insights**.
+
+[discrete]
+== Resolve incompatibilities
+
+After a scan has completed, you can click the **Create trusted app** button to the right of a result to quickly add the associated AV program to {elastic-defend}'s trusted applications list. If the button is not clickable, you don't have the <<trusted-apps-ov, required privilege>>.
+
+IMPORTANT: If you plan to use {elastic-defend} alongside third-party AV software, we recommend you that you both <<allowlist-endpoint-3rd-party-av-apps, allowlist {elastic-endpoint} in your AV>> and <<trusted-apps-ov, make the AV a trusted application>>.
+

--- a/docs/management/manage-intro.asciidoc
+++ b/docs/management/manage-intro.asciidoc
@@ -13,6 +13,7 @@ include::{security-docs-root}/docs/management/admin/blocklist.asciidoc[leveloffs
 include::{security-docs-root}/docs/management/admin/endpoint-artifacts.asciidoc[leveloffset=+1]
 include::{security-docs-root}/docs/management/admin/endpoint-event-capture.asciidoc[leveloffset=+1]
 include::{security-docs-root}/docs/management/admin/endpoint-protection-rules.asciidoc[leveloffset=+1]
+include::{security-docs-root}/docs/management/admin/identify-antivirus-software-on-hosts.asciidoc[leveloffset=+1]
 include::{security-docs-root}/docs/management/admin/allowlist-endpoint-3rd-party-av.asciidoc[leveloffset=+1]
 include::{security-docs-root}/docs/management/admin/endpoint-self-protection.asciidoc[leveloffset=+1]
 include::{security-docs-root}/docs/management/admin/endpoint-command-ref.asciidoc[leveloffset=+1]


### PR DESCRIPTION
fixes #[1158](https://github.com/elastic/docs-content/issues/1158)

Adds missing page to the ESS 8.18 docs. 

[Preview](https://security-docs_bk_6751.docs-preview.app.elstc.co/guide/en/security/8.x/identify-third-party-av-products.html)