### PR TITLE
Moves longstanding known issues for manual runs to docs 

### DIFF
--- a/docs/release-notes/8.16.asciidoc
+++ b/docs/release-notes/8.16.asciidoc
@@ -11,26 +11,6 @@
 
 // tag::known-issue[]
 [discrete]
-.Duplicate alerts can be produced from manually running threshold rules 
-[%collapsible]
-====
-*Details* +
-On November 12, 2024, it was discovered that manually running threshold rules could produce duplicate alerts if the date range was already covered by a scheduled rule execution.
-====
-// end::known-issue[]
-
-// tag::known-issue[]
-[discrete]
-.Manually running custom query rules with suppression could suppress more alerts than expected
-[%collapsible]
-====
-*Details* +
-On November 12, 2024, it was discovered that manually running a custom query rule with suppression could incorrectly inflate the number of suppressed alerts. 
-====
-// end::known-issue[]
-
-// tag::known-issue[]
-[discrete]
 .Installing an {elastic-defend} integration or a new agent policy upgrades installed prebuilt rules, overwriting user-added actions and exceptions
 [%collapsible]
 ====
@@ -59,30 +39,6 @@ To resolve this issue, before you add an {elastic-defend} integration to a polic
 === 8.16.5
 
 [discrete]
-[[known-issue-8.16.5]]
-==== Known issues
-
-// tag::known-issue[]
-[discrete]
-.Duplicate alerts can be produced from manually running threshold rules 
-[%collapsible]
-====
-*Details* +
-On November 12, 2024, it was discovered that manually running threshold rules could produce duplicate alerts if the date range was already covered by a scheduled rule execution.
-====
-// end::known-issue[]
-
-// tag::known-issue[]
-[discrete]
-.Manually running custom query rules with suppression could suppress more alerts than expected
-[%collapsible]
-====
-*Details* +
-On November 12, 2024, it was discovered that manually running a custom query rule with suppression could incorrectly inflate the number of suppressed alerts. 
-====
-// end::known-issue[]
-
-[discrete]
 [[bug-fixes-8.16.5]]
 ==== Bug fixes
 * Fixes an issue with the Event Rendered View in the Alerts table where the table would sometimes have a height of zero and become unusable ({kibana-pull}212130[#212130]).
@@ -91,30 +47,6 @@ On November 12, 2024, it was discovered that manually running a custom query rul
 [discrete]
 [[release-notes-8.16.4]]
 === 8.16.4
-
-[discrete]
-[[known-issue-8.16.4]]
-==== Known issues
-
-// tag::known-issue[]
-[discrete]
-.Duplicate alerts can be produced from manually running threshold rules 
-[%collapsible]
-====
-*Details* +
-On November 12, 2024, it was discovered that manually running threshold rules could produce duplicate alerts if the date range was already covered by a scheduled rule execution.
-====
-// end::known-issue[]
-
-// tag::known-issue[]
-[discrete]
-.Manually running custom query rules with suppression could suppress more alerts than expected
-[%collapsible]
-====
-*Details* +
-On November 12, 2024, it was discovered that manually running a custom query rule with suppression could incorrectly inflate the number of suppressed alerts. 
-====
-// end::known-issue[]
 
 [discrete]
 [[features-8.16.4]]
@@ -148,30 +80,6 @@ On November 12, 2024, it was discovered that manually running a custom query rul
 === 8.16.3
 
 [discrete]
-[[known-issue-8.16.3]]
-==== Known issues
-
-// tag::known-issue[]
-[discrete]
-.Duplicate alerts can be produced from manually running threshold rules 
-[%collapsible]
-====
-*Details* +
-On November 12, 2024, it was discovered that manually running threshold rules could produce duplicate alerts if the date range was already covered by a scheduled rule execution.
-====
-// end::known-issue[]
-
-// tag::known-issue[]
-[discrete]
-.Manually running custom query rules with suppression could suppress more alerts than expected
-[%collapsible]
-====
-*Details* +
-On November 12, 2024, it was discovered that manually running a custom query rule with suppression could incorrectly inflate the number of suppressed alerts. 
-====
-// end::known-issue[]
-
-[discrete]
 [[bug-fixes-8.16.3]]
 ==== Bug fixes
 
@@ -194,30 +102,6 @@ Affected users who are unable to upgrade should set one or both of the following
 [discrete]
 [[release-notes-8.16.2]]
 === 8.16.2
-
-[discrete]
-[[known-issue-8.16.2]]
-==== Known issues
-
-// tag::known-issue[]
-[discrete]
-.Duplicate alerts can be produced from manually running threshold rules 
-[%collapsible]
-====
-*Details* +
-On November 12, 2024, it was discovered that manually running threshold rules could produce duplicate alerts if the date range was already covered by a scheduled rule execution.
-====
-// end::known-issue[]
-
-// tag::known-issue[]
-[discrete]
-.Manually running custom query rules with suppression could suppress more alerts than expected
-[%collapsible]
-====
-*Details* +
-On November 12, 2024, it was discovered that manually running a custom query rule with suppression could incorrectly inflate the number of suppressed alerts. 
-====
-// end::known-issue[]
 
 [discrete]
 [[bug-fixes-8.16.2]]
@@ -305,27 +189,6 @@ On December 17, 2024, this issue was resolved.
 ====
 // end::known-issue[201820]
 
-// tag::known-issue[]
-[discrete]
-.Manually running threshold rules may generate duplicate alerts
-[%collapsible]
-====
-*Details* +
-On November 12, 2024, it was discovered that manually running threshold rules could generate duplicate alerts if the date range was already covered in a scheduled rule execution.
-
-====
-// end::known-issue[]
-
-// tag::known-issue[]
-[discrete]
-.Manually running custom query rules with suppression could suppress more alerts than expected
-[%collapsible]
-====
-*Details* +
-On November 12, 2024, it was discovered that manually running a custom query rule with suppression could incorrectly inflate the number of suppressed alerts. 
-
-====
-// end::known-issue[]
 
 [discrete]
 [[bug-fixes-8.16.1]]
@@ -419,28 +282,6 @@ Updating a Knowledge Base entry of type "index" results in an error.
 
 *Workaround* +
 Instead of updating an "index" entry, delete it and add it again with the desired changes.
-
-====
-// end::known-issue[]
-
-// tag::known-issue[]
-[discrete]
-.Manually running threshold rules may generate duplicate alerts
-[%collapsible]
-====
-*Details* +
-On November 12, 2024, it was discovered that manually running threshold rules could generate duplicate alerts if the date range was already covered in a scheduled rule execution.
-
-====
-// end::known-issue[]
-
-// tag::known-issue[]
-[discrete]
-.Manually running custom query rules with suppression could suppress more alerts than expected
-[%collapsible]
-====
-*Details* +
-On November 12, 2024, it was discovered that manually running a custom query rule with suppression could incorrectly inflate the number of suppressed alerts. 
 
 ====
 // end::known-issue[]

--- a/docs/release-notes/8.17.asciidoc
+++ b/docs/release-notes/8.17.asciidoc
@@ -11,26 +11,6 @@
 
 // tag::known-issue[]
 [discrete]
-.Duplicate alerts can be produced from manually running threshold rules 
-[%collapsible]
-====
-*Details* +
-On November 12, 2024, it was discovered that manually running threshold rules could produce duplicate alerts if the date range was already covered by a scheduled rule execution.
-====
-// end::known-issue[]
-
-// tag::known-issue[]
-[discrete]
-.Manually running custom query rules with suppression could suppress more alerts than expected
-[%collapsible]
-====
-*Details* +
-On November 12, 2024, it was discovered that manually running a custom query rule with suppression could incorrectly inflate the number of suppressed alerts. 
-====
-// end::known-issue[]
-
-// tag::known-issue[]
-[discrete]
 .Installing an {elastic-defend} integration or a new agent policy upgrades installed prebuilt rules, overwriting user-added actions and exceptions
 [%collapsible]
 ====
@@ -67,26 +47,6 @@ To resolve this issue, before you add an {elastic-defend} integration to a polic
 
 // tag::known-issue[]
 [discrete]
-.Duplicate alerts can be produced from manually running threshold rules 
-[%collapsible]
-====
-*Details* +
-On November 12, 2024, it was discovered that manually running threshold rules could produce duplicate alerts if the date range was already covered by a scheduled rule execution.
-====
-// end::known-issue[]
-
-// tag::known-issue[]
-[discrete]
-.Manually running custom query rules with suppression could suppress more alerts than expected
-[%collapsible]
-====
-*Details* +
-On November 12, 2024, it was discovered that manually running a custom query rule with suppression could incorrectly inflate the number of suppressed alerts. 
-====
-// end::known-issue[]
-
-// tag::known-issue[]
-[discrete]
 .Installing an {elastic-defend} integration or a new agent policy upgrades installed prebuilt rules, overwriting user-added actions and exceptions
 [%collapsible]
 ====
@@ -114,30 +74,6 @@ To resolve this issue, before you add an {elastic-defend} integration to a polic
 === 8.17.3
 
 [discrete]
-[[known-issue-8.17.3]]
-==== Known issues
-
-// tag::known-issue[]
-[discrete]
-.Duplicate alerts can be produced from manually running threshold rules 
-[%collapsible]
-====
-*Details* +
-On November 12, 2024, it was discovered that manually running threshold rules could produce duplicate alerts if the date range was already covered by a scheduled rule execution.
-====
-// end::known-issue[]
-
-// tag::known-issue[]
-[discrete]
-.Manually running custom query rules with suppression could suppress more alerts than expected
-[%collapsible]
-====
-*Details* +
-On November 12, 2024, it was discovered that manually running a custom query rule with suppression could incorrectly inflate the number of suppressed alerts. 
-====
-// end::known-issue[]
-
-[discrete]
 [[bug-fixes-8.17.3]]
 ==== Bug fixes
 * Fixes an issue with the Event Rendered View in the Alerts table where the table would sometimes have a height of zero and become unusable ({kibana-pull}212130[#212130]).
@@ -152,30 +88,6 @@ On November 12, 2024, it was discovered that manually running a custom query rul
 [discrete]
 [[release-notes-8.17.2]]
 === 8.17.2
-
-[discrete]
-[[known-issue-8.17.2]]
-==== Known issues
-
-// tag::known-issue[]
-[discrete]
-.Duplicate alerts can be produced from manually running threshold rules 
-[%collapsible]
-====
-*Details* +
-On November 12, 2024, it was discovered that manually running threshold rules could produce duplicate alerts if the date range was already covered by a scheduled rule execution.
-====
-// end::known-issue[]
-
-// tag::known-issue[]
-[discrete]
-.Manually running custom query rules with suppression could suppress more alerts than expected
-[%collapsible]
-====
-*Details* +
-On November 12, 2024, it was discovered that manually running a custom query rule with suppression could incorrectly inflate the number of suppressed alerts. 
-====
-// end::known-issue[]
 
 [discrete]
 [[features-8.17.2]]
@@ -224,26 +136,6 @@ This issue was discovered on February 6, 2025.
 *Workaround* +
 To resolve this issue, upgrade to 8.17.2. Alternatively, increase {kib}'s RAM to 2 GB.
 
-====
-// end::known-issue[]
-
-// tag::known-issue[]
-[discrete]
-.Duplicate alerts can be produced from manually running threshold rules 
-[%collapsible]
-====
-*Details* +
-On November 12, 2024, it was discovered that manually running threshold rules could produce duplicate alerts if the date range was already covered by a scheduled rule execution.
-====
-// end::known-issue[]
-
-// tag::known-issue[]
-[discrete]
-.Manually running custom query rules with suppression could suppress more alerts than expected
-[%collapsible]
-====
-*Details* +
-On November 12, 2024, it was discovered that manually running a custom query rule with suppression could incorrectly inflate the number of suppressed alerts. 
 ====
 // end::known-issue[]
 
@@ -358,27 +250,6 @@ curl -XPOST -H 'Authorization: ApiKey API_KEY_HERE' -H 'kbn-xsrf: true' -H 'elas
 ====
 // end::known-issue[201820]
 
-// tag::known-issue[]
-[discrete]
-.Duplicate alerts can be produced from manually running threshold rules 
-[%collapsible]
-====
-*Details* +
-On November 12, 2024, it was discovered that manually running threshold rules could produce duplicate alerts if the date range was already covered by a scheduled rule execution.
-
-====
-// end::known-issue[]
-
-// tag::known-issue[]
-[discrete]
-.Manually running custom query rules with suppression could suppress more alerts than expected
-[%collapsible]
-====
-*Details* +
-On November 12, 2024, it was discovered that manually running a custom query rule with suppression could incorrectly inflate the number of suppressed alerts. 
-
-====
-// end::known-issue[]
 
 [discrete]
 [[features-8.17.0]]


### PR DESCRIPTION
### Description

Removes longstanding known issues that have not been fixed (and are not on the docket to be fixed) from the Security release notes. 

Since it's still important for users to know about these bugs, I'll be doc'ing them as "limitations" in the manual run feature docs instead. This change has already been made to the 8.18 docs. The 8.16 and 8.17 docs are being updated via https://github.com/elastic/security-docs/pull/6800.

### Preview:
- [8.17.x release notes](https://security-docs_bk_6799.docs-preview.app.elstc.co/guide/en/security/8.x/release-notes-header-8.17.0.html)
- [8.16.x release notes](https://security-docs_bk_6799.docs-preview.app.elstc.co/guide/en/security/8.x/release-notes-header-8.16.0.html)
