### PR TITLE
Mention service risk on Entity Analytics dashboard page

### DIFF
--- a/docs/dashboards/entity-dashboard.asciidoc
+++ b/docs/dashboards/entity-dashboard.asciidoc
@@ -1,7 +1,7 @@
 [[detection-entity-dashboard]]
 = Entity Analytics dashboard
 
-The Entity Analytics dashboard provides a centralized view of emerging insider threats - including host risk, user risk, and anomalies from within your network. Use it to triage, investigate, and respond to these emerging threats.
+The Entity Analytics dashboard provides a centralized view of emerging insider threats—including host risk, user risk, service risk, and anomalies from within your network. Use it to triage, investigate, and respond to these emerging threats.
 
 
 .Requirements


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/1225 by mentioning service risk in the intro paragraph on the Entity Analytics dashboard page.

Preview: [Entity Analytics dashboard](https://security-docs_bk_6803.docs-preview.app.elstc.co/guide/en/security/8.x/detection-entity-dashboard.html)

9.0 PR: https://github.com/elastic/docs-content/pull/1323