### PR TITLE
Fix typo on Endpoint protection rules page

### DIFF
--- a/docs/management/admin/endpoint-protection-rules.asciidoc
+++ b/docs/management/admin/endpoint-protection-rules.asciidoc
@@ -24,14 +24,14 @@ NOTE: When you install Elastic prebuilt rules, the {elastic-defend} is enabled b
 
 The following endpoint protection rules give you more granular control over how you handle the generated alerts. These rules are tailored for each of {elastic-defend}'s endpoint protection features—malware, ransomware, memory threats, and malicious behavior. Enabling these rules allows you to configure more specific actions based on the protection feature and whether the malicious activity was prevented or detected.
 
-* Behavior - Detected - Elastic Defend
-* Behavior - Prevented - Endpoint Defend
-* Malicious File - Detected - Elastic Defend
-* Malicious File - Prevented - Elastic Defend
-* Memory Signature - Detected - Elastic Defend
-* Memory Signature - Prevented - Elastic Defend
-* Ransomware - Detected - Elastic Defend
-* Ransomware - Prevented - Elastic Defend
+* Behavior - Detected - {elastic-defend}
+* Behavior - Prevented - {elastic-defend}
+* Malicious File - Detected - {elastic-defend}
+* Malicious File - Prevented - {elastic-defend}
+* Memory Signature - Detected - {elastic-defend}
+* Memory Signature - Prevented - {elastic-defend}
+* Ransomware - Detected - {elastic-defend}
+* Ransomware - Prevented - {elastic-defend}
 
 NOTE: If you choose to use the feature-specific protection rules, we recommend that you disable the Endpoint Security rule, as using both will result in duplicate alerts.
 


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/1224 by fixing the "Endpoint Defend" typo and replacing all "Elastic Defend" occurrences with the relevant attribute.

Preview: [Endpoint protection rules](https://security-docs_bk_6804.docs-preview.app.elstc.co/guide/en/security/8.x/endpoint-protection-rules.html)

9.0 PR: https://github.com/elastic/docs-content/pull/1324