### PR TITLE
[BUG] Missing param in exception list fetch

### DIFF
--- a/docs/detections/api/exceptions/api-get-exception-containers.asciidoc
+++ b/docs/detections/api/exceptions/api-get-exception-containers.asciidoc
@@ -14,7 +14,7 @@ The URL query must include the container's `id` or `list_id`:
 * `id` - `GET /api/exception_lists?id=<id>`
 * `list_id` - `GET /api/exception_lists?list_id=<list_id>`
 
-(Optional) Use `namespace_type` to to get an exception containers that is available in all {kib} spaces or just the space in which it is created. The available value are:
+(Optional) Use `namespace_type` to to get an exception containers that is available in all {kib} spaces or just the space in which it is created. The available values are:
 
 * `single`: Only available in the {kib} space in which it is created. This is the default value. 
 * `agnostic`: Available in all {kib} spaces.

--- a/docs/detections/api/exceptions/api-get-exception-containers.asciidoc
+++ b/docs/detections/api/exceptions/api-get-exception-containers.asciidoc
@@ -14,6 +14,11 @@ The URL query must include the container's `id` or `list_id`:
 * `id` - `GET /api/exception_lists?id=<id>`
 * `list_id` - `GET /api/exception_lists?list_id=<list_id>`
 
+(Optional) Use `namespace_type` to to get an exception containers that is available in all {kib} spaces or just the space in which it is created. The available value are:
+
+* `single`: Only available in the {kib} space in which it is created. This is the default value. 
+* `agnostic`: Available in all {kib} spaces.
+
 ===== Example request
 
 Retrieves the list container with a `list_id` of `allowed-processes`:


### PR DESCRIPTION
Fixes https://github.com/elastic/security-docs/issues/5966.

Preview: [Get exception container | URL query parameters](https://security-docs_bk_6823.docs-preview.app.elstc.co/guide/en/security/8.15/exceptions-api-get-container.html)
