### PR TITLE
[REQUEST][8.18]: Update frozen tier support wording for DE

### DIFF
--- a/docs/detections/detection-engine-intro.asciidoc
+++ b/docs/detections/detection-engine-intro.asciidoc
@@ -60,7 +60,7 @@ Cold {ref}/data-tiers.html[data tiers] store time series data that's accessed in
 === Best practices 
 
 * **Retention in hot tier**: We recommend keeping data in the hot data tier ({ilm-cap} hot phase) for at least 24 hours. {ilm-cap} policies that move ingested data from the hot phase to another phase (for example, cold or frozen) in less than 24 hours may cause performance issues and/or rule execution errors.
-* **Replicas for mission-critical data**: Your data should have replicas if it must be highly available. Since frozen tiers don't support replicas, shard unavailability can cause partial rule run failures if rules query frozen tiers. Shard unavailability may also occur during or after {stack} upgrades. If this happens, you can <<manually-run-rules,manually rerun>> rules over the affected time period once the shards are available.
+* **Replicas for mission-critical data**: Your data should have replicas if it must be highly available. Since frozen tiers don't have replicas by default, shard unavailability can cause partial rule run failures if rules query frozen tiers. Shard unavailability may also occur during or after {stack} upgrades. If this happens, you can <<manually-run-rules,manually rerun>> rules over the affected time period once the shards are available.
 
 
 [float]


### PR DESCRIPTION
### Description
Contributes to https://github.com/elastic/docs-content/issues/1328 by updating 8.18 docs for the "Manage data in cold and frozen tiers" section. 

Corresponding 9.0 doc updates: https://github.com/elastic/docs-content/pull/1366

### Preview
Preview: [Manage data in cold and frozen tiers | Best practices](https://security-docs_bk_6827.docs-preview.app.elstc.co/guide/en/security/8.x/detection-engine-overview.html#best-practices-data-tiers) - Updated lang in second bullet to show that frozen tiers don't have replicas by default. 

