### PR TITLE
[8.19] Rule execution summary added to Rule Monitoring tab 

### DIFF
--- a/docs/detections/rules-ui-monitor.asciidoc
+++ b/docs/detections/rules-ui-monitor.asciidoc
@@ -22,6 +22,8 @@ Refer to the <<troubleshoot-signals>> section below for strategies on adjusting 
 
 To view a summary of all rule executions (including the most recent failures, execution times, and gaps in rule executions), select the *Rule Monitoring* tab on the *Rules* page. To access the tab, find **Detection rules (SIEM)** in the navigation menu or look for “Detection rules (SIEM)” using the {kibana-ref}/introduction.html#kibana-navigation-search[global search field], then go to the *Rule Monitoring* tab. 
 
+// Remember to update this screenshot for 8.19.
+
 [role="screenshot"]
 image::images/monitor-table.png[]
 

--- a/docs/detections/rules-ui-monitor.asciidoc
+++ b/docs/detections/rules-ui-monitor.asciidoc
@@ -31,11 +31,16 @@ TIP: To sort the rules list, click any column header. To sort in descending orde
 
 For detailed information on a rule, the alerts it generated, and associated errors, click on its name in the table. This also allows you to perform the same actions that are available on the <<rules-ui-management, **Installed Rules** tab>>, such as modifying or deleting rules, activating or deactivating rules, exporting or importing rules, and duplicating prebuilt rules.
 
-For information about rule execution gaps (which are periods of time when a rule didn't run), use the panel above the table. The time filter on the left allows you to select a time range for viewing gap data. The **Total rules with gaps:** field tells you how many rules have unfilled or partially filled gaps within the selected time range. The **Only rules with gaps** filter on the right lets you only display rules with unfilled or partially filled gaps. 
+For information about rule executions and gaps (which are periods of time when a rule didn't run), use the panel above the table, which has the following:
 
-Within the table, the **Last Gap (if any)** column conveys how long the most recent gap for a rule lasted. The **Unfilled gaps duration** column shows whether a rule still has gaps and provides a total sum of the remaining unfilled or partially filled gaps. The total sum can change based on the time range that you select in the panel above the table. If a rule has no gaps, the columns display a dash (`––`).
+* **Time filter**: Allows you to select a time range for viewing execution and gap data. 
+* **Total execution success**: The total success rate of all rule executions that occurred within the selected time range. 
+* **Last execution status summary**: The number of sucessful, failed, and warning statuses reported for the last execution of each rule.
+* **Total rules with gaps**: How many rules have unfilled or partially filled gaps within the selected time range. 
+* **Only rules with gaps**: This filter lets you only display rules with unfilled or partially filled gaps. For a detailed view of a specific rule's gaps, go to the **Execution results** tab and check the <<gaps-table>>.
++
+TIP: Within the rules table, the **Last Gap (if any)** column conveys how long the most recent gap for a rule lasted. The **Unfilled gaps duration** column shows whether a rule still has gaps and provides a total sum of the remaining unfilled or partially filled gaps. The total sum can change based on the time range that you select in the panel above the table. If a rule has no gaps, the columns display a dash (`––`).
 
-TIP: For a detailed view of a rule's gaps, go to the **Execution results** tab and check the <<gaps-table>>.
 
 [float]
 [[rule-execution-logs]]


### PR DESCRIPTION
### Description
Contributes to https://github.com/elastic/docs-content/issues/1325 by updating 8.19 docs.

Corresponding Serverless docs: 

### Preview
Monitor rule executions | Rule Monitoring tab