### PR TITLE
[Security] 8.17.7 release notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -5,6 +5,7 @@ This section summarizes the changes in each release.
 
 * <<release-notes-8.18.1, {elastic-sec} version 8.18.1>>
 * <<release-notes-8.18.0, {elastic-sec} version 8.18.0>>
+* <<release-notes-8.17.7, {elastic-sec} version 8.17.7>>
 * <<release-notes-8.17.6, {elastic-sec} version 8.17.6>>
 * <<release-notes-8.17.5, {elastic-sec} version 8.17.5>>
 * <<release-notes-8.17.4, {elastic-sec} version 8.17.4>>

--- a/docs/release-notes/8.17.asciidoc
+++ b/docs/release-notes/8.17.asciidoc
@@ -8,8 +8,8 @@
 [discrete]
 [[bug-fixes-8.17.7]]
 ==== Fixes
-* Fixes a bug that caused installed prebuilt detection rules to upgrade to their latest available versions when you installed a new {elastic-defend} integration or {agent} policy ({kibana-pull}217959[#217959]).
-* Fixes a bug in {elastic-defend} 8.16.0 where {elastic-endpoint} would incorrectly report some files as being .NET.
+* Fixes a bug that caused installed prebuilt detection rules to upgrade to their latest available versions when you installed a new {elastic-defend} integration or {agent} policy ({kibana-pull}218519[#218519]).
+* Fixes a bug in {elastic-defend} 8.16.0 where {elastic-endpoint} would incorrectly report some files as being `.NET`.
 
 [discrete]
 [[release-notes-8.17.6]]

--- a/docs/release-notes/8.17.asciidoc
+++ b/docs/release-notes/8.17.asciidoc
@@ -2,6 +2,16 @@
 == 8.17
 
 [discrete]
+[[release-notes-8.17.7]]
+=== 8.17.7
+
+[discrete]
+[[bug-fixes-8.17.7]]
+==== Fixes
+* Fixes a bug that caused installed prebuilt detection rules to upgrade to their latest available versions when you installed a new {elastic-defend} integration or {agent} policy ({kibana-pull}217959[#217959]).
+* Fixes a bug in {elastic-defend} 8.16.0 where {elastic-endpoint} would incorrectly report some files as being .NET.
+
+[discrete]
 [[release-notes-8.17.6]]
 === 8.17.6
 


### PR DESCRIPTION
Adds the 8.17.7 Security and Elastic Defend release notes. 

Preview: [8.17.7 release notes](https://security-docs_bk_6852.docs-preview.app.elstc.co/guide/en/security/8.x/release-notes-header-8.17.0.html#release-notes-8.17.7)