### PR TITLE
[Security] 8.18.2 release notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.18.2, {elastic-sec} version 8.18.2>>
 * <<release-notes-8.18.1, {elastic-sec} version 8.18.1>>
 * <<release-notes-8.18.0, {elastic-sec} version 8.18.0>>
 * <<release-notes-8.17.6, {elastic-sec} version 8.17.6>>

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -37,7 +37,7 @@ On April 8, 2025, it was discovered that alert suppression for event correlation
 ==== Enhancements
 * Updates the **MITRE ATT&CK® coverage** page mapping to `v16.1` ({kibana-pull}215026[#215026]).
 * Adds a background task to upgrade Agentless deployments after {kib} has been upgraded ({kibana-pull}207143[#207143]).
-* Improves {elastic-defend}'s' CPU usage on systems with very high event volumes.
+* Improves {elastic-defend}'s CPU usage on systems with very high event volumes.
 
 [discrete]
 [[bug-fixes-8.18.1]]

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -11,6 +11,7 @@
 * Improves error telemetry for the AI assistant ({kibana-pull}220938[#220938]).
 * Simplifies and improves the rule import error message ({kibana-pull}218701[#218701]).
 * Fixes a bug that caused the Dashboard overview page to crash when a Lens widget aggregation error occurred ({kibana-pull}214888[#214888]).
+* Fixes a bug in {elastic-defend} 8.16.0 where {elastic-endpoint} would incorrectly report some files as being `.NET`.
 
 [discrete]
 [[release-notes-8.18.1]]

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -10,7 +10,7 @@
 ==== Fixes
 * Improves error telemetry for the AI assistant ({kibana-pull}220938[#220938]).
 * Simplifies and improves the rule import error message ({kibana-pull}218701[#218701]).
-* Improves the Dashboards overview page by moving visualization responses to visualization tables ({kibana-pull}214888[#214888]).
+* Fixes a bug that caused the Dashboard overview page to crash when a Lens widget aggregation error occurred ({kibana-pull}214888[#214888]).
 
 [discrete]
 [[release-notes-8.18.1]]

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -8,7 +8,7 @@
 [discrete]
 [[bug-fixes-8.18.2]]
 ==== Fixes
-* Improves error telemetry for the AI assistant  ({kibana-pull}220938[#220938]).
+* Improves error telemetry for the AI assistant ({kibana-pull}220938[#220938]).
 * Simplifies and improves the rule import error message ({kibana-pull}218701[#218701]).
 * Improves the dashboards overview page by moving visualization responses to visualization tables ({kibana-pull}214888[#214888]).
 

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -2,6 +2,17 @@
 == 8.18
 
 [discrete]
+[[release-notes-8.18.2]]
+=== 8.18.2
+
+[discrete]
+[[bug-fixes-8.18.2]]
+==== Fixes
+* Improves error telemetry for the AI assistant  ({kibana-pull}220938[#220938]).
+* Simplifies and improves the rule import error message ({kibana-pull}218701[#218701]).
+* Improves the dashboards overview page by moving visualization responses to visualization tables ({kibana-pull}214888[#214888]).
+
+[discrete]
 [[release-notes-8.18.1]]
 === 8.18.1
 

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -10,7 +10,7 @@
 ==== Fixes
 * Improves error telemetry for the AI assistant ({kibana-pull}220938[#220938]).
 * Simplifies and improves the rule import error message ({kibana-pull}218701[#218701]).
-* Improves the dashboards overview page by moving visualization responses to visualization tables ({kibana-pull}214888[#214888]).
+* Improves the Dashboards overview page by moving visualization responses to visualization tables ({kibana-pull}214888[#214888]).
 
 [discrete]
 [[release-notes-8.18.1]]

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -6,6 +6,21 @@
 === 8.18.2
 
 [discrete]
+[[known-issue-8.18.2]]
+==== Known issues
+
+// tag::known-issue[]
+[discrete]
+.The technical preview badge incorrectly displays on the alert suppression fields for event correlation rules 
+[%collapsible]
+====
+*Details* +
+On April 8, 2025, it was discovered that alert suppression for event correlation rules is incorrectly shown as being in technical preview when you create a new rule. For more information, check https://github.com/elastic/docs-content/issues/1021[#1021].
+
+====
+// end::known-issue[]
+
+[discrete]
 [[bug-fixes-8.18.2]]
 ==== Fixes
 * Improves error telemetry for the AI assistant ({kibana-pull}220938[#220938]).


### PR DESCRIPTION
Adds the 8.18.2 Security and Elastic Defend release notes. 

Preview: [8.18.2 release notes](https://security-docs_bk_6853.docs-preview.app.elstc.co/guide/en/security/8.x/release-notes-header-8.18.0.html)