### PR TITLE
Removes tech preview label from Automatic Import in 8.18

### DIFF
--- a/docs/getting-started/automatic-import.asciidoc
+++ b/docs/getting-started/automatic-import.asciidoc
@@ -7,8 +7,6 @@
 :frontmatter-tags-content-type: [overview]
 :frontmatter-tags-user-goals: [get-started]
 
-WARNING: This feature is in technical preview. It may change in the future, and you should exercise caution when using it in production environments. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of GA features.
-
 Automatic Import helps you quickly parse, ingest, and create https://www.elastic.co/elasticsearch/common-schema[ECS mappings] for data from sources that don't yet have prebuilt Elastic integrations. This can accelerate your migration to {elastic-sec}, and help you quickly add new data sources to an existing SIEM solution in {elastic-sec}. Automatic Import uses a large language model (LLM) with specialized instructions to quickly analyze your source data and create a custom integration. 
 
 While Elastic has 400+ {integrations-docs}[prebuilt data integrations], Automatic Import helps you extend data coverage to other security-relevant technologies and applications. Elastic integrations (including those created by Automatic Import) normalize data to {ecs-ref}/ecs-reference.html[the Elastic Common Schema (ECS)], which creates uniformity across dashboards, search, alerts, machine learning, and more. 


### PR DESCRIPTION
Fixes docs-content/1499. Removes the tech preview warning from the 8.18 version of the Automatic Import doc.