### PR TITLE
[Release notes][8.18.x] Add known issue to release notes for "Entity Risk Score documents eventually fail to persist 

### DIFF
--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -19,6 +19,8 @@ On May 30, 2025, it was discovered that the entity risk score feature may stop p
 
 This is due to a bug that prevents the `entity_analytics_create_eventIngest_from_timestamp-pipeline-<space_name>` ingest pipeline (which is set as a default pipeline for the risk scoring index in {stack} 8.18.0) from being created when {kib} starts up.
 
+While document persistence may initially succeed, it will eventually fail after 0 to 30 days. This is how long it takes for the risk score data stream to roll over and apply its underlying index settings to the new default pipeline.
+
 *Workaround* +
 
 To resolve this issue, apply the following workaround before or after upgrading to {stack} 8.18.0 or higher.
@@ -85,6 +87,8 @@ On April 8, 2025, it was discovered that alert suppression for event correlation
 On May 30, 2025, it was discovered that the entity risk score feature may stop persisting risk score documents if risk scoring was turned on before you upgraded to {stack} 8.18.0 or higher. 
 
 This is due to a bug that prevents the `entity_analytics_create_eventIngest_from_timestamp-pipeline-<space_name>` ingest pipeline (which is set as a default pipeline for the risk scoring index in {stack} 8.18.0) from being created when {kib} starts up.
+
+While document persistence may initially succeed, it will eventually fail after 0 to 30 days. This is how long it takes for the risk score data stream to roll over and apply its underlying index settings to the new default pipeline.
 
 *Workaround* +
 
@@ -161,6 +165,8 @@ On April 8, 2025, it was discovered that alert suppression for event correlation
 On May 30, 2025, it was discovered that the entity risk score feature may stop persisting risk score documents if risk scoring was turned on before you upgraded to {stack} 8.18.0 or higher. 
 
 This is due to a bug that prevents the `entity_analytics_create_eventIngest_from_timestamp-pipeline-<space_name>` ingest pipeline (which is set as a default pipeline for the risk scoring index in {stack} 8.18.0) from being created when {kib} starts up.
+
+While document persistence may initially succeed, it will eventually fail after 0 to 30 days. This is how long it takes for the risk score data stream to roll over and apply its underlying index settings to the new default pipeline.
 
 *Workaround* +
 

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -11,6 +11,46 @@
 
 // tag::known-issue[]
 [discrete]
+.The entity risk score feature may stop persisting risk score documents 
+[%collapsible]
+====
+*Details* +
+On May 30, 2025, it was discovered that the entity risk score feature may stop persisting risk score documents if risk scoring was turned on before you upgraded to {stack} 8.18.0 or higher. 
+
+This is due to a bug that prevents the `entity_analytics_create_eventIngest_from_timestamp-pipeline-<space_name>` ingest pipeline (which is set as a default pipeline for the risk scoring index in {stack} 8.18.0) from being created when {kib} starts up.
+
+*Workaround* +
+
+To resolve this issue, apply the following workaround before or after upgrading to {stack} 8.18.0 or higher.
+
+First, manually create the ingest pipeline in each space that has entity risk scoring turned on. You can do this using a PUT request, which is described in the example below. When reviewing the example, note that `default` in the example ingest pipeline name below is the {kib} space ID.
+
+```
+PUT /_ingest/pipeline/entity_analytics_create_eventIngest_from_timestamp-pipeline-default
+{
+  "_meta": {
+    "managed_by": "entity_analytics",
+    "managed": true
+  },
+  "description": "Pipeline for adding timestamp value to event.ingested",
+  "processors": [
+    {
+      "set": {
+        "field": "event.ingested",
+        "value": "{{_ingest.timestamp}}"
+      }
+    }
+  ]
+}
+```
+
+After you complete this step, risk scores should automatically begin to successfully persist during the entity risk engine's next run. Details for the next run time are described on the  Entity risk score page, where you can also manually run the risk score by clicking **Run Engine**. 
+
+====
+// end::known-issue[]
+
+// tag::known-issue[]
+[discrete]
 .The technical preview badge incorrectly displays on the alert suppression fields for event correlation rules 
 [%collapsible]
 ====
@@ -35,6 +75,46 @@ On April 8, 2025, it was discovered that alert suppression for event correlation
 [discrete]
 [[known-issue-8.18.1]]
 ==== Known issues
+
+// tag::known-issue[]
+[discrete]
+.The entity risk score feature may stop persisting risk score documents 
+[%collapsible]
+====
+*Details* +
+On May 30, 2025, it was discovered that the entity risk score feature may stop persisting risk score documents if risk scoring was turned on before you upgraded to {stack} 8.18.0 or higher. 
+
+This is due to a bug that prevents the `entity_analytics_create_eventIngest_from_timestamp-pipeline-<space_name>` ingest pipeline (which is set as a default pipeline for the risk scoring index in {stack} 8.18.0) from being created when {kib} starts up.
+
+*Workaround* +
+
+To resolve this issue, apply the following workaround before or after upgrading to {stack} 8.18.0 or higher.
+
+First, manually create the ingest pipeline in each space that has entity risk scoring turned on. You can do this using a PUT request, which is described in the example below. When reviewing the example, note that `default` in the example ingest pipeline name below is the {kib} space ID.
+
+```
+PUT /_ingest/pipeline/entity_analytics_create_eventIngest_from_timestamp-pipeline-default
+{
+  "_meta": {
+    "managed_by": "entity_analytics",
+    "managed": true
+  },
+  "description": "Pipeline for adding timestamp value to event.ingested",
+  "processors": [
+    {
+      "set": {
+        "field": "event.ingested",
+        "value": "{{_ingest.timestamp}}"
+      }
+    }
+  ]
+}
+```
+
+After you complete this step, risk scores should automatically begin to successfully persist during the entity risk engine's next run. Details for the next run time are described on the  Entity risk score page, where you can also manually run the risk score by clicking **Run Engine**. 
+
+====
+// end::known-issue[]
 
 // tag::known-issue[]
 [discrete]
@@ -71,6 +151,47 @@ On April 8, 2025, it was discovered that alert suppression for event correlation
 [discrete]
 [[known-issue-8.18.0]]
 ==== Known issues
+
+// tag::known-issue[]
+[discrete]
+.The entity risk score feature may stop persisting risk score documents 
+[%collapsible]
+====
+*Details* +
+On May 30, 2025, it was discovered that the entity risk score feature may stop persisting risk score documents if risk scoring was turned on before you upgraded to {stack} 8.18.0 or higher. 
+
+This is due to a bug that prevents the `entity_analytics_create_eventIngest_from_timestamp-pipeline-<space_name>` ingest pipeline (which is set as a default pipeline for the risk scoring index in {stack} 8.18.0) from being created when {kib} starts up.
+
+*Workaround* +
+
+To resolve this issue, apply the following workaround before or after upgrading to {stack} 8.18.0 or higher.
+
+First, manually create the ingest pipeline in each space that has entity risk scoring turned on. You can do this using a PUT request, which is described in the example below. When reviewing the example, note that `default` in the example ingest pipeline name below is the {kib} space ID.
+
+```
+PUT /_ingest/pipeline/entity_analytics_create_eventIngest_from_timestamp-pipeline-default
+{
+  "_meta": {
+    "managed_by": "entity_analytics",
+    "managed": true
+  },
+  "description": "Pipeline for adding timestamp value to event.ingested",
+  "processors": [
+    {
+      "set": {
+        "field": "event.ingested",
+        "value": "{{_ingest.timestamp}}"
+      }
+    }
+  ]
+}
+```
+
+After you complete this step, risk scores should automatically begin to successfully persist during the entity risk engine's next run. Details for the next run time are described on the  Entity risk score page, where you can also manually run the risk score by clicking **Run Engine**. 
+
+====
+// end::known-issue[]
+
 // tag::known-issue[]
 [discrete]
 .Rules cannot be enabled if they're corrupted while upgrading from 7.17.x to 8.x 

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -46,7 +46,7 @@ PUT /_ingest/pipeline/entity_analytics_create_eventIngest_from_timestamp-pipelin
 }
 ```
 
-After you complete this step, risk scores should automatically begin to successfully persist during the entity risk engine's next run. Details for the next run time are described on the  Entity risk score page, where you can also manually run the risk score by clicking **Run Engine**. 
+After you complete this step, risk scores should automatically begin to successfully persist during the entity risk engine's next run. Details for the next run time are described on the **Entity risk score** page, where you can also manually run the risk score by clicking **Run Engine**. 
 
 ====
 // end::known-issue[]
@@ -115,7 +115,7 @@ PUT /_ingest/pipeline/entity_analytics_create_eventIngest_from_timestamp-pipelin
 }
 ```
 
-After you complete this step, risk scores should automatically begin to successfully persist during the entity risk engine's next run. Details for the next run time are described on the  Entity risk score page, where you can also manually run the risk score by clicking **Run Engine**. 
+After you complete this step, risk scores should automatically begin to successfully persist during the entity risk engine's next run. Details for the next run time are described on the **Entity risk score** page, where you can also manually run the risk score by clicking **Run Engine**. 
 
 ====
 // end::known-issue[]
@@ -193,7 +193,7 @@ PUT /_ingest/pipeline/entity_analytics_create_eventIngest_from_timestamp-pipelin
 }
 ```
 
-After you complete this step, risk scores should automatically begin to successfully persist during the entity risk engine's next run. Details for the next run time are described on the  Entity risk score page, where you can also manually run the risk score by clicking **Run Engine**. 
+After you complete this step, risk scores should automatically begin to successfully persist during the entity risk engine's next run. Details for the next run time are described on the **Entity risk score** page, where you can also manually run the risk score by clicking **Run Engine**. 
 
 ====
 // end::known-issue[]


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/1548 by adding a known issue about the risk score feature in 8.18.x. 

Preview: 
- [8.18.0](https://security-docs_bk_6866.docs-preview.app.elstc.co/guide/en/security/8.x/release-notes-header-8.18.0.html#known-issue-8.18.0)
- [8.18.1](https://security-docs_bk_6866.docs-preview.app.elstc.co/guide/en/security/8.x/release-notes-header-8.18.0.html#known-issue-8.18.1)
- [8.18.2](https://security-docs_bk_6866.docs-preview.app.elstc.co/guide/en/security/8.x/release-notes-header-8.18.0.html#known-issue-8.18.2)

**Corresponding PRs**
- 9.x/Serverless: https://github.com/elastic/docs-content/pull/1550