### PR TITLE
[8.18.x] Tech preview label removed from alert suppression fields for EQL rules 

### DIFF
--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -120,7 +120,7 @@ After you complete this step, risk scores should automatically begin to successf
 On April 8, 2025, it was discovered that alert suppression for event correlation rules is incorrectly shown as being in technical preview when you create a new rule. For more information, check https://github.com/elastic/docs-content/issues/1021[#1021].
 
 *Resolved* +
-This issue is fixed in {stack} versions 8.18.2.
+This issue is fixed in {stack} version 8.18.2.
 
 ====
 // end::known-issue[]
@@ -216,7 +216,7 @@ Duplicate your rules and enable them.
 On April 8, 2025, it was discovered that alert suppression for event correlation rules is incorrectly shown as being in technical preview when you create a new rule. For more information, check https://github.com/elastic/docs-content/issues/1021[#1021].
 
 *Resolved* +
-This issue is fixed in {stack} versions 8.18.2.
+This issue is fixed in {stack} version 8.18.2.
 
 ====
 // end::known-issue[]

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -51,16 +51,6 @@ After you complete this step, risk scores should automatically begin to successf
 ====
 // end::known-issue[]
 
-// tag::known-issue[]
-[discrete]
-.The technical preview badge incorrectly displays on the alert suppression fields for event correlation rules 
-[%collapsible]
-====
-*Details* +
-On April 8, 2025, it was discovered that alert suppression for event correlation rules is incorrectly shown as being in technical preview when you create a new rule. For more information, check https://github.com/elastic/docs-content/issues/1021[#1021].
-
-====
-// end::known-issue[]
 
 [discrete]
 [[bug-fixes-8.18.2]]
@@ -68,6 +58,7 @@ On April 8, 2025, it was discovered that alert suppression for event correlation
 * Improves error telemetry for the AI assistant ({kibana-pull}220938[#220938]).
 * Simplifies and improves the rule import error message ({kibana-pull}218701[#218701]).
 * Fixes a bug that caused the Dashboard overview page to crash when a Lens widget aggregation error occurred ({kibana-pull}214888[#214888]).
+* Removes the technical preview badge from the alert suppression fields for event correlation rules.
 * Fixes a bug in {elastic-defend} 8.16.0 where {elastic-endpoint} would incorrectly report some files as being `.NET`.
 
 [discrete]
@@ -127,6 +118,9 @@ After you complete this step, risk scores should automatically begin to successf
 ====
 *Details* +
 On April 8, 2025, it was discovered that alert suppression for event correlation rules is incorrectly shown as being in technical preview when you create a new rule. For more information, check https://github.com/elastic/docs-content/issues/1021[#1021].
+
+*Resolved* +
+This issue is fixed in {stack} versions 8.18.2.
 
 ====
 // end::known-issue[]
@@ -220,6 +214,9 @@ Duplicate your rules and enable them.
 ====
 *Details* +
 On April 8, 2025, it was discovered that alert suppression for event correlation rules is incorrectly shown as being in technical preview when you create a new rule. For more information, check https://github.com/elastic/docs-content/issues/1021[#1021].
+
+*Resolved* +
+This issue is fixed in {stack} versions 8.18.2.
 
 ====
 // end::known-issue[]


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/1653.

The tech preview label was removed from alert suppression fields for EQL rules in 8.18.2. This PR updates the known issue summaries for that bug and adds a bug fix summary to the 8.18.2 release notes.

Preview: [8.18.x release notes](https://security-docs_bk_6877.docs-preview.app.elstc.co/guide/en/security/8.x/release-notes-header-8.18.0.html)

Corresponding 9.x PR: https://github.com/elastic/docs-content/pull/1654