### PR TITLE
Adds required API permissions for runscript

### DIFF
--- a/docs/management/admin/response-actions-config.asciidoc
+++ b/docs/management/admin/response-actions-config.asciidoc
@@ -37,7 +37,8 @@ Expand a section below for your endpoint security system:
 . **Enable API access in CrowdStrike.** Create an API client in CrowdStrike to allow access to the system. Refer to CrowdStrike's docs for instructions.
 +
 - Give the API client the minimum privilege required to read CrowdStrike data and perform actions on enrolled hosts. Consider creating separate API clients for reading data and performing actions, to limit privileges allowed by each API client.
-   * To isolate and release hosts, the API client must have `Read` access for Alerts, and `Read` and `Write` access for Hosts.
+   * To isolate and release hosts: `Read` access for `Alerts`, and `Read` and `Write` access for `Hosts`.
+   * To run a script on a host: `Read` and `Write` access for `Real time response`; for elevated access, `Write` access for `Real time response (admin)` is also required.
 
 - Take note of the client ID, client secret, and base URL; you'll need them in later steps when you configure {elastic-sec} components to access CrowdStrike.
 


### PR DESCRIPTION
Adds the missing required API permissions for the `runscript` response action when creating an API client in CrowdStrike, per [this comment](https://github.com/elastic/docs-content/pull/1650#issuecomment-2958367773).
`runscript` for CrowdStrike was [added](https://github.com/elastic/security-docs/issues/6365) in 8.18.

Preview: [Configure third-party response actions](https://security-docs_bk_6879.docs-preview.app.elstc.co/guide/en/security/8.x/response-actions-config.html)