### PR TITLE
Fixes to Security AI Assistant Knowledge Base page

### DIFF
--- a/docs/AI-for-security/knowledge-base.asciidoc
+++ b/docs/AI-for-security/knowledge-base.asciidoc
@@ -52,12 +52,13 @@ image::images/knowledge-base-assistant-settings-kb-tab.png[AI Assistant's settin
 [discrete]
 [[rag-for-alerts]]
 == Knowledge base for alerts
-When Knowledge Base is enabled, AI Assistant receives `open` or `acknowledged` alerts from your environment from the last 24 hours. It uses these as context for each of your prompts. This enables it to answer questions about multiple alerts in your environment rather than just about individual alerts you choose to send it. It receives alerts ordered by risk score, then by the most recently generated. Building block alerts are excluded. 
+AI Assistant receives `open` or `acknowledged` alerts from your environment from the last 24 hours and uses them as context for your prompts. This enables it to answer questions about multiple alerts in your environment rather than just about individual alerts you choose to send it. It receives alerts ordered by risk score, then by the most recently generated. Building block alerts are excluded. 
 
-To enable Knowledge Base for alerts:
+To configure alert access for Knowledge Base:
 
-. Ensure that knowledge base is <<enable-knowledge-base, enabled>>.
-. On the **Security AI settings** page, go to the **Knowledge Base** tab and use the slider to select the number of alerts to send to AI Assistant. Click **Save**.
+. Go the **Security AI settings** page. Use the {kibana-ref}/introduction.html#kibana-navigation-search[global search field] to find "AI Assistant for Security."
+. On the **Knowledge Base** tab, use the slider to select the number of alerts to send to AI Assistant.
+. Click **Save**.
 
 NOTE: Including a large number of alerts may cause your request to exceed the maximum token length of your third-party generative AI provider. If this happens, try selecting a lower number of alerts to send.
 


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/1399 by clarifying that the Knowledge Base feature does not need to be enabled to ask the assistant about open or acknowledged alerts in the environment from the last 24 hours.

9.x PR: https://github.com/elastic/docs-content/pull/1683

Preview: [AI Assistant Knowledge Base | Knowledge base for alerts](https://security-docs_bk_6883.docs-preview.app.elstc.co/guide/en/security/8.x/ai-assistant-knowledge-base.html#rag-for-alerts)