### PR TITLE
[Security] 8.17.8 release notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -6,6 +6,7 @@ This section summarizes the changes in each release.
 * <<release-notes-8.18.2, {elastic-sec} version 8.18.2>>
 * <<release-notes-8.18.1, {elastic-sec} version 8.18.1>>
 * <<release-notes-8.18.0, {elastic-sec} version 8.18.0>>
+* <<release-notes-8.17.8, {elastic-sec} version 8.17.8>>
 * <<release-notes-8.17.7, {elastic-sec} version 8.17.7>>
 * <<release-notes-8.17.6, {elastic-sec} version 8.17.6>>
 * <<release-notes-8.17.5, {elastic-sec} version 8.17.5>>

--- a/docs/release-notes/8.17.asciidoc
+++ b/docs/release-notes/8.17.asciidoc
@@ -2,6 +2,18 @@
 == 8.17
 
 [discrete]
+[[release-notes-8.17.8]]
+=== 8.17.8
+
+[discrete]
+[[bug-fixes-8.17.8]]
+==== Fixes
+* Fixes cell actions not working when opening a timeline from specific rules ({kibana-pull}223297[#223297]).
+* Fixes rule filters display issues ({kibana-pull}222963[#222963]).
+* Fixes banner title in event preview ({kibana-pull}222266[#222266]).
+* Fixes model bedrock on preconfigured connectors ({kibana-pull}221411[#221411]).
+
+[discrete]
 [[release-notes-8.17.7]]
 === 8.17.7
 

--- a/docs/release-notes/8.17.asciidoc
+++ b/docs/release-notes/8.17.asciidoc
@@ -17,7 +17,7 @@
 * Fixes rule filters display issues ({kibana-pull}222963[#222963]).
 * Fixes banner title in event preview ({kibana-pull}222266[#222266]).
 * Fixes model bedrock on preconfigured connectors ({kibana-pull}221411[#221411]).
-* Fixes an issue in {elastic-defend}'s networking kernel driver that can manifest as a `DPC_WATCHDOG_VIOLATION` [bugcheck](https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/bug-checks--blue-screens-) in high-load environments that maintain a large number of concurrent and/or short-lived network connections.
+* Fixes an issue in {elastic-defend}'s networking kernel driver that can manifest as a `DPC_WATCHDOG_VIOLATION` https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/bug-checks--blue-screens-[bugcheck] in high-load environments that maintain a large number of concurrent and/or short-lived network connections.
 * Removes potentially confusing {elastic-defend} error messages.
 * Fixes an edge case in {elastic-defend}'s `call_stack_final_user_module` and `call_stack_final_hook_module` logic.
 

--- a/docs/release-notes/8.17.asciidoc
+++ b/docs/release-notes/8.17.asciidoc
@@ -13,10 +13,10 @@
 [discrete]
 [[bug-fixes-8.17.8]]
 ==== Fixes
-* Fixes cell actions not working when opening a timeline from specific rules ({kibana-pull}223297[#223297]).
+* Fixes cell actions not working when opening a Timeline from specific rules ({kibana-pull}223297[#223297]).
 * Fixes rule filters display issues ({kibana-pull}222963[#222963]).
 * Fixes banner title in event preview ({kibana-pull}222266[#222266]).
-* Fixes model bedrock on preconfigured connectors ({kibana-pull}221411[#221411]).
+* Fixes model {bedrock} on preconfigured connectors ({kibana-pull}221411[#221411]).
 * Fixes an issue in {elastic-defend}'s networking kernel driver that can manifest as a `DPC_WATCHDOG_VIOLATION` https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/bug-checks--blue-screens-[bugcheck] in high-load environments that maintain a large number of concurrent and/or short-lived network connections.
 * Removes potentially confusing {elastic-defend} error messages.
 * Fixes an edge case in {elastic-defend}'s `call_stack_final_user_module` and `call_stack_final_hook_module` logic.

--- a/docs/release-notes/8.17.asciidoc
+++ b/docs/release-notes/8.17.asciidoc
@@ -6,12 +6,20 @@
 === 8.17.8
 
 [discrete]
+[[enhancements-8.17.8]]
+==== Enhancements
+* Improves the performance of {elastic-defend}'s WFP network driver in high-load environments that maintain a large number of concurrent and/or short-lived network connections.
+
+[discrete]
 [[bug-fixes-8.17.8]]
 ==== Fixes
 * Fixes cell actions not working when opening a timeline from specific rules ({kibana-pull}223297[#223297]).
 * Fixes rule filters display issues ({kibana-pull}222963[#222963]).
 * Fixes banner title in event preview ({kibana-pull}222266[#222266]).
 * Fixes model bedrock on preconfigured connectors ({kibana-pull}221411[#221411]).
+* Fixes an issue in {elastic-defend}'s networking kernel driver that can manifest as a `DPC_WATCHDOG_VIOLATION` [bugcheck](https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/bug-checks--blue-screens-) in high-load environments that maintain a large number of concurrent and/or short-lived network connections.
+* Removes potentially confusing {elastic-defend} error messages.
+* Fixes an edge case in {elastic-defend}'s `call_stack_final_user_module` and `call_stack_final_hook_module` logic.
 
 [discrete]
 [[release-notes-8.17.7]]

--- a/docs/release-notes/8.17.asciidoc
+++ b/docs/release-notes/8.17.asciidoc
@@ -20,6 +20,8 @@
 * Fixes an issue in {elastic-defend}'s networking kernel driver that can manifest as a `DPC_WATCHDOG_VIOLATION` https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/bug-checks--blue-screens-[bugcheck] in high-load environments that maintain a large number of concurrent and/or short-lived network connections.
 * Removes potentially confusing {elastic-defend} error messages.
 * Fixes an edge case in {elastic-defend}'s `call_stack_final_user_module` and `call_stack_final_hook_module` logic.
+* Fixes an issue where {elastic-defend} Linux network events would have source and destination byte counts swapped.
+* Fixes a memory growth bug in {elastic-defend} for Linux when both "Collect session data" and "Capture terminal output" are enabled.
 
 [discrete]
 [[release-notes-8.17.7]]

--- a/docs/release-notes/8.17.asciidoc
+++ b/docs/release-notes/8.17.asciidoc
@@ -21,7 +21,7 @@
 * Removes potentially confusing {elastic-defend} error messages.
 * Fixes an edge case in {elastic-defend}'s `call_stack_final_user_module` and `call_stack_final_hook_module` logic.
 * Fixes an issue where {elastic-defend} Linux network events would have source and destination byte counts swapped.
-* Fixes a memory growth bug in {elastic-defend} for Linux when both "Collect session data" and "Capture terminal output" are enabled.
+* Fixes a memory growth bug in {elastic-defend} for Linux when both **Collect session data** and **Capture terminal output** are enabled.
 
 [discrete]
 [[release-notes-8.17.7]]


### PR DESCRIPTION
Contributes to https://github.com/elastic/security-docs/issues/6874: adds the 8.17.8 Security and Elastic Defend release notes.

Preview: [8.17.8](https://security-docs_bk_6890.docs-preview.app.elstc.co/guide/en/security/8.x/release-notes-header-8.17.0.html#release-notes-8.17.8)