### PR TITLE
[Security] 8.18.3 release notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.18.3, {elastic-sec} version 8.18.3>>
 * <<release-notes-8.18.2, {elastic-sec} version 8.18.2>>
 * <<release-notes-8.18.1, {elastic-sec} version 8.18.1>>
 * <<release-notes-8.18.0, {elastic-sec} version 8.18.0>>

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -2,6 +2,24 @@
 == 8.18
 
 [discrete]
+[[release-notes-8.18.3]]
+=== 8.18.3
+
+[discrete]
+[[enhancements-8.18.3]]
+==== Enhancements
+* Adds `dns` event collection for macOS for {elastic-defend} ({kibana-pull}223566[#223566]).
+* Adds pricing information about Elastic Managed LLM in AI Assistant and Attack Discovery tours and callouts ({kibana-pull}221566[#221566]).
+
+[discrete]
+[[bug-fixes-8.18.3]]
+==== Fixes
+* Fixes a bug where OSS models didn't work when streaming was ON ({kibana-pull}224129[#224129]).
+* Fixes a bug where cell actions didn't work when opening a timeline from specific rules ({kibana-pull}223302[#223302]).
+* Fixes an issue where the entity risk score feature stopped persisting risk score documents ({kibana-pull}221937[#221937]).
+* Fixes rule upgrade Threat Match mapping components overflowing on small screens ({kibana-pull}218628[#218628]).
+
+[discrete]
 [[release-notes-8.18.2]]
 === 8.18.2
 
@@ -47,6 +65,9 @@ PUT /_ingest/pipeline/entity_analytics_create_eventIngest_from_timestamp-pipelin
 ```
 
 After you complete this step, risk scores should automatically begin to successfully persist during the entity risk engine's next run. Details for the next run time are described on the **Entity risk score** page, where you can also manually run the risk score by clicking **Run Engine**. 
+
+*Resolved* +
+This issue is fixed in {stack} version 8.18.3.
 
 ====
 // end::known-issue[]
@@ -107,6 +128,9 @@ PUT /_ingest/pipeline/entity_analytics_create_eventIngest_from_timestamp-pipelin
 ```
 
 After you complete this step, risk scores should automatically begin to successfully persist during the entity risk engine's next run. Details for the next run time are described on the **Entity risk score** page, where you can also manually run the risk score by clicking **Run Engine**. 
+
+*Resolved* +
+This issue is fixed in {stack} version 8.18.3.
 
 ====
 // end::known-issue[]
@@ -188,6 +212,9 @@ PUT /_ingest/pipeline/entity_analytics_create_eventIngest_from_timestamp-pipelin
 ```
 
 After you complete this step, risk scores should automatically begin to successfully persist during the entity risk engine's next run. Details for the next run time are described on the **Entity risk score** page, where you can also manually run the risk score by clicking **Run Engine**. 
+
+*Resolved* +
+This issue is fixed in {stack} version 8.18.3.
 
 ====
 // end::known-issue[]

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -17,7 +17,7 @@
 * Fixes a bug where OSS models didn't work when streaming was ON ({kibana-pull}224129[#224129]).
 * Fixes a bug where cell actions didn't work when opening a Timeline from specific rules ({kibana-pull}223302[#223302]).
 * Fixes an issue where the entity risk score feature stopped persisting risk score documents ({kibana-pull}221937[#221937]).
-* Fixes rule upgrade Threat Match mapping components overflowing on small screens ({kibana-pull}218628[#218628]).
+* Fixes overflow issues with the threat match mapping component when you viewed the rule upgrade flyout on a smaller screen ({kibana-pull}218628[#218628]).
 
 [discrete]
 [[release-notes-8.18.2]]

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -10,6 +10,7 @@
 ==== Enhancements
 * Adds `dns` event collection for macOS for {elastic-defend} ({kibana-pull}223566[#223566]).
 * Adds pricing information about Elastic Managed LLM in AI Assistant and Attack Discovery tours and callouts ({kibana-pull}221566[#221566]).
+* Adds local file path support for `xpack.productDocBase.artifactRepositoryUrl` ({kibana-pull}217046[#217046]).
 
 [discrete]
 [[bug-fixes-8.18.3]]
@@ -18,6 +19,8 @@
 * Fixes a bug where cell actions didn't work when opening a Timeline from specific rules ({kibana-pull}223302[#223302]).
 * Fixes an issue where the entity risk score feature stopped persisting risk score documents ({kibana-pull}221937[#221937]).
 * Fixes overflow issues with the threat match mapping component when you viewed the rule upgrade flyout on a smaller screen ({kibana-pull}218628[#218628]).
+* Ensures the {bedrock} connector respects the action proxy configuration ({kibana-pull}224130[#224130]).
+* Ensures the OpenAI connector respects the action proxy configuration for all sub-actions ({kibana-pull}219617[#219617]).
 
 [discrete]
 [[release-notes-8.18.2]]

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -15,7 +15,7 @@
 [[bug-fixes-8.18.3]]
 ==== Fixes
 * Fixes a bug where OSS models didn't work when streaming was ON ({kibana-pull}224129[#224129]).
-* Fixes a bug where cell actions didn't work when opening a timeline from specific rules ({kibana-pull}223302[#223302]).
+* Fixes a bug where cell actions didn't work when opening a Timeline from specific rules ({kibana-pull}223302[#223302]).
 * Fixes an issue where the entity risk score feature stopped persisting risk score documents ({kibana-pull}221937[#221937]).
 * Fixes rule upgrade Threat Match mapping components overflowing on small screens ({kibana-pull}218628[#218628]).
 


### PR DESCRIPTION
Contributes to https://github.com/elastic/security-docs/issues/6874: adds the 8.18.3 Security release notes.

Preview: [8.18.3](https://security-docs_bk_6891.docs-preview.app.elstc.co/guide/en/security/8.x/release-notes-header-8.18.0.html#release-notes-8.18.3)