### PR TITLE
[Security] 7.17.29 release notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.17.29, {elastic-sec} version 7.17.29>>
 * <<release-notes-7.17.28, {elastic-sec} version 7.17.28>>
 * <<release-notes-7.17.27, {elastic-sec} version 7.17.27>>
 * <<release-notes-7.17.26, {elastic-sec} version 7.17.26>>

--- a/docs/release-notes/7.17.asciidoc
+++ b/docs/release-notes/7.17.asciidoc
@@ -2,6 +2,16 @@
 == 7.17
 
 [discrete]
+[[release-notes-7.17.29]]
+=== 7.17.29
+
+[discrete]
+[[bug-fixes-7.17.29]]
+==== Bug fixes and enhancements
+
+There are no user-facing changes in the 7.17.29 release.
+
+[discrete]
 [[release-notes-7.17.28]]
 === 7.17.28
 


### PR DESCRIPTION
Adds a release notes entry for 7.17.29.

Preview: [7.17](https://security-docs_bk_6895.docs-preview.app.elstc.co/guide/en/security/7.17/release-notes-header-7.17.0.html)