### PR TITLE
[8.19] Document external EDR script picker for CrowdStrike

### DIFF
--- a/docs/management/admin/response-actions.asciidoc
+++ b/docs/management/admin/response-actions.asciidoc
@@ -203,7 +203,7 @@ NOTE: This response action is supported only for <<crowdstrike-response-actions,
 Run a script on a host. You must include one of the following parameters to identify the script you want to run:
 
 * `--Raw`: The full script content provided directly as a string.
-* `--CloudFile`: The name of the script stored in a cloud storage location.
+* `--CloudFile`: The name of the script stored in a cloud storage location. When using this parameter, select from a list of saved custom scripts.
 * `--HostPath`: The absolute or relative file path of the script located on the host machine.
 
 You can also use these optional parameters:


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/1498 by documenting the script picker functionality for the `runscript` response action for Crodwstrike.

Twin serverless PR: https://github.com/elastic/docs-content/pull/1650.

Preview: [Endpoint response actions | runscript](https://security-docs_bk_6896.docs-preview.app.elstc.co/guide/en/security/8.x/response-actions.html#runscript)
