### PR TITLE
[8.18 Removes CEL support statement from automatic import in 8.18

### DIFF
--- a/docs/getting-started/automatic-import.asciidoc
+++ b/docs/getting-started/automatic-import.asciidoc
@@ -31,10 +31,7 @@ To use Automatic Import, you must provide a sample of the data you wish to impor
 * The more variety in your sample, the more accurate the pipeline will be. For best results, include a wide range of unique log entries in your sample instead of repeating similar logs.
 * When uploading a CSV, a header with column names will be automatically recognized. However if the header is not present, the LLM will still attempt to create descriptive field names based on field formats and values.
 * For JSON and NDJSON samples, each object in your sample should represent an event, and you should avoid deeply nested object structures.
-* When you select `API (CEL input)` as one of the sources, you will be prompted to provide the associated OpenAPI specification (OAS) file to generate a CEL program that consumes this API.
 --
-
-WARNING: Note that CEL generation in Automatic Import is in beta and is subject to change. The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.
 
 .Recommended models
 [sidebar]

--- a/docs/whats-new.asciidoc
+++ b/docs/whats-new.asciidoc
@@ -23,11 +23,6 @@ Other versions: {security-guide-all}/8.17/whats-new.html[8.17] | {security-guide
 image::whats-new/images/8.18/security-siem-migration-1.png[The Upload Splunk SIEM rules flyout]
 
 [float]
-=== Automatic Import improvements
-
-{security-guide}/automatic-import.html[Automatic Import] now allows you to select API (CEL input) as a data source and to provide the associated OpenAPI specification (OAS) file to automatically generate a CEL program to consume an API.
-
-[float]
 === Control which alerts Attack Discovery analyzes 
 
 You can now specify which alerts {security-guide}/attack-discovery.html[Attack Discovery] analyzes using a date and time selector and a KQL filter.


### PR DESCRIPTION
Fixes [#2014](https://github.com/elastic/docs-content/issues/2014)

Removes an incorrect statement about support automatic import supporting CEL input in 8.18