### PR TITLE
Adds BSOD known issue to 8.18.3 RNs

### DIFF
--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -11,7 +11,7 @@
 
 // tag::known-issue[]
 [discrete]
-.
+. {elastic-defend}'s network driver may lead to bug checks
 [%collapsible]
 ====
 *Details* +

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -11,7 +11,7 @@
 
 // tag::known-issue[]
 [discrete]
-. {elastic-defend}'s network driver may lead to bug checks
+.{elastic-defend}'s network driver may lead to bug checks
 [%collapsible]
 ====
 *Details* +

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -6,6 +6,30 @@
 === 8.18.3
 
 [discrete]
+[[known-issue-8.18.3]]
+==== Known issues
+
+// tag::known-issue[]
+[discrete]
+.
+[%collapsible]
+====
+*Details* +
+On July 8, 2025, a known issue was discovered in {elastic-defend}'s network driver that may lead to kernel pool corruption, resulting in bug checks (BSODs) on Windows systems with a large number of long-lived network connections that remain inactive for 30+ minutes.
+
+The system may bug check with any of a variety of codes such as `SYSTEM_SERVICE_EXCEPTION` or `PAGE_FAULT_IN_NONPAGED_AREA`.
+
+For more information, check https://github.com/elastic/endpoint/issues/90[#90]
+
+*Workaround* +
+Upgrade to the fixed version: https://www.elastic.co/downloads/past-releases/elastic-agent-8-18-3+build202507101319[8.18.3+build202507101319].
+
+If you're unable to upgrade or downgrade, set the `advanced.kernel.network` advanced setting to `false` in your {elastic-defend} integration policy.
+====
+// end::known-issue[]
+
+
+[discrete]
 [[enhancements-8.18.3]]
 ==== Enhancements
 * Adds `dns` event collection for macOS for {elastic-defend} ({kibana-pull}223566[#223566]).


### PR DESCRIPTION
Contributes to https://github.com/elastic/security-docs/issues/6927.

Preview: [8.18](https://security-docs_bk_6928.docs-preview.app.elstc.co/guide/en/security/8.19/release-notes-header-8.18.0.html)