### PR TITLE
[8.19] Bulk-apply and remove alert suppression 

### DIFF
--- a/docs/detections/alert-suppression.asciidoc
+++ b/docs/detections/alert-suppression.asciidoc
@@ -115,8 +115,6 @@ Some rule types have a maximum number of alerts that can be suppressed (custom q
 * **Threshold, event correlation, {esql}, and {ml}:** The maximum number of alerts is the value you choose for the rule's **Max alerts per run** <<rule-ui-advanced-params,advanced setting>>, which is `100` by default.
 * **Indicator match and new terms:** The maximum number is five times the value you choose for the rule's **Max alerts per run** <<rule-ui-advanced-params,advanced setting>>. The default value is `100`, which means the default maximum limit for indicator match rules and new term rules is `500`.
 
-[float]
-[[alert-suppression-bulk-apply]]
 === Bulk apply and remove alert suppression
 
 From the Rules table, use the **Bulk actions** menu to apply or remove alert suppression to multiple rules. The **Apply alert suppression** option can be used for all rules types except for the threshold rule type. To bulk-apply alert suppression to threshold rules, use the bulk menu option that's labeled for threshold rules only.

--- a/docs/detections/alert-suppression.asciidoc
+++ b/docs/detections/alert-suppression.asciidoc
@@ -114,3 +114,9 @@ Some rule types have a maximum number of alerts that can be suppressed (custom q
 
 * **Threshold, event correlation, {esql}, and {ml}:** The maximum number of alerts is the value you choose for the rule's **Max alerts per run** <<rule-ui-advanced-params,advanced setting>>, which is `100` by default.
 * **Indicator match and new terms:** The maximum number is five times the value you choose for the rule's **Max alerts per run** <<rule-ui-advanced-params,advanced setting>>. The default value is `100`, which means the default maximum limit for indicator match rules and new term rules is `500`.
+
+[float]
+[[alert-suppression-bulk-apply]]
+=== Bulk apply and remove alert suppression
+
+From the Rules table, use the **Bulk actions** menu to apply or remove alert suppression to multiple rules. The *Apply alert suppression** option can be used for all rules types except for the threshold rule type. To bulk-apply alert suppression to threshold rules, use the bulk menu option that's labeled for threshold rules only.

--- a/docs/detections/alert-suppression.asciidoc
+++ b/docs/detections/alert-suppression.asciidoc
@@ -119,4 +119,4 @@ Some rule types have a maximum number of alerts that can be suppressed (custom q
 [[alert-suppression-bulk-apply]]
 === Bulk apply and remove alert suppression
 
-From the Rules table, use the **Bulk actions** menu to apply or remove alert suppression to multiple rules. The *Apply alert suppression** option can be used for all rules types except for the threshold rule type. To bulk-apply alert suppression to threshold rules, use the bulk menu option that's labeled for threshold rules only.
+From the Rules table, use the **Bulk actions** menu to apply or remove alert suppression to multiple rules. The **Apply alert suppression** option can be used for all rules types except for the threshold rule type. To bulk-apply alert suppression to threshold rules, use the bulk menu option that's labeled for threshold rules only.


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/1719 by adding a new section to the alert suppression page about bulk-applying and removing suppression from rules.

Preview - New section 

**Corresponding 9.1 and Serverless docs**: https://github.com/elastic/docs-content/pull/2174