### PR TITLE
[8.19] Prebuilt rule reversion documentation 

### DIFF
--- a/docs/detections/rules-ui-manage.asciidoc
+++ b/docs/detections/rules-ui-manage.asciidoc
@@ -90,6 +90,19 @@ NOTE: Rule actions won't run during a {kibana-ref}/maintenance-windows.html[main
 +
 NOTE: Edited prebuilt rules have the `Modified` badge on their details' pages and in the Rules table.
 
+
+NOTE: Modified fields on prebuilt rules are marked with the **Modified** badge. From the rule's details page, click the badge to view the changed fields. Changes are displayed in a side-by-side comparison of the original Elastic version and the modified version. Deleted characters are highlighted in red; added characters are highlighted in green. You can also view this comparison by clicking the **Modified Elastic rule** badge under the rule's name on the rule's details page.
+
+[float]
+[[revert-rule-changes]]
+=== Revert modifications to prebuilt rules
+
+After modifying a prebuilt rule, you can restore it's original version. To do this:
+
+1. Open the rule's details page, click the **All actions** menu, then **Revert to Elastic version**.
+2. In the flyout, review the modified fields. Deleted characters are highlighted in red; added characters are highlighted in green.
+3. Click **Revert** to restore the modified fields to their original versions. 
+
 [float]
 [[manage-rules-ui]]
 === Manage rules

--- a/docs/detections/rules-ui-manage.asciidoc
+++ b/docs/detections/rules-ui-manage.asciidoc
@@ -103,6 +103,8 @@ After modifying a prebuilt rule, you can restore it's original version. To do th
 2. In the flyout, review the modified fields. Deleted characters are highlighted in red; added characters are highlighted in green.
 3. Click **Revert** to restore the modified fields to their original versions. 
 
+NOTE: If you haven’t updated the rule in a while, its original version might be unavailable for comparison. You can avoid this by regularly updating prebuilt rules.
+
 [float]
 [[manage-rules-ui]]
 === Manage rules


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/1940 by documenting how to check modified prebuilt rule fields and revert them.

Previews:
- [Modify existing rules settings](https://security-docs_bk_6937.docs-preview.app.elstc.co/guide/en/security/8.19/rules-ui-management.html#edit-rules-settings) - Added a note to the end about how to spot and view modified fields on prebuilt rules.
- [Revert modifications to prebuilt rules](https://security-docs_bk_6937.docs-preview.app.elstc.co/guide/en/security/8.19/rules-ui-management.html#revert-rule-changes) - New section

**Corresponding 9.19 and Serverless docs**: https://github.com/elastic/docs-content/pull/2175