### PR TITLE
8.18.4 release notes fix

### DIFF
--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -24,7 +24,7 @@
 * Fixes a bug where the **Rules**, **Alerts**, and **Fleet** pages would stall in air-gapped environments ({kibana-pull}220510[#220510]).
 * Fixes a bug where unmodified prebuilt rules installed before v8.18 didn't appear in the **Upgrade** table when the **Unmodified** filter was selected ({kibana-pull}227859[#227859]).
 * Improves UI copy for the "bulk update with conflicts" modal ({kibana-pull}227803[#227803]).
-* Fixes an issue in {elastic-defend} that may result in bugchecks (BSODs) on Windows systems with a very high volume of network connections. This issue has only been observed on Windows Server.
+* Fixes an issue in {elastic-defend} that may result in bugchecks (BSODs) on Windows systems with a very high volume of network connections.
 
 [discrete]
 [[release-notes-8.18.3]]


### PR DESCRIPTION
Removes reference to Windows server in the Elastic Defend bugfix, per https://github.com/elastic/endpoint/issues/90#issuecomment-3102832354.