### PR TITLE
8.17.9 release notes fix

### DIFF
--- a/docs/release-notes/8.17.asciidoc
+++ b/docs/release-notes/8.17.asciidoc
@@ -13,7 +13,7 @@
 [discrete]
 [[bug-fixes-8.17.9]]
 ==== Fixes
-* Fixes an issue in {elastic-defend} that sometimes caused bugchecks (BSODs) on Windows Server systems that had a very high volume of network connections. 
+* Fixes an issue in {elastic-defend} that sometimes caused bugchecks (BSODs) on Windows systems that had a very high volume of network connections. 
 * Fixes a bug where Linux endpoint network events would fail to load if IPv6 was not supported by the system.
 
 [discrete]


### PR DESCRIPTION
Removes reference to Windows server in the Elastic Defend bugfix, per https://github.com/elastic/endpoint/issues/90#issuecomment-3102832354.