### PR TITLE
[Internal][Security]: Building block rule actions

### DIFF
--- a/docs/detections/building-block-rule.asciidoc
+++ b/docs/detections/building-block-rule.asciidoc
@@ -10,6 +10,8 @@ in the UI. This is useful when you want:
 You can then use building block rules to create hidden alerts that act as a
 basis for an 'ordinary' rule to generate visible alerts.
 
+TIP: Add <<rule-notifications, rule notifications>> to building block rules to notify you when building block alerts are generated. 
+
 [float]
 === Set up rules that run on alert indices
 


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/2334 by clarifying that you can add rule notifications to building block rules.

Preview

**Corresponding 9.x/Serverless docs**:
- https://github.com/elastic/docs-content/pull/2370