### PR TITLE
8.18.5 release notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -5,6 +5,7 @@ This section summarizes the changes in each release.
 
 * <<release-notes-8.19.1, {elastic-sec} version 8.19.1>>
 * <<release-notes-8.19.0, {elastic-sec} version 8.19.0>>
+* <<release-notes-8.18.5, {elastic-sec} version 8.18.5>>
 * <<release-notes-8.18.4, {elastic-sec} version 8.18.4>>
 * <<release-notes-8.18.3, {elastic-sec} version 8.18.3>>
 * <<release-notes-8.18.2, {elastic-sec} version 8.18.2>>

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -15,6 +15,8 @@
 [[bug-fixes-8.18.5]]
 ==== Fixes
 * Improves UI copy for the "bulk update with conflicts" modal ({kibana-pull}227803[#227803]).
+* Fixes an issue where {elastic-defend} would fail to enable network events on Linux if IPv6 is not supported by the system.
+* Fixes an issue in {elastic-defend} that could result in a crash if a {ls} output configuration is specified containing a certificate that cannot not be parsed.
 
 [discrete]
 [[release-notes-8.18.4]]
@@ -38,7 +40,6 @@
 * Refactors Timeline styling for improved consistency with design updates ({kibana-pull}222438[#222438]).
 * Fixes a bug where the **Rules**, **Alerts**, and **Fleet** pages would stall in air-gapped environments ({kibana-pull}220510[#220510]).
 * Fixes a bug where unmodified prebuilt rules installed before v8.18 didn't appear in the **Upgrade** table when the **Unmodified** filter was selected ({kibana-pull}227859[#227859]).
-* Improves UI copy for the "bulk update with conflicts" modal ({kibana-pull}227803[#227803]).
 * Fixes an issue in {elastic-defend} that may result in bugchecks (BSODs) on Windows systems with a very high volume of network connections.
 
 [discrete]
@@ -68,6 +69,7 @@ If you're unable to upgrade or downgrade, set the `advanced.kernel.network` adva
 
 *Resolved* +
 This issue is fixed in {stack} version 8.18.4.
+
 ====
 // end::known-issue[]
 

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -13,7 +13,7 @@
 * Reduces {elastic-defend} CPU usage for ETW events, API events, and Behavioral Protections. In some cases, this may be a significant reduction.
 * Allows {elastic-defend} to automatically recover in some situations when it loses connectivity with {agent}.
 * Shortens the time it takes {elastic-defend} to recover from a `DEGRADED` status caused by communication issues with {agent}.
-* Makes {elastic-defend} malware scan queue operate more efficiently on Windows by not blocking scan requests when an oplock for the file being scanned cannot be acquired.
+* Improves {elastic-defend} malware scan queue efficiency on Windows by not blocking scan requests when an oplock for the file being scanned cannot be acquired.
 * Due to an issue in macOS, {elastic-defend} would sometimes send network events without `user.name` populated. {elastic-defend} will now identify these events and populate `user.name` if necessary.
 
 [discrete]
@@ -21,7 +21,7 @@
 ==== Fixes
 * Improves UI copy for the "bulk update with conflicts" modal ({kibana-pull}227803[#227803]).
 * Fixes an issue where {elastic-defend} would fail to enable network events on Linux if IPv6 is not supported by the system.
-* Fixes an issue in {elastic-defend} that could result in a crash if a {ls} output configuration is specified containing a certificate that cannot not be parsed.
+* Fixes an issue in {elastic-defend} that could result in a crash if a {ls} output configuration contains a certificate that cannot be parsed.
 
 [discrete]
 [[release-notes-8.18.4]]

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -2,6 +2,21 @@
 == 8.18
 
 [discrete]
+[[release-notes-8.18.5]]
+=== 8.18.5
+
+[discrete]
+[[enhancements-8.18.5]]
+==== Enhancements
+* Adds the `detection_rule_upgrade_status` object to snapshot telemetry schema ({kibana-pull}223086[#223086]).
+* To help identify which parts of `elastic-endpoint.exe` are using a significant amount of CPU, {elastic-defend} on Windows can now include CPU profiling data in diagnostics. To request CPU profiling data using the command line, refer to {fleet-guide}/elastic-agent-cmd-options.html#_options[{agent} command reference]. To request CPU profiling data using {kib}, check the **Collect additional CPU metrics** box when requesting {agent} diagnostics.
+
+[discrete]
+[[bug-fixes-8.18.5]]
+==== Fixes
+* Improves UI copy for the "bulk update with conflicts" modal ({kibana-pull}227803[#227803]).
+
+[discrete]
 [[release-notes-8.18.4]]
 === 8.18.4
 

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -11,10 +11,10 @@
 * Adds the `detection_rule_upgrade_status` object to snapshot telemetry schema ({kibana-pull}223086[#223086]).
 * Reduces {elastic-defend} CPU when processing events from the System process on Windows.
 * Reduces {elastic-defend} CPU usage for ETW events, API events, and Behavioral Protections. In some cases, this may be a significant reduction.
-* Allows the {elastic-defend} to automatically recover in some situations when it loses connectivity with Agent.
-* Shortens the time it takes {elastic-defend} to recover from a DEGRADED status caused by communication issues with {elastic-agent}.
+* Allows {elastic-defend} to automatically recover in some situations when it loses connectivity with {agent}.
+* Shortens the time it takes {elastic-defend} to recover from a `DEGRADED` status caused by communication issues with {agent}.
 * Makes {elastic-defend} malware scan queue operate more efficiently on Windows by not blocking scan requests when an oplock for the file being scanned cannot be acquired.
-* Due to an issue in macOS, {elastic-defend} would sometimes send network events without `user.name` populated. {elastic-defend} will now identify these events and populate `user.name` if necessary
+* Due to an issue in macOS, {elastic-defend} would sometimes send network events without `user.name` populated. {elastic-defend} will now identify these events and populate `user.name` if necessary.
 
 [discrete]
 [[bug-fixes-8.18.5]]
@@ -30,6 +30,7 @@
 [discrete]
 [[enhancements-8.18.4]]
 ==== Enhancements
+* Adds the `elastic_customized_total`, `elastic_noncustomized_total`, and `is_customized` fields to snapshot telemetry schema ({kibana-pull}222370[#222370]).
 * Improves logging of fatal exceptions in {elastic-defend}.
 * Allows {elastic-defend} users to control the maximum file size for malware protection using the `advanced.malware.max_file_size_bytes` advanced policy setting.
 

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -9,7 +9,7 @@
 [[enhancements-8.18.5]]
 ==== Enhancements
 * Adds the `detection_rule_upgrade_status` object to snapshot telemetry schema ({kibana-pull}223086[#223086]).
-* Reduces {elastic-defend} CPU when processing events from the System process on Windows.
+* Reduces {elastic-defend} CPU usage when processing events from the System process on Windows.
 * Reduces {elastic-defend} CPU usage for ETW events, API events, and Behavioral Protections. In some cases, this may be a significant reduction.
 * Allows {elastic-defend} to automatically recover in some situations when it loses connectivity with {agent}.
 * Shortens the time it takes {elastic-defend} to recover from a `DEGRADED` status caused by communication issues with {agent}.

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -65,6 +65,9 @@ For more information, check https://github.com/elastic/endpoint/issues/90[#90]
 Upgrade to the fixed version: https://www.elastic.co/downloads/past-releases/elastic-agent-8-18-3+build202507101319[8.18.3+build202507101319].
 
 If you're unable to upgrade or downgrade, set the `advanced.kernel.network` advanced setting to `false` in your {elastic-defend} integration policy.
+
+*Resolved* +
+This issue is fixed in {stack} version 8.18.4.
 ====
 // end::known-issue[]
 

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -9,7 +9,12 @@
 [[enhancements-8.18.5]]
 ==== Enhancements
 * Adds the `detection_rule_upgrade_status` object to snapshot telemetry schema ({kibana-pull}223086[#223086]).
-* To help identify which parts of `elastic-endpoint.exe` are using a significant amount of CPU, {elastic-defend} on Windows can now include CPU profiling data in diagnostics. To request CPU profiling data using the command line, refer to {fleet-guide}/elastic-agent-cmd-options.html#_options[{agent} command reference]. To request CPU profiling data using {kib}, check the **Collect additional CPU metrics** box when requesting {agent} diagnostics.
+* Reduces {elastic-defend} CPU when processing events from the System process on Windows.
+* Reduces {elastic-defend} CPU usage for ETW events, API events, and Behavioral Protections. In some cases, this may be a significant reduction.
+* Allows the {elastic-defend} to automatically recover in some situations when it loses connectivity with Agent.
+* Shortens the time it takes {elastic-defend} to recover from a DEGRADED status caused by communication issues with {elastic-agent}.
+* Makes {elastic-defend} malware scan queue operate more efficiently on Windows by not blocking scan requests when an oplock for the file being scanned cannot be acquired.
+* Due to an issue in macOS, {elastic-defend} would sometimes send network events without `user.name` populated. {elastic-defend} will now identify these events and populate `user.name` if necessary
 
 [discrete]
 [[bug-fixes-8.18.5]]


### PR DESCRIPTION
Resolves https://github.com/elastic/security-docs/issues/6954: adds the 8.18.5 Security and Endpoint release notes.

Preview: [8.18.5](https://security-docs_bk_7022.docs-preview.app.elstc.co/guide/en/security/8.19/release-notes-header-8.18.0.html#release-notes-8.18.5)