### PR TITLE
8.19.2 release notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.19.2, {elastic-sec} version 8.19.2>>
 * <<release-notes-8.19.1, {elastic-sec} version 8.19.1>>
 * <<release-notes-8.19.0, {elastic-sec} version 8.19.0>>
 * <<release-notes-8.18.4, {elastic-sec} version 8.18.4>>

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -16,7 +16,8 @@
 [discrete]
 [[bug-fixes-8.19.2]]
 ==== Fixes
-* Fixes a bug where Linux endpoint network events would fail to load if IPV6 is not supported by the system.
+* Due to an issue in macOS, {elastic-defend} would sometimes send network events without `user.name` populated. {elastic-defend} will now identify these events and populate `user.name` if necessary
+* Fixes an issue in {elastic-defend} performance metrics that resulted in `endpoint_uptime_percent` always being 0 for behavioral rules.
 
 [discrete]
 [[release-notes-8.19.1]]

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -2,6 +2,15 @@
 == 8.19
 
 [discrete]
+[[release-notes-8.19.2]]
+=== 8.19.2
+
+[discrete]
+[[bug-fixes-8.19.2]]
+==== Bug fixes and enhancements
+There are no user-facing changes in the 8.19.2 release.
+
+[discrete]
 [[release-notes-8.19.1]]
 === 8.19.1
 

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -10,6 +10,8 @@
 ==== Enhancements
 * Makes {elastic-defend} malware scan queue operate more efficiently by not blocking scan requests when an oplock for the file being scanned cannot be acquired.
 * To help identify which parts of `elastic-endpoint.exe` are using a significant amount of CPU, {elastic-defend} on Windows can now include CPU profiling data in diagnostics. To request CPU profiling data via the command line, refer to the {fleet-guide}/elastic-agent-cmd-options.html#_options[Agent command reference]. To request CPU profiling data via Kibana, check the **Collect additional CPU metrics** box when requesting {agent} diagnostics.  
+* Shortens the time it takes for {elastic-defend} to recover from a DEGRADED status caused by Elastic Agent communication issues.
+* Allows {elastic-defend} to automatically recover in some situations when it loses connectivity with {agent}.
 
 [discrete]
 [[bug-fixes-8.19.2]]

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -2,13 +2,16 @@
 == 8.19
 
 [discrete]
-[[release-notes-8.19.2]]
-=== 8.19.2
+[[enhancements-8.19.2]]
+==== Enhancements
+* Makes {elastic-defend} malware scan queue operate more efficiently by not blocking scan requests when an oplock for the file being scanned cannot be acquired.
+* To help identify which parts of `elastic-endpoint.exe` are using a significant amount of CPU, {elastic-defend} on Windows can now include CPU profiling data in diagnostics. To request CPU profiling data via the command line, refer to the {ref}/elastic-agent-cmd-options.html#_options[Agent command reference]. To request CPU profiling data via Kibana, check the **Collect additional CPU metrics** box when requesting {agent} diagnostics.
 
 [discrete]
 [[bug-fixes-8.19.2]]
-==== Bug fixes and enhancements
-There are no user-facing changes in the 8.19.2 release.
+==== Fixes
+* Fixes a race condition in {elastic-defend} that may occasionally result in corrupted process command lines on Windows.  When this occurs, `process.command_line`, `process.args_count` and `process.args` may be incorrect, leading to false positives.
+* Fixes a bug where Linux endpoint network events would fail to load if IPV6 is not supported by the system.
 
 [discrete]
 [[release-notes-8.19.1]]

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -16,7 +16,6 @@
 [discrete]
 [[bug-fixes-8.19.2]]
 ==== Fixes
-* Fixes a race condition in {elastic-defend} that may occasionally result in corrupted process command lines on Windows.  When this occurs, `process.command_line`, `process.args_count` and `process.args` may be incorrect, leading to false positives.
 * Fixes a bug where Linux endpoint network events would fail to load if IPV6 is not supported by the system.
 
 [discrete]

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -2,6 +2,10 @@
 == 8.19
 
 [discrete]
+[[release-notes-8.19.2]]
+=== 8.19.2
+
+[discrete]
 [[enhancements-8.19.2]]
 ==== Enhancements
 * Makes {elastic-defend} malware scan queue operate more efficiently by not blocking scan requests when an oplock for the file being scanned cannot be acquired.

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -125,3 +125,4 @@
 * Fixes the {elastic-defend} artifact `channel` field and adds `manifest_type` in {elastic-defend} policy responses.
 * Fixes a bug in {elastic-defend} where Linux network events would have source and destination byte counts swapped.
 * Fixes a memory growth bug in {elastic-defend} on Linux when both **Collect session data** and **Capture terminal output** are enabled.
+* Fixes a bug where Linux endpoint network events would fail to load if IPV6 is not supported by the system.

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -9,7 +9,7 @@
 [[enhancements-8.19.2]]
 ==== Enhancements
 * Makes {elastic-defend} malware scan queue operate more efficiently by not blocking scan requests when an oplock for the file being scanned cannot be acquired.
-* To help identify which parts of `elastic-endpoint.exe` are using a significant amount of CPU, {elastic-defend} on Windows can now include CPU profiling data in diagnostics. To request CPU profiling data via the command line, refer to the {ref}/elastic-agent-cmd-options.html#_options[Agent command reference]. To request CPU profiling data via Kibana, check the **Collect additional CPU metrics** box when requesting {agent} diagnostics.
+* To help identify which parts of `elastic-endpoint.exe` are using a significant amount of CPU, {elastic-defend} on Windows can now include CPU profiling data in diagnostics. To request CPU profiling data via the command line, refer to the {fleet-guide}/elastic-agent-cmd-options.html#_options[Agent command reference]. To request CPU profiling data via Kibana, check the **Collect additional CPU metrics** box when requesting {agent} diagnostics.  
 
 [discrete]
 [[bug-fixes-8.19.2]]

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -8,15 +8,15 @@
 [discrete]
 [[enhancements-8.19.2]]
 ==== Enhancements
-* Makes {elastic-defend} malware scan queue operate more efficiently by not blocking scan requests when an oplock for the file being scanned cannot be acquired.
-* To help identify which parts of `elastic-endpoint.exe` are using a significant amount of CPU, {elastic-defend} on Windows can now include CPU profiling data in diagnostics. To request CPU profiling data via the command line, refer to the {fleet-guide}/elastic-agent-cmd-options.html#_options[Agent command reference]. To request CPU profiling data via Kibana, check the **Collect additional CPU metrics** box when requesting {agent} diagnostics.  
-* Shortens the time it takes for {elastic-defend} to recover from a DEGRADED status caused by Elastic Agent communication issues.
+* Improves {elastic-defend} malware scan queue efficiency by not blocking scan requests when an oplock for the file being scanned cannot be acquired.
+* To help identify which parts of `elastic-endpoint.exe` are using a significant amount of CPU, {elastic-defend} on Windows can now include CPU profiling data in diagnostics. To request CPU profiling data using the command line, refer to the {fleet-guide}/elastic-agent-cmd-options.html#_options[Agent command reference]. To request CPU profiling data using Kibana, check the **Collect additional CPU metrics** box when requesting {agent} diagnostics.  
+* Shortens the time it takes for {elastic-defend} to recover from a `DEGRADED` status caused by {agent} communication issues.
 * Allows {elastic-defend} to automatically recover in some situations when it loses connectivity with {agent}.
 
 [discrete]
 [[bug-fixes-8.19.2]]
 ==== Fixes
-* Due to an issue in macOS, {elastic-defend} would sometimes send network events without `user.name` populated. {elastic-defend} will now identify these events and populate `user.name` if necessary
+* Due to an issue in macOS, {elastic-defend} would sometimes send network events without `user.name` populated. {elastic-defend} will now identify these events and populate `user.name` if necessary.
 * Fixes an issue in {elastic-defend} performance metrics that resulted in `endpoint_uptime_percent` always being 0 for behavioral rules.
 
 [discrete]


### PR DESCRIPTION
Resolves https://github.com/elastic/security-docs/issues/7023: adds the 8.19.2 Security and Endpoint release notes.

Preview: [8.19.2](https://security-docs_bk_7024.docs-preview.app.elstc.co/guide/en/security/8.19/release-notes-header-8.19.0.html)