### PR TITLE
Updates to Endpoints page

### DIFF
--- a/docs/management/admin/admin-pg-ov.asciidoc
+++ b/docs/management/admin/admin-pg-ov.asciidoc
@@ -24,19 +24,9 @@ The Endpoints list provides the following data:
 
 * *Endpoint*: The system hostname. Click the link to display <<endpoint-details,endpoint details>> in a flyout.
 
-* *Agent Status*: The current status of the {agent}, which is one of the following:
-
-** `Healthy`: The agent is online and communicating with {kib}.
-
-** `Unenrolling`: The agent is currently unenrolling and will soon be removed from Fleet. Afterward, the endpoint will also uninstall.
-
-** `Unhealthy`: The agent is online but requires attention from an administrator because it's reporting a problem with a process. An unhealthy status could mean an upgrade failed and was rolled back to its previous version, or an integration might be missing prerequisites or additional configuration. Refer to <<ts-unhealthy-agent,Endpoint management troubleshooting>> for more on resolving an unhealthy agent status.
-
-** `Updating`: The agent is online and is updating the agent policy or binary, or is enrolling or unenrolling.
-
-** `Offline`: The agent is still enrolled but may be on a machine that is shut down or currently does not have internet access. In this state, the agent is no longer communicating with {kib} at a regular interval.
+* *Agent Status*: The current {fleet-guide}/monitor-elastic-agent.html#view-agent-status[status] of the {agent}.
 +
-NOTE: {agent} statuses in {fleet} correspond to the agent statuses in the {security-app}.
+NOTE: Not all {agent} statuses in {fleet} correspond to the statuses in the {security-app}. For example, an `unenrolled` {agent} in {fleet} shows as `offline` in the {security-app}.
 
 * *Policy:* The name of the associated integration policy when the agent was installed. Click the link to display the <<integration-policy-details,integration policy details>> page.
 


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/2327 by replacing the list of Agent statuses with a link to the source-of-truth Agent docs.
Contributes to https://github.com/elastic/docs-content/issues/2332 by updating the note about status mapping in Fleet and Elastic Security.

9.x PR: https://github.com/elastic/docs-content/pull/2604

Preview: [Endpoints](https://security-docs_bk_7031.docs-preview.app.elstc.co/guide/en/security/8.19/admin-page-ov.html)