### PR TITLE
Adds links for endpoint protection rules

### DIFF
--- a/docs/management/admin/endpoint-protection-rules.asciidoc
+++ b/docs/management/admin/endpoint-protection-rules.asciidoc
@@ -14,9 +14,9 @@ When endpoint protection rules are triggered, {elastic-endpoint} alerts are disp
 [[endpoint-sec-rule]]
 == Endpoint Security rule
 
-The Endpoint Security rule automatically creates an alert from all incoming {elastic-endpoint} alerts. 
+The <<endpoint-security-elastic-defend>> rule automatically creates an alert from all incoming {elastic-endpoint} alerts. 
 
-NOTE: When you install Elastic prebuilt rules, the {elastic-defend} is enabled by default. 
+NOTE: When you install Elastic prebuilt rules, the Endpoint Security ({elastic-defend}) rule is enabled by default. 
 
 [discrete]
 [[feature-protection-rules]]
@@ -24,20 +24,20 @@ NOTE: When you install Elastic prebuilt rules, the {elastic-defend} is enabled b
 
 The following endpoint protection rules give you more granular control over how you handle the generated alerts. These rules are tailored for each of {elastic-defend}'s endpoint protection features—malware, ransomware, memory threats, and malicious behavior. Enabling these rules allows you to configure more specific actions based on the protection feature and whether the malicious activity was prevented or detected.
 
-* Behavior - Detected - {elastic-defend}
-* Behavior - Prevented - {elastic-defend}
-* Malicious File - Detected - {elastic-defend}
-* Malicious File - Prevented - {elastic-defend}
-* Memory Signature - Detected - {elastic-defend}
-* Memory Signature - Prevented - {elastic-defend}
-* Ransomware - Detected - {elastic-defend}
-* Ransomware - Prevented - {elastic-defend}
+* <<behavior-detected-elastic-defend>>
+* <<behavior-prevented-elastic-defend>>
+* <<malicious-file-detected-elastic-defend>>
+* <<malicious-file-prevented-elastic-defend>>
+* <<memory-threat-detected-elastic-defend>>
+* <<memory-threat-prevented-elastic-defend>>
+* <<ransomware-detected-elastic-defend>>
+* <<ransomware-prevented-elastic-defend>>
 
-NOTE: If you choose to use the feature-specific protection rules, we recommend that you disable the Endpoint Security rule, as using both will result in duplicate alerts.
+NOTE: If you choose to use the feature-specific protection rules, we recommend that you disable the Endpoint Security ({elastic-defend}) rule, as using both will result in duplicate alerts.
 
 To use these rules, you need to manually enable them from the **Rules** page in the {security-app}. Follow the instructions for <<load-prebuilt-rules,installing and enabling Elastic prebuilt rules>>.
 
 [discrete]
 == Endpoint security exception handling
 
-All endpoint protection rules share a common exception list called the Endpoint Security Exception List. This ensures that if you switch between using the Endpoint Security rule and the feature-specific protection rules, your existing <<endpoint-rule-exceptions, {elastic-endpoint} exceptions>> continue to apply.
+All endpoint protection rules share a common exception list called the Endpoint Security Exception List. This ensures that if you switch between using the Endpoint Security ({elastic-defend}) rule and the feature-specific protection rules, your existing <<endpoint-rule-exceptions, {elastic-endpoint} exceptions>> continue to apply.


### PR DESCRIPTION
Contributes to https://github.com/elastic/security-docs/issues/6182 by adding links from the Endpoint protection rules page to the prebuilt rule docs for those rules.

9.x PR: https://github.com/elastic/docs-content/pull/2620

Preview: [Endpoint protection rules](https://security-docs_bk_7036.docs-preview.app.elstc.co/guide/en/security/current/endpoint-protection-rules.html)