### PR TITLE
Clarify quarantined file handling in Elastic Defend docs

### DIFF
--- a/docs/getting-started/configure-integration-policy.asciidoc
+++ b/docs/getting-started/configure-integration-policy.asciidoc
@@ -84,7 +84,7 @@ image::images/install-endpoint/malware-protection.png[Detail of malware protecti
 [[manage-quarantined-files]]
 === Manage quarantined files
 
-When *Prevent* is enabled for malware protection, {elastic-defend} will quarantine any malicious file it finds (this includes files defined in the <<blocklist>>). Specifically {elastic-defend} will remove the file from its current location, encrypt it with the encryption key `ELASTIC`, move it to a different folder, and rename it as a GUID string, such as `318e70c2-af9b-4c3a-939d-11410b9a112c`.
+When *Prevent* is enabled for malware protection, {elastic-defend} will quarantine any malicious file it finds (this includes files defined in the <<blocklist>>). Specifically {elastic-defend} will remove the file from its current location, apply a rolling XOR with the key `ELASTIC`, move it to a different folder, and rename it as a GUID string, such as `318e70c2-af9b-4c3a-939d-11410b9a112c`.
 
 The quarantine folder location varies by operating system:
 
@@ -96,6 +96,8 @@ The quarantine folder location varies by operating system:
 To restore a quarantined file to its original state and location, <<add-exceptions, add an exception>> to the rule that identified the file as malicious. If the exception would've stopped the rule from identifying the file as malicious, {elastic-defend} restores the file.
 
 You can access a quarantined file by using the `get-file` <<response-action-commands,response action command>> in the response console. To do this, copy the path from the alert's **Quarantined file path** field (`file.Ext.quarantine_path`), which appears under **Highlighted fields** in the alert details flyout. Then paste the value into the `--path` parameter. This action doesn't restore the file to its original location, so you will need to do this manually.
+
+IMPORTANT: When you retrieve a quarantined file using `get-file`, the XOR obfuscation is automatically reversed, and the original malicious file is retrieved.
 
 NOTE: Response actions and the response console UI are https://www.elastic.co/pricing[Enterprise subscription] features.
 


### PR DESCRIPTION
Contributes to https://github.com/elastic/security-docs/issues/5157 by clarifying that files quarantined by Elastic Defend are obfuscated with a rolling XOR and that the get-file action automatically reverses this to retrieve the original file.

9.x PR: https://github.com/elastic/docs-content/pull/2619

Preview: [Configure an integration policy for Elastic Defend > Manage quarantined files](https://security-docs_bk_7037.docs-preview.app.elstc.co/guide/en/security/current/configure-endpoint-integration-policy.html#manage-quarantined-files)