### PR TITLE
8.18.6 release notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -6,6 +6,7 @@ This section summarizes the changes in each release.
 * <<release-notes-8.19.2, {elastic-sec} version 8.19.2>>
 * <<release-notes-8.19.1, {elastic-sec} version 8.19.1>>
 * <<release-notes-8.19.0, {elastic-sec} version 8.19.0>>
+* <<release-notes-8.18.6, {elastic-sec} version 8.18.6>>
 * <<release-notes-8.18.5, {elastic-sec} version 8.18.5>>
 * <<release-notes-8.18.4, {elastic-sec} version 8.18.4>>
 * <<release-notes-8.18.3, {elastic-sec} version 8.18.3>>

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -9,7 +9,6 @@
 [[enhancements-8.18.6]]
 ==== Enhancements
 * Improves the reliability of {elastic-defend}'s connection to its kernel driver. This should reduce the instances of temporary `DEGRADED` policy statuses at boot due to `connect_kernel` failures.
-* Capture CPU Profiling Data in Windows Diagnostics.
 * To help identify which parts of `elastic-endpoint.exe` are using a significant amount of CPU, {elastic-defend} on Windows can now include CPU profiling data in diagnostics. To request CPU profiling data using the command line, refer to the {fleet-guide}/elastic-agent-cmd-options.html#_options[Agent command reference]. To request CPU profiling data using Kibana, check the **Collect additional CPU metrics** box when requesting {agent} diagnostics. 
 
 [discrete]

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -2,6 +2,24 @@
 == 8.18
 
 [discrete]
+[[release-notes-8.18.6]]
+=== 8.18.6
+
+[discrete]
+[[enhancements-8.18.6]]
+==== Enhancements
+* Improves the reliability of {elastic-defend}'s connection to its kernel driver. This should reduce the instances of temporary `DEGRADED` policy statuses at boot due to `connect_kernel` failures.
+* Capture CPU Profiling Data in Windows Diagnostics.
+* To help identify which parts of `elastic-endpoint.exe` are using a significant amount of CPU, {elastic-defend} on Windows can now include CPU profiling data in diagnostics. To request CPU profiling data using the command line, refer to the {fleet-guide}/elastic-agent-cmd-options.html#_options[Agent command reference]. To request CPU profiling data using Kibana, check the **Collect additional CPU metrics** box when requesting {agent} diagnostics. 
+
+[discrete]
+[[bug-fixes-8.18.6]]
+==== Fixes
+* Prevents the {esql} form from locking in read-only mode in the rule upgrade flyout ({kibana-pull}231699[#231699]).
+* Fixes a bug in {elastic-defend} where Linux endpoints would report `process.executable` as a relative, instead of absolute, path.
+* Fixes a race condition in {elastic-defend} on Windows that occasionally resulted in corrupted process command lines. This could cause incorrect values for `process.command_line`, `process.args_count`, and `process.args`, leading to false positives.
+
+[discrete]
 [[release-notes-8.18.5]]
 === 8.18.5
 

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -17,6 +17,8 @@
 * Prevents the {esql} form from locking in read-only mode in the rule upgrade flyout ({kibana-pull}231699[#231699]).
 * Fixes a bug in {elastic-defend} where Linux endpoints would report `process.executable` as a relative, instead of absolute, path.
 * Fixes a race condition in {elastic-defend} on Windows that occasionally resulted in corrupted process command lines. This could cause incorrect values for `process.command_line`, `process.args_count`, and `process.args`, leading to false positives.
+* Hides case connectors in the create case workflow based on your license ({kibana-pull}232506[#232506]).
+* Fixes inconsistencies in case activity statistics ({kibana-pull}231948[#231948]).
 
 [discrete]
 [[release-notes-8.18.5]]


### PR DESCRIPTION
Resolves https://github.com/elastic/security-docs/issues/7032: adds the 8.18.6 Security and Endpoint release notes.

Preview: [8.18](https://security-docs_bk_7044.docs-preview.app.elstc.co/guide/en/security/current/release-notes-header-8.18.0.html)