### PR TITLE
8.19.3 release notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.19.3, {elastic-sec} version 8.19.3>>
 * <<release-notes-8.19.2, {elastic-sec} version 8.19.2>>
 * <<release-notes-8.19.1, {elastic-sec} version 8.19.1>>
 * <<release-notes-8.19.0, {elastic-sec} version 8.19.0>>

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -9,17 +9,16 @@
 [[enhancements-8.19.3]]
 ==== Enhancements
 * Improves the reliability of {elastic-defend}'s connection to its kernel driver. This should reduce the instances of temporary `DEGRADED` policy statuses at boot due to `connect_kernel` failures.
-* Enriches {elastic-defend} macOS network connect events with `network.direction`. Possible values are ingress and egress.
+* Enriches {elastic-defend} macOS network connect events with `network.direction`. Possible values are `ingress` and `egress`.
 
 [discrete]
 [[bug-fixes-8.19.3]]
 ==== Fixes
 * Fixes a bug in Session View where `args` fields in `event.process` and nested objects had string values instead of array of strings as expected ({kibana-pull}232462[#232462]).
 * Fixes a bug in {elastic-defend} where Linux endpoints would report `process.executable` as a relative, instead of absolute, path.
-* Fixes a bug where {elastic-defend} Linux network events would fail to load if ipv6 is not supported by the system.
-* Fixes a bug in {elastic-defend} where the fqdn feature flag was not being persisted across system/endpoint restarts
-* Fix a race condition in {elastic-defend} that may occasionally result in corrupted process command lines on Windows.  When this occurs, `process.command_line`, `process.args_count` and `process.args` may be incorrect, leading to false positives.
-* Fixes a bug in {elastic-defend} where Linux endpoints would report `process.executable` as a relative, instead of absolute, path.
+* Fixes a bug where {elastic-defend} Linux network events would fail to load if IPv6 is not supported by the system.
+* Fixes a bug in {elastic-defend} where the `fqdn` feature flag was not being persisted across system/endpoint restarts.
+* Fixes a race condition in {elastic-defend} on Windows that occasionally resulted in corrupted process command lines. This could cause incorrect values for `process.command_line`, `process.args_count`, and `process.args`, leading to false positives.
 
 [discrete]
 [[release-notes-8.19.2]]

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -2,6 +2,21 @@
 == 8.19
 
 [discrete]
+[[release-notes-8.19.3]]
+=== 8.19.3
+
+[discrete]
+[[enhancements-8.19.3]]
+==== Enhancements
+* Improves the reliability of {elastic-defend}'s connection to its kernel driver. This should reduce the instances of temporary `DEGRADED` policy statuses at boot due to `connect_kernel` failures.
+
+[discrete]
+[[bug-fixes-8.19.3]]
+==== Fixes
+* Prevents Session View from crashing by normalizing the `event.process.args` field ({kibana-pull}232462[#232462]).
+* Fixes a bug in {elastic-defend} where Linux endpoints would report `process.executable` as a relative, instead of absolute, path.
+
+[discrete]
 [[release-notes-8.19.2]]
 === 8.19.2
 

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -19,6 +19,8 @@
 * Fixes a bug where {elastic-defend} Linux network events would fail to load if IPv6 is not supported by the system.
 * Fixes a bug in {elastic-defend} where the `fqdn` feature flag was not being persisted across system or endpoint restarts.
 * Fixes a race condition in {elastic-defend} on Windows that occasionally resulted in corrupted process command lines. This could cause incorrect values for `process.command_line`, `process.args_count`, and `process.args`, leading to false positives.
+* Hides case connectors in the create case workflow based on your license ({kibana-pull}232506[#232506]).
+* Fixes inconsistencies in case activity statistics ({kibana-pull}231948[#231948]).
 
 [discrete]
 [[release-notes-8.19.2]]

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -17,7 +17,7 @@
 * Fixes a bug in Session View where `args` fields in `event.process` and nested objects had string values instead of array of strings as expected ({kibana-pull}232462[#232462]).
 * Fixes a bug in {elastic-defend} where Linux endpoints would report `process.executable` as a relative, instead of absolute, path.
 * Fixes a bug where {elastic-defend} Linux network events would fail to load if IPv6 is not supported by the system.
-* Fixes a bug in {elastic-defend} where the `fqdn` feature flag was not being persisted across system/endpoint restarts.
+* Fixes a bug in {elastic-defend} where the `fqdn` feature flag was not being persisted across system or endpoint restarts.
 * Fixes a race condition in {elastic-defend} on Windows that occasionally resulted in corrupted process command lines. This could cause incorrect values for `process.command_line`, `process.args_count`, and `process.args`, leading to false positives.
 
 [discrete]

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -9,11 +9,16 @@
 [[enhancements-8.19.3]]
 ==== Enhancements
 * Improves the reliability of {elastic-defend}'s connection to its kernel driver. This should reduce the instances of temporary `DEGRADED` policy statuses at boot due to `connect_kernel` failures.
+* Enriches {elastic-defend} macOS network connect events with `network.direction`. Possible values are ingress and egress.
 
 [discrete]
 [[bug-fixes-8.19.3]]
 ==== Fixes
-* Prevents Session View from crashing by normalizing the `event.process.args` field ({kibana-pull}232462[#232462]).
+* Fixes a bug in Session View where `args` fields in `event.process` and nested objects had string values instead of array of strings as expected ({kibana-pull}232462[#232462]).
+* Fixes a bug in {elastic-defend} where Linux endpoints would report `process.executable` as a relative, instead of absolute, path.
+* Fixes a bug where {elastic-defend} Linux network events would fail to load if ipv6 is not supported by the system.
+* Fixes a bug in {elastic-defend} where the fqdn feature flag was not being persisted across system/endpoint restarts
+* Fix a race condition in {elastic-defend} that may occasionally result in corrupted process command lines on Windows.  When this occurs, `process.command_line`, `process.args_count` and `process.args` may be incorrect, leading to false positives.
 * Fixes a bug in {elastic-defend} where Linux endpoints would report `process.executable` as a relative, instead of absolute, path.
 
 [discrete]


### PR DESCRIPTION
Resolves https://github.com/elastic/security-docs/issues/7033: adds the 8.19.3 Security and Endpoint release notes.

Preview: [8.19](https://security-docs_bk_7045.docs-preview.app.elstc.co/guide/en/security/current/release-notes-header-8.19.0.html)