### PR TITLE
Risk scoring clarification

### DIFF
--- a/docs/advanced-entity-analytics/entity-risk-scoring.asciidoc
+++ b/docs/advanced-entity-analytics/entity-risk-scoring.asciidoc
@@ -32,9 +32,9 @@ NOTE: Entities without any alerts, or with only `Closed` alerts, are not assigne
 
 [discrete]
 [[how-is-risk-score-calculated]]
-== How is risk score calculated?
+== How are risk scores calculated?
 
-. The risk scoring engine runs hourly to aggregate `Open` and `Acknowledged` alerts from the last 30 days. For each entity, the engine processes up to 10,000 alerts.
+. The risk scoring engine runs hourly to aggregate `Open` and `Acknowledged` alerts from the last 30 days, including <<building-block-rule, building block alerts>>. For each entity, the engine processes up to 10,000 alerts.
 +
 NOTE: When <<turn-on-risk-engine, turning on the risk engine>>, you can choose to also include `Closed` alerts in risk scoring calculations.
 
@@ -70,6 +70,17 @@ NOTE: Asset criticality levels and default risk weights are subject to change.
 |==============================================
 
 The risk score is updated every hour based on the configured date and time range, which defaults to 30 days. Each update generates a new score, calculated independently of any previous scores.
+
+[discrete]
+[[residual-risk]]
+=== Residual risk score
+
+In some cases, entities can retain a residual risk score:
+
+* If all alerts for an entity are closed
+* If all of the entity's open alerts fall outside of the configured date and time range
+
+In these situations, the entity retains its last computed risk score until a new alert causes the score to be recalculated.
 
 .Click for a risk score calculation example
 [%collapsible]


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/2705 and https://github.com/elastic/docs-content/issues/2706. Addresses customer inquiries around:

- impact of building block alerts on entity risk scoring
- residual risk score

Preview: 

9.x PR: https://github.com/elastic/docs-content/pull/2809