### PR TITLE
Add guide for configuring DNS histogram on Network page

### DIFF
--- a/docs/getting-started/configure-dns-histogram.asciidoc
+++ b/docs/getting-started/configure-dns-histogram.asciidoc
@@ -1,0 +1,43 @@
+[[configure-dns-histogram]]
+
+= Configure the DNS histogram
+
+The DNS histogram (**Top domains by dns.question.registered_domain**) on the **Network** page helps you visualize domain activity in your environment. If you're using {elastic-defend}, you may need to add the `dns.question.registered_domain` field so that DNS data appears correctly.
+
+If the DNS histogram is empty, follow these steps to populate the data.
+
+[discrete]
+== Add the `dns.question.name` field
+
+Add the `dns.question.name` field to the Events table to confirm that DNS data is available.
+
+. Go to the **Network** page using the navigation menu or the {kibana-ref}/introduction.html#kibana-navigation-search[global search field]. 
+. Select the **Events** tab.
+. In the Events table, click **Fields**, then add the `dns.question.name` field.
+
+[discrete]
+== Create a custom ingest pipeline
+
+Create an ingest pipeline that extracts registered domains (for example, `example.com`) from full DNS query names (for example, `www.example.com`).
+
+. Go to the **Ingest Pipelines** page using the navigation menu or the {kibana-ref}/introduction.html#kibana-navigation-search[global search field], and select **Create pipeline → New pipeline**.
+. On the **Create pipeline** page, set the pipeline name to `logs-endpoint.events.network@custom`.
+. Click **Add a processor**. In the **Add processor** flyout, configure the following:
+.. From the **Processor** dropdown, select **Registered domain**.
+.. Under **Field**, enter `dns.question.name`.
+.. Under **Target field (optional)**, enter `dns.question.registered_domain`.
+.. Turn **Ignore missing** on.
+.. Under **Condition (optional)**, enter `ctx?.dns?.question?.name != null`.
+.. Turn **Ignore failures for this processor** on.
+.. Select **Add processor**.
+. Select **Create pipeline**. This custom pipeline is automatically picked up by the existing `logs-endpoint.events.network-<version>` pipeline.
+
+[discrete]
+== Add the `dns.question.registered_domain` field
+
+Add the `dns.question.registered_domain` field to the Events table to verify that the ingest pipeline processes DNS queries correctly.
+
+. Go back to the Events table on the **Network** page.
+. Click **Fields**, then add the `dns.question.registered_domain` field.
+
+After you configure the DNS histogram, it will show domain activity grouped by registered domain, allowing you to identify the top domains queried in your environment.

--- a/docs/getting-started/explore-intro.asciidoc
+++ b/docs/getting-started/explore-intro.asciidoc
@@ -7,4 +7,5 @@ The following section includes an overview of the *Hosts*, *Network*, and *Users
 include::{security-docs-root}/docs/management/hosts/hosts-overview.asciidoc[leveloffset=+1]
 include::network-page-overview.asciidoc[leveloffset=+1]
 include::net-map-req.asciidoc[leveloffset=+2]
+include::configure-dns-histogram.asciidoc[leveloffset=+2]
 include::users-page.asciidoc[leveloffset=+1]

--- a/docs/getting-started/network-page-overview.asciidoc
+++ b/docs/getting-started/network-page-overview.asciidoc
@@ -44,7 +44,7 @@ There are also tabs for viewing and investigating specific types of data:
 
 * *Events*: All network events. To display alerts received from external monitoring tools, scroll down to the events table and select *Show only external alerts* on the right.
 * *Flows*: Source and destination IP addresses and countries.
-* *DNS*: DNS network queries.
+* *DNS*: DNS network queries. To view this data, you may need to <<configure-dns-histogram>>.
 * *HTTP*: Received HTTP requests (HTTP requests for applications using
 {apm-app-ref}/apm-getting-started.html[Elastic APM] are monitored by default).
 * *TLS*: Handshake details.


### PR DESCRIPTION
Contributes to https://github.com/elastic/security-docs/issues/5584.

9.x PR: https://github.com/elastic/docs-content/pull/2757

Preview: [Configure the DNS histogram](https://security-docs_bk_7058.docs-preview.app.elstc.co/guide/en/security/current/configure-dns-histogram.html)