### PR TITLE
[DOCS] MITRE ATT&CK® v17.1 being mapped to 8.18.7 and 8.19.4

### DIFF
--- a/docs/detections/rules-coverage.asciidoc
+++ b/docs/detections/rules-coverage.asciidoc
@@ -14,7 +14,7 @@ To access the **MITRE ATT&CK® coverage** page, find **Detection rules (SIEM)** 
 
 [NOTE]
 ====
-This page only includes the detection rules you currently have installed, and only rules that are mapped to MITRE ATT&CK®. The coverage page maps detections to the following https://attack.mitre.org/resources/updates/updates-april-2024[MITRE ATT&CK® version] used by {elastic-sec}: `v16.1`. Elastic prebuilt rules that aren't installed and custom rules that are either unmapped or mapped to a deprecated tactic or technique will not appear on the coverage map.
+This page only includes the detection rules you currently have installed, and only rules that are mapped to MITRE ATT&CK®. The coverage page maps detections to the following https://attack.mitre.org/resources/updates/updates-april-2024[MITRE ATT&CK® version] used by {elastic-sec}: `v17.1`. Elastic prebuilt rules that aren't installed and custom rules that are either unmapped or mapped to a deprecated tactic or technique will not appear on the coverage map.
 
 You can map custom rules to tactics in **Advanced settings** when creating or editing a rule.
 ====


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/2791. Updates the note that communicates the mapping between Security and MITRE ATT&CK®.

Corresponding 9.x updates: https://github.com/elastic/docs-content/pull/2898

Preview