### PR TITLE
8.18.7 release notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -7,6 +7,7 @@ This section summarizes the changes in each release.
 * <<release-notes-8.19.2, {elastic-sec} version 8.19.2>>
 * <<release-notes-8.19.1, {elastic-sec} version 8.19.1>>
 * <<release-notes-8.19.0, {elastic-sec} version 8.19.0>>
+* <<release-notes-8.18.7, {elastic-sec} version 8.18.7>>
 * <<release-notes-8.18.6, {elastic-sec} version 8.18.6>>
 * <<release-notes-8.18.5, {elastic-sec} version 8.18.5>>
 * <<release-notes-8.18.4, {elastic-sec} version 8.18.4>>

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -11,7 +11,7 @@
 * Prevents users without appropriate privileges from deleting notes ({kibana-pull}233948[#233948]).
 * Fixes a bug that prevented the **MITRE ATT&CK** section from appearing in the alert details flyout ({kibana-pull}233805[#233805]).
 * Updates {kib} MITRE ATT&CK data to v17.1 ({kibana-pull}231375[#231375]).
-* Fixes a bug where Linux capabilities were included in network events despite being disabled.
+* Fixes a bug where Linux capabilities were included in {elastic-endpoint}  network events despite being disabled.
 * Makes the delivery of {elastic-endpoint} command line commands more robust. In rare cases, commands could previously fail due to interprocess communication issues.
 
 [discrete]

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -11,7 +11,7 @@
 * Prevents users without appropriate privileges from deleting notes ({kibana-pull}233948[#233948]).
 * Fixes a bug that prevented the **MITRE ATT&CK** section from appearing in the alert details flyout ({kibana-pull}233805[#233805]).
 * Updates {kib} MITRE ATT&CK data to v17.1 ({kibana-pull}231375[#231375]).
-* Fixes a bug where Linux capabilities were included in {elastic-endpoint}  network events despite being disabled.
+* Fixes a bug where Linux capabilities were included in {elastic-endpoint} network events despite being disabled.
 * Makes the delivery of {elastic-endpoint} command line commands more robust. In rare cases, commands could previously fail due to interprocess communication issues.
 
 [discrete]

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -2,6 +2,19 @@
 == 8.18
 
 [discrete]
+[[release-notes-8.18.7]]
+=== 8.18.7
+
+[discrete]
+[[bug-fixes-8.18.7]]
+==== Fixes
+* Prevents users without appropriate privileges from deleting notes ({kibana-pull}233948[#233948]).
+* Fixes a bug that prevented the **MITRE ATT&CK** section from appearing in the alert details flyout ({kibana-pull}233805[#233805]).
+* Updates {kib} MITRE ATT&CK data to v17.1 ({kibana-pull}231375[#231375]).
+* Fixes a bug where Linux capabilities were included in network events despite being disabled.
+* Makes the delivery of {elastic-endpoint} command line commands more robust. In rare cases, commands could previously fail due to interprocess communication issues.
+
+[discrete]
 [[release-notes-8.18.6]]
 === 8.18.6
 


### PR DESCRIPTION
Resolves https://github.com/elastic/security-docs/issues/7054: adds the 8.18.7 Security and Endpoint release notes.