### PR TITLE
8.19.4 release notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.19.4, {elastic-sec} version 8.19.4>>
 * <<release-notes-8.19.3, {elastic-sec} version 8.19.3>>
 * <<release-notes-8.19.2, {elastic-sec} version 8.19.2>>
 * <<release-notes-8.19.1, {elastic-sec} version 8.19.1>>

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -9,6 +9,8 @@
 [[bug-fixes-8.19.4]]
 ==== Fixes
 * Fixes a bug where the toggle column functionality only functioned on the **Alerts** page ({kibana-pull}234278[#234278]).
+* Fixes a bug where Linux capabilities were included in {elastic-endpoint} network events despite being disabled.
+* Makes the delivery of {elastic-endpoint} command line commands more robust. In rare cases, commands could previously fail due to interprocess communication issues.
 
 [discrete]
 [[release-notes-8.19.3]]

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -2,6 +2,15 @@
 == 8.19
 
 [discrete]
+[[release-notes-8.19.4]]
+=== 8.19.4
+
+[discrete]
+[[bug-fixes-8.19.4]]
+==== Fixes
+* Fixes a bug where the toggle column functionality only functioned on the **Alerts** page ({kibana-pull}234278[#234278]).
+
+[discrete]
 [[release-notes-8.19.3]]
 === 8.19.3
 


### PR DESCRIPTION
Resolves https://github.com/elastic/security-docs/issues/7055: adds the 8.19.4 Security release notes.
No Endpoint release notes were picked up by the RN tool.