### PR TITLE
workflow: update elastic/workflows reference to elastic/dev-docs-workflows for docs-versioned-publish.yml

### DIFF
--- a/.github/workflows/co-docs-builder.yml
+++ b/.github/workflows/co-docs-builder.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   publish:
     if: contains(github.event.pull_request.labels.*.name, 'ci:doc-build')
-    uses: elastic/workflows/.github/workflows/docs-versioned-publish.yml@main
+    uses: elastic/dev-docs-workflows/.github/workflows/docs-versioned-publish.yml@main
     with:
       # Refers to Vercel project
       project-name: elastic-dot-co-docs-preview-docs


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

This change updates workflow references from:
```yaml
uses: elastic/workflows/.github/workflows/docs-versioned-publish.yml
```

to:
```yaml
uses: elastic/dev-docs-workflows/.github/workflows/docs-versioned-publish.yml
```

This ensures workflows are using the correct repository reference for dev docs publishing.

If there are any questions, please reach out to the @elastic/docs-engineering

For more details, please see: https://github.com/elastic/docs-eng-team/issues/179
