### PR TITLE
Security 8.19.5 release notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.19.5, {elastic-sec} version 8.19.5>>
 * <<release-notes-8.19.4, {elastic-sec} version 8.19.4>>
 * <<release-notes-8.19.3, {elastic-sec} version 8.19.3>>
 * <<release-notes-8.19.2, {elastic-sec} version 8.19.2>>

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -2,6 +2,35 @@
 == 8.19
 
 [discrete]
+[[release-notes-8.19.5]]
+=== 8.19.5
+
+[discrete]
+[[features-8.19.5]]
+==== New features
+* Adds an {elastic-defend} option to remediate orphaned state by attempting to start Elastic Agent service.
+* Adds more {elastic-defend} Linux diagnostic process `ptrace` events.
+
+[discrete]
+[[enhancements-8.19.5]]
+==== Enhancements
+* Fixes {elastic-defend} error log on Windows where only the first character, usually 'C', was logged instead of a path.
+* Improves reliability and accuracy of reporting of {elastic-endpoint}'s {es} connection.
+
+[discrete]
+[[bug-fixes-8.19.5]]
+==== Fixes
+* Removes `null` in confirmation dialog when bulk editing index patterns for rules ({kibana-pull}236572[#236572]).
+* Fixes the URL passed to detection rule actions via the `{{context.results_link}}` placeholder ({kibana-pull}236067[#236067]).
+* Fixes alert page filtering by checking for empty `dataView` ({kibana-pull}235144[#235144]).
+* Fixes browser fields caching to use the `dataView` ID instead of the index pattern({kibana-pull}234381[#234381]).
+* Adds support in {elastic-defend} for installing eBPF event probes on Linux endpoints when cgroup2 is mounted in a non-standard location or not mounted at all.
+* Adds support in {elastic-defend} for installing eBPF probes on Linux endpoints when taskstats is compiled out of the kernel.
+* Fixes a bug in {elastic-defend} where Linux network events could have source and destination bytes swapped.
+* Removes `.process.thread.capabilities.permitted` and `.process.thread.capabilities.effective` from Linux network events in {elastic-defend}.
+* Fixes a bug in {elastic-defend} where host isolation could auto-release incorrectly. Host isolation now only releases when {elastic-endpoint} becomes orphaned. Intermittent {elastic-agent} connectivity changes no longer alter the host isolation state.
+
+[discrete]
 [[release-notes-8.19.4]]
 === 8.19.4
 

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -9,12 +9,10 @@
 [[features-8.19.5]]
 ==== New features
 * Adds an {elastic-defend} option to remediate orphaned state by attempting to start Elastic Agent service.
-* Adds more {elastic-defend} Linux diagnostic process `ptrace` events.
 
 [discrete]
 [[enhancements-8.19.5]]
 ==== Enhancements
-* Fixes {elastic-defend} error log on Windows where only the first character, usually 'C', was logged instead of a path.
 * Improves reliability and accuracy of reporting of {elastic-endpoint}'s {es} connection.
 
 [discrete]
@@ -29,10 +27,17 @@
 * Fixes a bug in {elastic-defend} where Linux network events could have source and destination bytes swapped.
 * Removes `.process.thread.capabilities.permitted` and `.process.thread.capabilities.effective` from Linux network events in {elastic-defend}.
 * Fixes a bug in {elastic-defend} where host isolation could auto-release incorrectly. Host isolation now only releases when {elastic-endpoint} becomes orphaned. Intermittent {elastic-agent} connectivity changes no longer alter the host isolation state.
+* Fixes an issue where {elastic-defend} would incorrectly calculate throughput capacity when sending documents to output. This may have limited event throughput on extremely busy endpoints.
+* Fixes an issue in {elastic-defend} installation logging where only the first character of install paths (usually 'C') would be logged.
 
 [discrete]
 [[release-notes-8.19.4]]
 === 8.19.4
+
+[discrete]
+[[features-8.19.4]]
+==== New features
+* Adds more {elastic-defend} Linux diagnostic process `ptrace` events.
 
 [discrete]
 [[bug-fixes-8.19.4]]


### PR DESCRIPTION
Resolves https://github.com/elastic/security-docs/issues/7076: adds the 8.19.5 Security and Endpoint release notes.

Preview: [8.19](https://security-docs_bk_7079.docs-preview.app.elstc.co/guide/en/security/8.19/release-notes-header-8.19.0.html)