### PR TITLE
Security 8.18.8 release notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -8,6 +8,7 @@ This section summarizes the changes in each release.
 * <<release-notes-8.19.2, {elastic-sec} version 8.19.2>>
 * <<release-notes-8.19.1, {elastic-sec} version 8.19.1>>
 * <<release-notes-8.19.0, {elastic-sec} version 8.19.0>>
+* <<release-notes-8.18.8, {elastic-sec} version 8.18.8>>
 * <<release-notes-8.18.7, {elastic-sec} version 8.18.7>>
 * <<release-notes-8.18.6, {elastic-sec} version 8.18.6>>
 * <<release-notes-8.18.5, {elastic-sec} version 8.18.5>>

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -2,6 +2,30 @@
 == 8.18
 
 [discrete]
+[[release-notes-8.18.8]]
+=== 8.18.8
+
+[discrete]
+[[features-8.18.8]]
+==== New features
+* Adds an {elastic-defend} option to remediate orphaned state by attempting to start Elastic Agent service.
+
+[discrete]
+[[enhancements-8.18.8]]
+==== Enhancements
+* Fixes {elastic-defend} error log on Windows where only the first character, usually 'C', was logged instead of a path.
+
+[discrete]
+[[bug-fixes-8.18.8]]
+==== Fixes
+* Removes `null` in confirmation dialog when bulk editing index patterns for rules ({kibana-pull}236572[#236572]).
+* Fixes the URL passed to detection rule actions via the `{{context.results_link}}` placeholder ({kibana-pull}236067[#236067]).
+* Adds support in {elastic-defend} for installing eBPF probes on Linux endpoints when taskstats is compiled out of the kernel.
+* Fixes a bug in {elastic-defend} where Linux network events could have source and destination bytes swapped.
+* Removes `.process.thread.capabilities.permitted` and `.process.thread.capabilities.effective` from Linux network events in {elastic-defend}.
+* Fixes a bug in {elastic-defend} where host isolation could auto-release incorrectly. Host isolation now only releases when {elastic-endpoint} becomes orphaned. Intermittent {elastic-agent} connectivity changes no longer alter the host isolation state.
+
+[discrete]
 [[release-notes-8.18.7]]
 === 8.18.7
 

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -20,6 +20,7 @@
 ==== Fixes
 * Removes `null` in confirmation dialog when bulk editing index patterns for rules ({kibana-pull}236572[#236572]).
 * Fixes the URL passed to detection rule actions via the `{{context.results_link}}` placeholder ({kibana-pull}236067[#236067]).
+* Adds support in {elastic-defend} for installing eBPF probes on Linux endpoints when taskstats is compiled out of the kernel.
 * Fixes a bug in {elastic-defend} where Linux network events could have source and destination bytes swapped.
 * Removes `.process.thread.capabilities.permitted` and `.process.thread.capabilities.effective` from Linux network events in {elastic-defend}.
 * Fixes a bug in {elastic-defend} where host isolation could auto-release incorrectly. Host isolation now only releases when {elastic-endpoint} becomes orphaned. Intermittent {elastic-agent} connectivity changes no longer alter the host isolation state.

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -20,7 +20,6 @@
 ==== Fixes
 * Removes `null` in confirmation dialog when bulk editing index patterns for rules ({kibana-pull}236572[#236572]).
 * Fixes the URL passed to detection rule actions via the `{{context.results_link}}` placeholder ({kibana-pull}236067[#236067]).
-* Adds support in {elastic-defend} for installing eBPF probes on Linux endpoints when taskstats is compiled out of the kernel.
 * Fixes a bug in {elastic-defend} where Linux network events could have source and destination bytes swapped.
 * Removes `.process.thread.capabilities.permitted` and `.process.thread.capabilities.effective` from Linux network events in {elastic-defend}.
 * Fixes a bug in {elastic-defend} where host isolation could auto-release incorrectly. Host isolation now only releases when {elastic-endpoint} becomes orphaned. Intermittent {elastic-agent} connectivity changes no longer alter the host isolation state.

--- a/docs/release-notes/8.18.asciidoc
+++ b/docs/release-notes/8.18.asciidoc
@@ -13,7 +13,7 @@
 [discrete]
 [[enhancements-8.18.8]]
 ==== Enhancements
-* Fixes {elastic-defend} error log on Windows where only the first character, usually 'C', was logged instead of a path.
+* Increases the throughput of {elastic-defend} Logstash connections by increasing the maximum size it can upload at once.
 
 [discrete]
 [[bug-fixes-8.18.8]]
@@ -24,6 +24,9 @@
 * Fixes a bug in {elastic-defend} where Linux network events could have source and destination bytes swapped.
 * Removes `.process.thread.capabilities.permitted` and `.process.thread.capabilities.effective` from Linux network events in {elastic-defend}.
 * Fixes a bug in {elastic-defend} where host isolation could auto-release incorrectly. Host isolation now only releases when {elastic-endpoint} becomes orphaned. Intermittent {elastic-agent} connectivity changes no longer alter the host isolation state.
+* Improves the reliability of local {elastic-defend} administrative shell commands. In rare cases, a command could fail to execute due to issue with interprocess communication.
+* Fixes an issue where {elastic-defend} would incorrectly calculate throughput capacity when sending documents to output.  This may have limited event throughput on extremely busy endpoints.
+* Fixes an issue in {elastic-defend} installation logging where only the first character of install paths (usually 'C') would be logged.
 
 [discrete]
 [[release-notes-8.18.7]]


### PR DESCRIPTION
Resolves https://github.com/elastic/security-docs/issues/7077: adds the 8.18.8 Security and Endpoint release notes.

Preview: [8.18](https://security-docs_bk_7080.docs-preview.app.elstc.co/guide/en/security/current/release-notes-header-8.18.0.html)