### PR TITLE
[Security][8.18 & 8.19][Bug] Removes note about suppression and prebuilt rules that's no longer applicable

### DIFF
--- a/docs/detections/alert-suppression.asciidoc
+++ b/docs/detections/alert-suppression.asciidoc
@@ -23,8 +23,6 @@ Normally, when a rule meets its criteria repeatedly, it creates multiple alerts,
 
 The {security-app} displays several indicators in the Alerts table and the alert details flyout when a detection alert is created with alert suppression enabled. You can view the original events associated with suppressed alerts by investigating the alert in Timeline.
 
-NOTE: Alert suppression is not available for Elastic prebuilt rules. However, if you want to suppress alerts for a prebuilt rule, you can duplicate it, then configure alert suppression on the duplicated rule.
-
 === Configure alert suppression
 
 You can configure alert suppression when you create or edit a supported rule type. Refer to documentation for creating <<create-custom-rule,custom query>>, <<create-threshold-rule, threshold>>, <<create-eql-rule,event correlation>>, <<create-new-terms-rule,new terms>>, <<create-esql-rule,{esql}>>, or <<create-ml-rule,{ml}>> rules for detailed instructions.


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/3290.

Removes note about suppression and prebuilt rules that's no longer applicable. Since 8.18, users can configure suppression on prebuilt rules if they edit them.

Corresponding 9.x and Serverless doc updates are at: https://github.com/elastic/docs-content/pull/3304

[Preview](https://security-docs_bk_7081.docs-preview.app.elstc.co/guide/en/security/8.19/alert-suppression.html)