### PR TITLE
[Security][8.18 & 8.19] Add 'search.allow_expensive_queries' to detection reqs

### DIFF
--- a/docs/detections/detections-req.asciidoc
+++ b/docs/detections/detections-req.asciidoc
@@ -20,15 +20,15 @@ These steps are only required for *self-managed* deployments:
 
 * HTTPS must be configured for communication between
 {kibana-ref}/configuring-tls.html#configuring-tls-kib-es[{es} and {kib}].
-* In the `elasticsearch.yml` configuration file, set the
-`xpack.security.enabled` setting to `true`. For more information, refer to
-{ref}/settings.html[Configuring {es}] and
-{ref}/security-settings.html[Security settings in {es}].
 * In the `kibana.yml` {kibana-ref}/settings.html[configuration file], add the
 `xpack.encryptedSavedObjects.encryptionKey` setting with any alphanumeric value
 of at least 32 characters. For example:
 +
 `xpack.encryptedSavedObjects.encryptionKey: 'fhjskloppd678ehkdfdlliverpoolfcr'`
+* In the `elasticsearch.yml` {ref}/settings.html[configuration] file: 
+
+** Set the `xpack.security.enabled` setting to `true`. For more information, refer to {ref}/security-settings.html[general security settings in {es}].
+** Remove the line `search.allow_expensive_queries=false` if you find it. The `search.allow_expensive_queries` setting must be left on its default value of `true` for key detection features like {kib}/alerting-getting-started.html#_rules[alerting rules] and rule exceptions to work.
 
 IMPORTANT: After changing the `xpack.encryptedSavedObjects.encryptionKey` value
 and restarting {kib}, you must restart all detection rules.

--- a/docs/detections/detections-req.asciidoc
+++ b/docs/detections/detections-req.asciidoc
@@ -28,7 +28,7 @@ of at least 32 characters. For example:
 * In the `elasticsearch.yml` {ref}/settings.html[configuration] file: 
 
 ** Set the `xpack.security.enabled` setting to `true`. For more information, refer to {ref}/security-settings.html[general security settings in {es}].
-** Remove the line `search.allow_expensive_queries=false` if you find it. The `search.allow_expensive_queries` setting must be left on its default value of `true` for key detection features like {kib}/alerting-getting-started.html#_rules[alerting rules] and rule exceptions to work.
+** Remove the line `search.allow_expensive_queries=false` if you find it. The `search.allow_expensive_queries` setting must be left on its default value of `true` for key detection features like {kibana-ref}/alerting-getting-started.html#_rules[alerting rules] and rule exceptions to work.
 
 IMPORTANT: After changing the `xpack.encryptedSavedObjects.encryptionKey` value
 and restarting {kib}, you must restart all detection rules.

--- a/docs/detections/detections-req.asciidoc
+++ b/docs/detections/detections-req.asciidoc
@@ -28,7 +28,8 @@ of at least 32 characters. For example:
 * In the `elasticsearch.yml` {ref}/settings.html[configuration] file: 
 
 ** Set the `xpack.security.enabled` setting to `true`. For more information, refer to {ref}/security-settings.html[general security settings in {es}].
-** Remove the line `search.allow_expensive_queries=false` if you find it. The `search.allow_expensive_queries` setting must be left on its default value of `true` for key detection features like {kibana-ref}/alerting-getting-started.html#_rules[alerting rules] and rule exceptions to work.
+** If the `search.allow_expensive_queries` setting is set to `false`, remove it. If the setting is set to its default value of `true` or not included in the `elasticsearch.yml` file, you don't need to change it. When this setting is set to `true`, it allows key detection features, such as {kibana-ref}/alerting-getting-started.html#_rules[alerting rules] and rule exceptions, to work.
+
 
 IMPORTANT: After changing the `xpack.encryptedSavedObjects.encryptionKey` value
 and restarting {kib}, you must restart all detection rules.

--- a/docs/detections/detections-req.asciidoc
+++ b/docs/detections/detections-req.asciidoc
@@ -28,7 +28,7 @@ of at least 32 characters. For example:
 * In the `elasticsearch.yml` {ref}/settings.html[configuration] file: 
 
 ** Set the `xpack.security.enabled` setting to `true`. For more information, refer to {ref}/security-settings.html[general security settings in {es}].
-** If the `search.allow_expensive_queries` setting is set to `false`, remove it. If set to its default value of `true` or not included in the file, you don't need to change it. This setting must be `true`, for key detection features, such as {kibana-ref}/alerting-getting-started.html#_rules[alerting rules] and rule exceptions, to work.
+** If the `search.allow_expensive_queries` setting is set to `false`, remove it. If set to its default value of `true` or not included in the file, you don't need to change it. This setting must be `true` for key detection features, such as {kibana-ref}/alerting-getting-started.html#_rules[alerting rules] and rule exceptions, to work.
 
 
 IMPORTANT: After changing the `xpack.encryptedSavedObjects.encryptionKey` value

--- a/docs/detections/detections-req.asciidoc
+++ b/docs/detections/detections-req.asciidoc
@@ -28,7 +28,7 @@ of at least 32 characters. For example:
 * In the `elasticsearch.yml` {ref}/settings.html[configuration] file: 
 
 ** Set the `xpack.security.enabled` setting to `true`. For more information, refer to {ref}/security-settings.html[general security settings in {es}].
-** If the `search.allow_expensive_queries` setting is set to `false`, remove it. If the setting is set to its default value of `true` or not included in the `elasticsearch.yml` file, you don't need to change it. When this setting is set to `true`, it allows key detection features, such as {kibana-ref}/alerting-getting-started.html#_rules[alerting rules] and rule exceptions, to work.
+** If the `search.allow_expensive_queries` setting is set to `false`, remove it. If set to its default value of `true` or not included in the file, you don't need to change it. This setting must be `true`, for key detection features, such as {kibana-ref}/alerting-getting-started.html#_rules[alerting rules] and rule exceptions, to work.
 
 
 IMPORTANT: After changing the `xpack.encryptedSavedObjects.encryptionKey` value


### PR DESCRIPTION
Ports changes made in https://github.com/elastic/docs-content/pull/3543 to the 8.18 and 8.19 docs. 

Preview - https://security-docs_bk_7092.docs-preview.app.elstc.co/guide/en/security/8.19/detections-permissions-section.html#detections-on-prem-requirements