### PR TITLE
Security 8.19.6 release notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.19.6, {elastic-sec} version 8.19.6>>
 * <<release-notes-8.19.5, {elastic-sec} version 8.19.5>>
 * <<release-notes-8.19.4, {elastic-sec} version 8.19.4>>
 * <<release-notes-8.19.3, {elastic-sec} version 8.19.3>>

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -2,6 +2,26 @@
 == 8.19
 
 [discrete]
+[[release-notes-8.19.6]]
+=== 8.19.6
+
+[discrete]
+[[enhancements-8.19.6]]
+==== Enhancements
+* Adds an {elastic-defend} advanced policy Windows setting that allows you to opt out of collecting specific security events ({kibana-pull}232360[#232360]).
+
+[discrete]
+[[bug-fixes-8.19.6]]
+==== Fixes
+* Fixes an issue with editing filters on the **Alerts** page ({kibana-pull}236756[#236756]).
+* Prioritizes connector `defaultModel` over stored conversation model ({kibana-pull}237947[#237947]).
+* Fixes an {elastic-defend} issue in malware protection for Linux where a deadlock could sometimes occur when containers and autofs were both active.
+* Fixes an {elastic-defend} issue on Linux by preventing unnecessary locking within malware protection to avoid invalid watchdog firings.
+* Fixes issues that could sometimes cause crashes of the {elastic-defend} user-mode process on very busy Windows systems.
+* Fixes an {elastic-defend} issue on Windows which could allow a low-privilege attacker to delete arbitrary files on the system. On versions of Windows before Windows 11 24H2, this could result in local privilege escalation.
+* Fixes an {elastic-defend} bug in Linux event collection where some long-running processes were not enriched.
+
+[discrete]
 [[release-notes-8.19.5]]
 === 8.19.5
 

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -9,6 +9,7 @@
 [[enhancements-8.19.6]]
 ==== Enhancements
 * Adds more options to the {elastic-defend} {ls} output configuration, allowing for finer control by the end user.
+* Implements CDR Data View versioning and migration logic ({kibana-pull}238547[#238547]).
 
 [discrete]
 [[bug-fixes-8.19.6]]

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -8,7 +8,7 @@
 [discrete]
 [[enhancements-8.19.6]]
 ==== Enhancements
-* Adds more options to the {elastic-defend} logstash output configuration, allowing for finer control by the end user
+* Adds more options to the {elastic-defend} {ls} output configuration, allowing for finer control by the end user.
 
 [discrete]
 [[bug-fixes-8.19.6]]

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -15,12 +15,6 @@
 ==== Fixes
 * Fixes an issue with editing filters on the **Alerts** page ({kibana-pull}236756[#236756]).
 * Prioritizes connector `defaultModel` over stored conversation model ({kibana-pull}237947[#237947]).
-* Fixes an {elastic-defend} issue in malware protection for Linux where a deadlock could sometimes occur when containers and autofs were both active.
-* Fixes an {elastic-defend} issue on Linux by preventing unnecessary locking within malware protection to avoid invalid watchdog firings.
-* Fixes issues that could sometimes cause crashes of the {elastic-defend} user-mode process on very busy Windows systems.
-* Fixes an {elastic-defend} issue on Windows which could allow a low-privilege attacker to delete arbitrary files on the system. On versions of Windows before Windows 11 24H2, this could result in local privilege escalation.
-* Fixes an {elastic-defend} bug in Linux event collection where some long-running processes were not enriched.
-
 [discrete]
 [[release-notes-8.19.5]]
 === 8.19.5

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -15,6 +15,7 @@
 ==== Fixes
 * Fixes an issue with editing filters on the **Alerts** page ({kibana-pull}236756[#236756]).
 * Prioritizes connector `defaultModel` over stored conversation model ({kibana-pull}237947[#237947]).
+
 [discrete]
 [[release-notes-8.19.5]]
 === 8.19.5

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -8,7 +8,7 @@
 [discrete]
 [[enhancements-8.19.6]]
 ==== Enhancements
-* Adds an {elastic-defend} advanced policy Windows setting that allows you to opt out of collecting specific security events ({kibana-pull}232360[#232360]).
+* Adds more options to the {elastic-defend} logstash output configuration, allowing for finer control by the end user
 
 [discrete]
 [[bug-fixes-8.19.6]]


### PR DESCRIPTION
Resolves https://github.com/elastic/security-docs/issues/7091: adds the 8.19.6 Security and Endpoint release notes.

Preview: [8.19](https://security-docs_bk_7093.docs-preview.app.elstc.co/guide/en/security/8.19/release-notes-header-8.19.0.html)