### PR TITLE
Security 8.19.7 release notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.19.7, {elastic-sec} version 8.19.7>>
 * <<release-notes-8.19.6, {elastic-sec} version 8.19.6>>
 * <<release-notes-8.19.5, {elastic-sec} version 8.19.5>>
 * <<release-notes-8.19.4, {elastic-sec} version 8.19.4>>

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -2,6 +2,30 @@
 == 8.19
 
 [discrete]
+[[release-notes-8.19.7]]
+=== 8.19.7
+
+[discrete]
+[[enhancements-8.19.7]]
+==== Enhancements
+* Improves the reliability of Cloud Security Posture (CSP) data by automatically upgrading outdated Misconfiguration and Vulnerabilities data views to the correct versions ({kibana-pull}238547[#238547]).
+* Improves the reliability of {elastic-defend} Kafka connections.
+* Improves the accuracy of thread CPU usage reported in {elastic-defend} metrics documents.
+
+[discrete]
+[[bug-fixes-8.19.7]]
+==== Fixes
+* Fixes entity flyout **Risk contributions** tab link ({kibana-pull}241153[#241153]).
+* Fixes a pagination issue with the data table on the **Indicators** page ({kibana-pull}241108[#241108]).
+* Allows partial matches on rule name when searching installed rules ({kibana-pull}237496[#237496]).
+* Fixes an issue where rule exception operators could not be cleared when editing a rule exception ({kibana-pull}236051[#236051]).
+* Fixes an {elastic-defend} issue on Linux by preventing unnecessary locking within malware protection to avoid invalid watchdog firings.
+* Fixes issues that could sometimes cause crashes of the {elastic-defend} user-mode process on very busy Windows systems.
+* Fixes multiple {elastic-defend} issues in malware protection for Linux where a deadlock could sometimes occur when containers and autofs were both active.
+* Fixes an {elastic-defend} bug in Linux event collection where some long-running processes were not enriched.
+* Fixes an issue in {elastic-defend} that could cause the `get-file` and `execute` response actions to start failing after many are issued with a single running instance of {elastic-defend}.
+
+[discrete]
 [[release-notes-8.19.6]]
 === 8.19.6
 

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -17,13 +17,14 @@
 ==== Fixes
 * Fixes entity flyout **Risk contributions** tab link ({kibana-pull}241153[#241153]).
 * Fixes a pagination issue with the data table on the **Indicators** page ({kibana-pull}241108[#241108]).
-* Allows partial matches on rule name when searching installed rules ({kibana-pull}237496[#237496]).
+* Fixes multiple issues searching installed rules by allowing partial matches on rule name and improving special character support ({kibana-pull}237496[#237496]).
 * Fixes an issue where rule exception operators could not be cleared when editing a rule exception ({kibana-pull}236051[#236051]).
 * Fixes an {elastic-defend} issue on Linux by preventing unnecessary locking within malware protection to avoid invalid watchdog firings.
 * Fixes issues that could sometimes cause crashes of the {elastic-defend} user-mode process on very busy Windows systems.
 * Fixes multiple {elastic-defend} issues in malware protection for Linux where a deadlock could sometimes occur when containers and autofs were both active.
 * Fixes an {elastic-defend} bug in Linux event collection where some long-running processes were not enriched.
 * Fixes an issue in {elastic-defend} that could cause the `get-file` and `execute` response actions to start failing after many are issued with a single running instance of {elastic-defend}.
+* Fixes CVE-2025-37735 ([ESA-2025-23](https://discuss.elastic.co/t/elastic-defend-8-19-6-9-1-6-and-9-2-0-security-update-esa-2025-23/383272)) in {{elastic-defend}} on Windows which could allow a low-privilege attacker to delete arbitrary files on the system and potentially escalate privileges to SYSTEM. Windows 11 24H2 includes changes which make this issue harder to exploit.
 
 [discrete]
 [[release-notes-8.19.6]]

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -24,7 +24,7 @@
 * Fixes multiple {elastic-defend} issues in malware protection for Linux where a deadlock could sometimes occur when containers and autofs were both active.
 * Fixes an {elastic-defend} bug in Linux event collection where some long-running processes were not enriched.
 * Fixes an issue in {elastic-defend} that could cause the `get-file` and `execute` response actions to start failing after many are issued with a single running instance of {elastic-defend}.
-* Fixes CVE-2025-37735 ([ESA-2025-23](https://discuss.elastic.co/t/elastic-defend-8-19-6-9-1-6-and-9-2-0-security-update-esa-2025-23/383272)) in {{elastic-defend}} on Windows which could allow a low-privilege attacker to delete arbitrary files on the system and potentially escalate privileges to SYSTEM. Windows 11 24H2 includes changes which make this issue harder to exploit.
+* Fixes CVE-2025-37735 (https://discuss.elastic.co/t/elastic-defend-8-19-6-9-1-6-and-9-2-0-security-update-esa-2025-23/383272[ESA-2025-23]) in {elastic-defend} on Windows which could allow a low-privilege attacker to delete arbitrary files on the system and potentially escalate privileges to SYSTEM. Windows 11 24H2 includes changes which make this issue harder to exploit.
 
 [discrete]
 [[release-notes-8.19.6]]


### PR DESCRIPTION
Resolves https://github.com/elastic/security-docs/issues/7108: adds the 8.19.7 Security and Endpoint release notes.

Preview: [8.19.7](https://security-docs_bk_7109.docs-preview.app.elstc.co/guide/en/security/current/release-notes-header-8.19.0.html#release-notes-8.19.7)