### PR TITLE
Update max limit of notes

### DIFF
--- a/docs/events/add-manage-notes.asciidoc
+++ b/docs/events/add-manage-notes.asciidoc
@@ -3,7 +3,7 @@
 
 Incorporate notes into your investigative workflows to coordinate responses, conduct threat hunting, and share investigative findings. You can attach notes to alerts, events, and Timelines and manage them from the **Notes** page. 
 
-NOTE: Configure the `securitySolution:maxUnassociatedNotes` <<max-notes-alerts-events,advanced setting>> to specify the maximum number of notes that you can attach to alerts and events. 
+NOTE: You can attach up to 100 notes to alerts and events. The number of notes you can attach to Timelines is unlimited.
 
 [discrete]
 [[notes-privileges]]

--- a/docs/getting-started/advanced-setting.asciidoc
+++ b/docs/getting-started/advanced-setting.asciidoc
@@ -178,12 +178,6 @@ By default, Elastic prebuilt rules in the *Rules* and *Rule Monitoring* tables i
 The `securitySolution:alertTags` field determines which options display in the alert tag menu. The default alert tag options are `Duplicate`, `False Positive`, and `Further investigation required`. You can update the alert tag menu by editing these options or adding more. To learn more about using alert tags, refer to <<apply-alert-tags>>.
 
 [discrete]
-[[max-notes-alerts-events]]
-== Set the maximum notes limit for alerts and events 
-
-The `securitySolution:maxUnassociatedNotes` field determines the maximum number of <<add-manage-notes,notes>> that you can attach to alerts and events. The maximum limit and default value is 10000. 
-
-[discrete]
 [[exclude-cold-frozen-data-rule-executions]]
 == Exclude cold and frozen data from rules 
 


### PR DESCRIPTION
Resolves https://github.com/elastic/docs-content/issues/3931.
Updates the information on the maximum supported number of notes per alert/event/Timeline and removes the `securitySolution:maxUnassociatedNotes` advanced setting.

Previews:
* [Notes](https://security-docs_bk_7113.docs-preview.app.elstc.co/guide/en/security/8.19/add-manage-notes.html)
* [Configure advanced settings](https://security-docs_bk_7113.docs-preview.app.elstc.co/guide/en/security/8.19/advanced-settings.html)

9.x PR: https://github.com/elastic/docs-content/pull/3958