### PR TITLE
Security 8.19.8 release notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.19.8, {elastic-sec} version 8.19.8>>
 * <<release-notes-8.19.7, {elastic-sec} version 8.19.7>>
 * <<release-notes-8.19.6, {elastic-sec} version 8.19.6>>
 * <<release-notes-8.19.5, {elastic-sec} version 8.19.5>>

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -10,7 +10,7 @@
 ==== Enhancements
 * Improves the alert details flyout by saving the selected threat intelligence time to local storage ({kibana-pull}243571[#243571]).
 * Improves the alert details flyout by saving the selected prevalence time to local storage ({kibana-pull}243543[#243543]).
-
+* Ignores `resource_already_exists_exception` for value list creation hook [#243642]({{kib-pull}}243642).
 [discrete]
 [[bug-fixes-8.19.8]]
 ==== Fixes

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -10,7 +10,7 @@
 ==== Enhancements
 * Improves the alert details flyout by saving the selected threat intelligence time to local storage ({kibana-pull}243571[#243571]).
 * Improves the alert details flyout by saving the selected prevalence time to local storage ({kibana-pull}243543[#243543]).
-* Ignores `resource_already_exists_exception` for value list creation hook [#243642]({{kib-pull}}243642).
+* Ignores `resource_already_exists_exception` for value list creation hook ({kibana-pull}243642[#243642]).
 [discrete]
 [[bug-fixes-8.19.8]]
 ==== Fixes

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -2,6 +2,21 @@
 == 8.19
 
 [discrete]
+[[release-notes-8.19.8]]
+=== 8.19.8
+
+[discrete]
+[[enhancements-8.19.8]]
+==== Enhancements
+* Improves the alert details flyout by saving the selected threat intelligence time to local storage ({kibana-pull}243571[#243571]).
+* Improves the alert details flyout by saving the selected prevalence time to local storage ({kibana-pull}243543[#243543]).
+
+[discrete]
+[[bug-fixes-8.19.8]]
+==== Fixes
+* Fixes a UI issue when displaying {esql} queries in Timeline full screen mode ({kibana-pull}242027[#242027]).
+
+[discrete]
 [[release-notes-8.19.7]]
 === 8.19.7
 


### PR DESCRIPTION
Resolves https://github.com/elastic/security-docs/issues/7116: adds the 8.19.8 Security release notes.
No Endpoint release notes were picked up by the release notes tool.

Preview: [8.19](https://security-docs_bk_7117.docs-preview.app.elstc.co/guide/en/security/current/release-notes-header-8.19.0.html)