### PR TITLE
Security 8.19.10 release notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,7 +3,8 @@
 
 This section summarizes the changes in each release.
 
-* <<release-notes-8.19.8, {elastic-sec} version 8.19.9>>
+* <<release-notes-8.19.10, {elastic-sec} version 8.19.10>>
+* <<release-notes-8.19.9, {elastic-sec} version 8.19.9>>
 * <<release-notes-8.19.8, {elastic-sec} version 8.19.8>>
 * <<release-notes-8.19.7, {elastic-sec} version 8.19.7>>
 * <<release-notes-8.19.6, {elastic-sec} version 8.19.6>>

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -11,14 +11,14 @@
 * Updates MITRE ATT&CK mappings to `v18.1` ({kibana-pull}246770[#246770]).
 * Adds support for multiple values in the indicator details flyout **Table** tab ({kibana-pull}236110[#236110]).
 * Updates Gemini Connector configuration ({kibana-pull}245647[#245647]).
-* Improves general system responsiveness while {elastic-defend} is installed.
+* Improves responsiveness on systems running {elastic-defend}.
 * Improves the {elastic-defend} startup log to explain details about unsigned policies.
 
 [discrete]
 [[bug-fixes-8.19.10]]
 ==== Fixes
 * Fixes an issue where the Security AI Assistant API didn't use an associated conversation's system prompt ({kibana-pull}248020[#248020]).
-* Fixes an issue in the notes filter where the `createdBy` field didn't use exact matching ({kibana-pull}247351[#247351]).
+* Fixes an issue where the `createdBy` field in the notes filter didn't use exact matching ({kibana-pull}247351[#247351]).
 * Fixes a display issue with filters on the **MITRE ATT&CK® coverage** page ({kibana-pull}246794[#246794]).
 * Fixes an issue where Timeline actions appeared in the Alerts table bulk actions menu without proper privileges ({kibana-pull}246150[#246150]).
 * Fixes an issue where the **Threat intelligence** section in the alert details flyout didn't display multiple values ({kibana-pull}245449[#245449]).

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -2,6 +2,32 @@
 == 8.19
 
 [discrete]
+[[release-notes-8.19.10]]
+=== 8.19.10
+
+[discrete]
+[[enhancements-8.19.10]]
+==== Enhancements
+* Updates MITRE ATT&CK mappings to `v18.1` ({kibana-pull}246770[#246770]).
+* Adds support for multiple values in the indicator details flyout **Table** tab ({kibana-pull}236110[#236110]).
+* Updates Gemini Connector configuration ({kibana-pull}245647[#245647]).
+* Improves general system responsiveness while {elastic-defend} is installed.
+* Improves the {elastic-defend} startup log to explain details about unsigned policies.
+
+[discrete]
+[[bug-fixes-8.19.10]]
+==== Fixes
+* Fixes an issue where the Security AI Assistant API didn't use an associated conversation's system prompt ({kibana-pull}248020[#248020]).
+* Fixes an issue in the notes filter where the `createdBy` field didn't use exact matching ({kibana-pull}247351[#247351]).
+* Fixes a display issue with filters on the **MITRE ATT&CK® coverage** page ({kibana-pull}246794[#246794]).
+* Fixes an issue where Timeline actions appeared in the Alerts table bulk actions menu without proper privileges ({kibana-pull}246150[#246150]).
+* Fixes an issue where the **Threat intelligence** section in the alert details flyout didn't display multiple values ({kibana-pull}245449[#245449]).
+* Fixes an issue where {elastic-defend} upgrades and uninstallations could fail on busy systems.
+* Fixes a bug where {elastic-defend} on Linux could fail to initialize with {elastic-agent}.
+* For {elastic-defend} on Linux, reduces the occurrence of policy failures related to malware protection system deadlock avoidance.
+* Fixes an issue in {elastic-defend} on Windows where Mark of the Web parsing incorrectly handled file origin information ending with a CRLF or `\0`.
+
+[discrete]
 [[release-notes-8.19.9]]
 === 8.19.9
 

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -25,7 +25,7 @@
 * Fixes an issue where {elastic-defend} upgrades and uninstallations could fail on busy systems.
 * Fixes a bug where {elastic-defend} on Linux could fail to initialize with {elastic-agent}.
 * For {elastic-defend} on Linux, reduces the occurrence of policy failures related to malware protection system deadlock avoidance.
-* Fixes an issue in {elastic-defend} on Windows where Mark of the Web parsing incorrectly handled file origin information ending with a CRLF or `\\0`.
+* Fixes an issue in {elastic-defend} on Windows where Mark of the Web parsing incorrectly handled file origin information ending with a `\\0`.
 
 [discrete]
 [[release-notes-8.19.9]]

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -13,11 +13,12 @@
 * Updates Gemini Connector configuration ({kibana-pull}245647[#245647]).
 * Improves responsiveness on systems running {elastic-defend}.
 * Improves the {elastic-defend} startup log to explain details about unsigned policies.
+* Optimizes the {elastic-defend} kernel driver to collect file and registry access events more efficiently, improving overall system responsiveness and reducing CPU usage.
 
 [discrete]
 [[bug-fixes-8.19.10]]
 ==== Fixes
-* Fixes an issue where the Security AI Assistant API didn't use an associated conversation's system prompt ({kibana-pull}248020[#248020]).
+* Fixes an issue where the Security AI Assistant chat completion API didn't use an associated conversation's system prompt ({kibana-pull}248020[#248020]).
 * Fixes an issue where the `createdBy` field in the notes filter didn't use exact matching ({kibana-pull}247351[#247351]).
 * Fixes a display issue with filters on the **MITRE ATT&CK® coverage** page ({kibana-pull}246794[#246794]).
 * Fixes an issue where Timeline actions appeared in the Alerts table bulk actions menu without proper privileges ({kibana-pull}246150[#246150]).
@@ -26,6 +27,9 @@
 * Fixes a bug where {elastic-defend} on Linux could fail to initialize with {elastic-agent}.
 * For {elastic-defend} on Linux, reduces the occurrence of policy failures related to malware protection system deadlock avoidance.
 * Fixes an issue in {elastic-defend} on Windows where Mark of the Web parsing incorrectly handled file origin information ending with a `\\0`.
+* Reduces the occurrence of Linux {elastic-defend} policy failures due Malware protections system deadlock avoidance.
+* Fixes an issue in {elastic-defend} that could result in delayed or missing malware-on-write alerts.
+* Fixes a bug in {elastic-defend} on Windows that can sometimes result in `KERNEL_AUTO_BOOST_LOCK_ACQUISITION_WITH_RAISED_IRQL` or `PAGE_FAULT_IN_NONPAGED_AREA` bugchecks when [Offloaded Data Transfer (ODX)](https://learn.microsoft.com/en-us/windows-hardware/drivers/storage/offloaded-data-transfer) is used to copy files.  This regression was introduced in {elastic-defend} versions 8.19.8, 9.1.8, and 9.2.2.
 
 [discrete]
 [[release-notes-8.19.9]]

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -29,7 +29,7 @@
 * Fixes an issue in {elastic-defend} on Windows where Mark of the Web parsing incorrectly handled file origin information ending with a `\\0`.
 * Reduces the occurrence of Linux {elastic-defend} policy failures due Malware protections system deadlock avoidance.
 * Fixes an issue in {elastic-defend} that could result in delayed or missing malware-on-write alerts.
-* Fixes a bug in {elastic-defend} on Windows that can sometimes result in `KERNEL_AUTO_BOOST_LOCK_ACQUISITION_WITH_RAISED_IRQL` or `PAGE_FAULT_IN_NONPAGED_AREA` bugchecks when [Offloaded Data Transfer (ODX)](https://learn.microsoft.com/en-us/windows-hardware/drivers/storage/offloaded-data-transfer) is used to copy files.  This regression was introduced in {elastic-defend} versions 8.19.8, 9.1.8, and 9.2.2.
+* Fixes a bug in {elastic-defend} on Windows that could sometimes result in `KERNEL_AUTO_BOOST_LOCK_ACQUISITION_WITH_RAISED_IRQL` or `PAGE_FAULT_IN_NONPAGED_AREA` bugchecks when [Offloaded Data Transfer (ODX)](https://learn.microsoft.com/en-us/windows-hardware/drivers/storage/offloaded-data-transfer) was used to copy files. This regression was introduced in {elastic-defend} versions 8.19.8, 9.1.8, and 9.2.2.
 
 [discrete]
 [[release-notes-8.19.9]]

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -25,7 +25,7 @@
 * Fixes an issue where {elastic-defend} upgrades and uninstallations could fail on busy systems.
 * Fixes a bug where {elastic-defend} on Linux could fail to initialize with {elastic-agent}.
 * For {elastic-defend} on Linux, reduces the occurrence of policy failures related to malware protection system deadlock avoidance.
-* Fixes an issue in {elastic-defend} on Windows where Mark of the Web parsing incorrectly handled file origin information ending with a CRLF or `\0`.
+* Fixes an issue in {elastic-defend} on Windows where Mark of the Web parsing incorrectly handled file origin information ending with a CRLF or `\\0`.
 
 [discrete]
 [[release-notes-8.19.9]]


### PR DESCRIPTION
Resolves https://github.com/elastic/security-docs/issues/7121: adds the 8.19.10 Security end Endpoint release notes.

Preview:  [8.19.10](https://security-docs_bk_7122.docs-preview.app.elstc.co/guide/en/security/8.19/release-notes-header-8.19.0.html#release-notes-8.19.10)


1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  


Tool(s) and model(s) used:
Cursor, claude-4.5-opus-high