### PR TITLE
8.19.9 release notes fix 

### DIFF
--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -76,7 +76,7 @@ TIP: As long as the major and minor versions match, you can run a newer patch ve
 [discrete]
 [[features-8.19.9]]
 ==== New features
-* Hardens {elastic-defend} against cloud filter rebinding.
+* Hardens {elastic-defend} on Windows against Bind Filter rebinding attacks.
 
 [discrete]
 [[enhancements-8.19.9]]


### PR DESCRIPTION
Edits an Elastic Defend release notes entry in 8.19.9 RNs to match the wording in 9.3 RNs. Requested by @AsuNa-jp in Slack.

9.x fix: https://github.com/elastic/docs-content/pull/5199