### PR TITLE
[Security][Cases][Bug]: Case templates were GA'd in 8.18

### DIFF
--- a/docs/cases/cases-manage-settings.asciidoc
+++ b/docs/cases/cases-manage-settings.asciidoc
@@ -102,8 +102,6 @@ You can subsequently remove or edit custom fields on the **Settings** page.
 [[cases-templates]]
 === Templates
 
-preview::[]
-
 You can make the case creation process faster and more consistent by adding templates.
 A template defines values for one or all of the case fields (such as severity, tags, description, and title) as well as any custom fields.
 

--- a/docs/cases/cases-manage.asciidoc
+++ b/docs/cases/cases-manage.asciidoc
@@ -16,7 +16,7 @@ colleagues.
 
 . Find **Cases** in the navigation menu or search for `Security/Cases` by using the {kibana-ref}/introduction.html#kibana-navigation-search[global search field], then click *Create case*. If no cases exist, the Cases table will be empty and you'll be prompted to create one by clicking the *Create case* button inside the table.
 
-. If you defined <<cases-templates,templates>>, you can optionally select one to use its default field values. preview:[]
+. If you defined <<cases-templates,templates>>, you can optionally select one to use its default field values.
 
 . Give the case a name, assign a severity level, and provide a description. You can use
 https://www.markdownguide.org/cheat-sheet[Markdown] syntax in the case description.


### PR DESCRIPTION
Fixes https://github.com/elastic/docs-content/issues/5209. 

Case templates were moved from tech preview to GA in 8.18. The 8.18 and 8.19 docs still show them as being in tech preview.