### PR TITLE
[Internal][8.x]: Modify DE privilege requirements 

### DIFF
--- a/docs/detections/detections-req.asciidoc
+++ b/docs/detections/detections-req.asciidoc
@@ -58,7 +58,7 @@ The following table describes the required privileges to access the Detections f
 a|`manage`, `write`, `read`, and `view_index_metadata` for these system indices and data streams, where `<space-id>` is the space name:
 
 * `.alerts-security.alerts-<space-id>`
-* `.siem-signals-<space-id>` ^1^
+* `.siem-signals-<space-id>*` ^1^
 * `.lists-<space-id>`
 * `.items-<space-id>`
 
@@ -73,10 +73,10 @@ a|`manage`, `write`, `read`, and `view_index_metadata` for these system indices 
 |`manage`
 a|`manage`, `write`, `read`, and `view_index_metadata` for these system indices and data streams:
 
-* `.alerts-security.alerts-<space-id>`
-* `.siem-signals-<space-id>` ^1^
-* `.lists-<space-id>`
-* `.items-<space-id>`
+* `.alerts-security.alerts-*`
+* `.siem-signals-*`
+* `.lists-*`
+* `.items-*`
 
 ^1^ *NOTE*: If you're upgrading to {stack} 8.0.0 or later, users should have privileges for the `.alerts-security.alerts-<space-id>` AND `.siem-signals-<space-id>` indices. If you're newly installing the {stack}, then users do not need privileges for the `.siem-signals-<space-id>` index.
 


### PR DESCRIPTION
Fixes https://github.com/elastic/docs-content/issues/1695 for the 8.19 docs. 

[Preview](https://security-docs_bk_7147.docs-preview.app.elstc.co/guide/en/security/8.19/detections-permissions-section.html#enable-detections-ui) - Corrected index patterns for enabling detections in your space (`.siem-signals-<space-id>` -> `.siem-signals-<space-id>*`) and index patterns for enabling detections in all spaces.