### PR TITLE
Add SSL/TLS certificate requirements to Elastic Defend requirements

### DIFF
--- a/docs/getting-started/elastic-endpoint-reqs.asciidoc
+++ b/docs/getting-started/elastic-endpoint-reqs.asciidoc
@@ -25,4 +25,7 @@ For information about supported operating systems, refer to the https://www.elas
 |**Resident set size (RSS) memory** |500 MB
 |===
 
+[discrete]
+== SSL/TLS certificate requirements 
 
+{elastic-endpoint} supports Elliptic Curve (EC) keys and all standard TLS {observability-guide}/apm-configuration-ssl.html#apm-ssl-common-config[common configuration options].


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/1133.

Preview: [Elastic Defend requirements](https://security-docs_bk_7150.docs-preview.app.elstc.co/guide/en/security/current/elastic-endpoint-deploy-reqs.html)

9.x docs updated in https://github.com/elastic/docs-content/pull/5344