### PR TITLE
Security 8.19.13 release notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.19.13, {elastic-sec} version 8.19.13>>
 * <<release-notes-8.19.12, {elastic-sec} version 8.19.12>>
 * <<release-notes-8.19.11, {elastic-sec} version 8.19.11>>
 * <<release-notes-8.19.10, {elastic-sec} version 8.19.10>>

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -2,6 +2,38 @@
 == 8.19
 
 [discrete]
+[[release-notes-8.19.13]]
+=== 8.19.13
+
+[discrete]
+[[breaking-changes-8.19.13]]
+==== Breaking changes
+*Removes `serializer` and `deserializer` parameters from the Lists API*
+
+Removes the unused `serializer` and `deserializer` parameters from the Lists API endpoints ({kibana-pull}250111[#250111]).
+
+*Impact* +
+API requests that include `serializer` or `deserializer` parameters will return a deprecation warning header. The parameters are ignored.
+
+*Action* +
+Remove any `serializer` or `deserializer` parameters from your Lists API requests.
+
+[discrete]
+[[enhancements-8.19.13]]
+==== Enhancements
+* Improves the reliability of {elastic-defend}'s malware-on-write detection.
+
+[discrete]
+[[bug-fixes-8.19.13]]
+==== Fixes
+* Fixes an issue where the alert details flyout persisted after navigating away from {elastic-sec} ({kibana-pull}256001[#256001]).
+* Enables `defaultModel` for Azure OpenAI connector to support APIM endpoints ({kibana-pull}253577[#253577]).
+* Fixes an issue where the legacy `rules/prepackaged` endpoints returned 500 errors on Basic licenses when processing prebuilt rule packages that include {ml} rules ({kibana-pull}253574[#253574]).
+* Adds support for timestamp overrides to Timeline at the data view level, allowing Timeline to use the data view's configured timestamp field instead of `@timestamp` ({kibana-pull}251827[#251827]).
+* Improves {elastic-defend} Linux trusted application handling by using Quark's trusted PID queue APIs for more consistent trusted PID synchronization.
+* Fixes an issue that would cause hotfix builds of {elastic-defend} to incorrectly report their version in Windows Security Center. 
+
+[discrete]
 [[release-notes-8.19.12]]
 === 8.19.12
 

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -8,7 +8,11 @@
 [discrete]
 [[breaking-changes-8.19.13]]
 ==== Breaking changes
-*Removes `serializer` and `deserializer` parameters from the Lists API*
+
+[discrete]
+.Removes `serializer` and `deserializer` parameters from the Lists API
+[%collapsible]
+====
 
 Removes the unused `serializer` and `deserializer` parameters from the Lists API endpoints ({kibana-pull}250111[#250111]).
 
@@ -17,6 +21,7 @@ API requests that include `serializer` or `deserializer` parameters will return 
 
 *Action* +
 Remove any `serializer` or `deserializer` parameters from your Lists API requests.
+====
 
 [discrete]
 [[enhancements-8.19.13]]


### PR DESCRIPTION
Resolves https://github.com/elastic/security-docs/issues/7152: adds the 8.19.13 Security end Endpoint release notes.

Preview: [8.19](https://security-docs_bk_7154.docs-preview.app.elstc.co/guide/en/security/current/release-notes-header-8.19.0.html)