### PR TITLE
Add `kibana.alert.original_data_stream` to alert schema

### DIFF
--- a/docs/reference/alert-schema.asciidoc
+++ b/docs/reference/alert-schema.asciidoc
@@ -34,17 +34,13 @@ NOTE: The non-ECS fields listed below are beta and subject to change.
 |{ecs-ref}/ecs-client.html[`client.*`] | `client.*` | ECS `client.*` fields copied from the source document, if present, for custom query and indicator match rules.
 |{ecs-ref}/ecs-cloud.html[`cloud.*`] |`cloud.*` | ECS `cloud.*` fields copied from the source document, if present, for custom query and indicator match rules.
 |{ecs-ref}/ecs-container.html[`container.*`] | `container.*` | ECS `container.* fields` copied from the source document, if present, for custom query and indicator match rules.
-|{ecs-ref}/ecs-data_stream.html[`data_stream.*`] |`data_stream.*`| ECS `data_stream.*` fields copied from the source document, if present, for custom query and indicator match rules.
-
-NOTE: These fields may be constant keywords in the source documents, but are copied into the alert documents as keywords.
-
 |{ecs-ref}/ecs-destination.html[`destination.*`] | `destination.*`|ECS `destination.*` fields copied from the source document, if present, for custom query and indicator match rules.
 |{ecs-ref}/ecs-dll.html[`dll.*`] |`dll.*`| ECS `dll.*` fields copied from the source document, if present, for custom query and indicator match rules.
 |{ecs-ref}/ecs-dns.html[`dns.*`] | dns.* | ECS `dns.*` fields copied from the source document, if present, for custom query and indicator match rules.
 |{ecs-ref}/ecs-error.html[`error.*`]| `error.*` |ECS `error.*` fields copied from the source document, if present, for custom query and indicator match rules.
 |{ecs-ref}/ecs-event.html[`event.*`] | `event.*`| ECS `event.*` fields copied from the source document, if present, for custom query and indicator match rules.
 
-NOTE: categorization fields above (`event.kind`, `event.category`, `event.type`, `event.outcome`) are listed separately above.
+NOTE: categorization fields (`event.kind`, `event.category`, `event.type`, `event.outcome`) are listed separately.
 
 |{ecs-ref}/ecs-file.html[`file.*`]| `file.*` | ECS `file.*` fields copied from the source document, if present, for custom query and indicator match rules.
 |{ecs-ref}/ecs-group.html[`group.*`] | `group.*` | ECS `group.*` fields copied from the source document, if present, for custom query and indicator match rules.
@@ -80,7 +76,12 @@ NOTE: These fields are not related to the detection rule that generated the aler
 | N/A | `kibana.alert.new_terms` | The value of the new term that generated this alert.
 
 Type: keyword
-|`signal.original_event.*` | `kibana.alert.original_event.*`| Type: object
+| N/A | `kibana.alert.original_data_stream.*`| Data stream information copied from the original source event, including `dataset`, `namespace`, and `type` fields.
+
+Type: object
+|`signal.original_event.*` | `kibana.alert.original_event.*`| Event information copied from the original source event.
+
+Type: object
 |`signal.original_time`|`kibana.alert.original_time`| The value copied from the source event (`@timestamp`).
 
 Type: date


### PR DESCRIPTION
## Summary

Backport of [docs-content#3011](https://github.com/elastic/docs-content/pull/3011) for the 8.19 asciidoc docs.

Adds the new `kibana.alert.original_data_stream.*` fields (`dataset`, `namespace`, `type`) that were introduced in [kibana#220447](https://github.com/elastic/kibana/pull/220447) to copy source data stream information into alerts.

### Changes

- **Added** `kibana.alert.original_data_stream.*` as a new non-ECS field with description
- **Improved** `kibana.alert.original_event.*` description (was just "Type: object")
- **Removed** inaccurate `data_stream.*` ECS row and its associated NOTE
- **Updated** `event.*` NOTE wording for clarity

Closes https://github.com/elastic/docs-content/issues/2673
Relates to SDH https://github.com/elastic/sdh-security-team/issues/1626


Made with [Cursor](https://cursor.com)