### PR TITLE
[Security] 8.19.14 release notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.19.14, {elastic-sec} version 8.19.14>>
 * <<release-notes-8.19.13, {elastic-sec} version 8.19.13>>
 * <<release-notes-8.19.12, {elastic-sec} version 8.19.12>>
 * <<release-notes-8.19.11, {elastic-sec} version 8.19.11>>

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -2,6 +2,17 @@
 == 8.19
 
 [discrete]
+[[release-notes-8.19.14]]
+=== 8.19.14
+
+[discrete]
+[[bug-fixes-8.19.14]]
+==== Fixes
+* Fixes a denial-of-service risk in Timeline bulk export by validating the number of Timeline IDs (up to 1,000), deduplicating IDs, and bounding enrichment work ({kibana-pull}260265[#260265]).
+* Fixes an issue where notes not associated with a saved Timeline could appear on the **Notes** tab while investigating in Timeline, including for draft Timelines ({kibana-pull}259658[#259658]).
+* Fixes missing `user.name` and `group.name` fields in {elastic-defend} events in some LDAP environments.
+
+[discrete]
 [[release-notes-8.19.13]]
 === 8.19.13
 


### PR DESCRIPTION
Resolves https://github.com/elastic/security-docs/issues/7161: adds the 8.19.14 Security and Endpoint release notes.