### PR TITLE
[Security] 8.19.15 release notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.19.15, {elastic-sec} version 8.19.15>>
 * <<release-notes-8.19.14, {elastic-sec} version 8.19.14>>
 * <<release-notes-8.19.13, {elastic-sec} version 8.19.13>>
 * <<release-notes-8.19.12, {elastic-sec} version 8.19.12>>

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -2,6 +2,26 @@
 == 8.19
 
 [discrete]
+[[release-notes-8.19.15]]
+=== 8.19.15
+
+[discrete]
+[[enhancements-8.19.15]]
+==== Enhancements
+* Enables search in the **JSON** tab of the alert details flyout, matching the search experience available in the Discover document flyout ({kibana-pull}263875[#263875]).
+
+[discrete]
+[[bug-fixes-8.19.15]]
+==== Fixes
+* Fixes an issue with Indicator Filters in the read-only rule details UI, where incorrect backing indices caused misleading warnings to display on hover ({kibana-pull}263657[#263657]).
+* Fixes a Firefox-specific issue where the **Table** tab in the document details flyout jumped to the bottom when hovering over field rows with cell actions ({kibana-pull}262682[#262682]).
+* Fixes EQL rule creation so the query field re-validates after changing the index pattern, clearing stale errors when the query is valid for the newly selected data view ({kibana-pull}261027[#261027]).
+* Fixes a layout issue where alert KPI panels overflowed their containers, causing excess whitespace on the **Alerts** and **Attacks** pages ({kibana-pull}260803[#260803]).
+* Returns an error when you submit a malware scan job while malware protection is not enabled for {elastic-defend}.
+* Fixes an {elastic-defend} Kafka output issue by falling back to broker-selected partitioning when transient or invalid metadata responses are received.
+* Fixes a bug in {elastic-defend} that could delay uninstall by 30 seconds in some configurations.
+
+[discrete]
 [[release-notes-8.19.14]]
 === 8.19.14
 


### PR DESCRIPTION
Resolves https://github.com/elastic/security-docs/issues/7169: adds the 8.19.15 Security and Endpoint release notes.