### PR TITLE
Clarify that gdb is needed for elastic-endpoint memorydump

### DIFF
--- a/docs/management/admin/endpoint-command-ref.asciidoc
+++ b/docs/management/admin/endpoint-command-ref.asciidoc
@@ -114,6 +114,8 @@ elastic-endpoint install --upgrade --resources endpoint-security-resources.zip
 
 Save a memory dump of the {elastic-endpoint} service.
 
+NOTE: On Linux, GNU Debugger (GDB) must be installed to perform a memory dump.
+
 [discrete]
 === Options
 


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/6119.

9.x docs updated in https://github.com/elastic/docs-content/pull/6623.