### PR TITLE
[Security] 8.19.16 release notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.19.16, {elastic-sec} version 8.19.16>>
 * <<release-notes-8.19.15, {elastic-sec} version 8.19.15>>
 * <<release-notes-8.19.14, {elastic-sec} version 8.19.14>>
 * <<release-notes-8.19.13, {elastic-sec} version 8.19.13>>

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -2,6 +2,24 @@
 == 8.19
 
 [discrete]
+[[release-notes-8.19.16]]
+=== 8.19.16
+
+[discrete]
+[[bug-fixes-8.19.16]]
+==== Fixes
+* Fixes the **Manage license** link on the Attack Discovery page to navigate directly to **License Management** instead of the {stack-manage-app} landing page  ({kibana-pull}266445[#266445]).
+* Fixes a bug where the **Add to case** and **Add to existing case** actions were visible on the **Attack Discovery** page when the user lacked the necessary cases privileges ({kibana-pull}266127[#266127]).
+* Fixes an issue where the Data Quality dashboard showed no data when {kib} was set to Japanese ({kibana-pull}265782[#265782]).
+* Fixes an issue where {elastic-defend} failed to send data to {ls} output when the kernel TCP send buffer was full, causing connections to drop prematurely.
+* Updates eBPF probes for {elastic-defend} on Linux to support 7.0 kernels.
+* Fixes {elastic-defend} on Linux to report more accurate path names for file-less execution events.
+* Fixes an issue where {elastic-endpoint} could get stuck in the `CONFIGURING` state when updating an {elastic-defend} policy with rollback enabled on Windows.
+* Improves legacy event source compatibility with newer kernel versions (6.1+ and 7.0+) in {elastic-defend} on Linux.
+* Fixes an issue where {elastic-defend} on Linux could trigger unnecessary automount activity on systems using `autofs`.
+* Improves `fanotify` event collection reliability in {elastic-defend} on Ubuntu 26.04 and Linux 7.0.
+
+[discrete]
 [[release-notes-8.19.15]]
 === 8.19.15
 


### PR DESCRIPTION
Resolves https://github.com/elastic/security-docs/issues/7176: adds the 8.19.16 Security and Endpoint release notes.