### PR TITLE
[Security] 8.19.18 release notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.19.18, {elastic-sec} version 8.19.18>>
 * <<release-notes-8.19.17, {elastic-sec} version 8.19.17>>
 * <<release-notes-8.19.16, {elastic-sec} version 8.19.16>>
 * <<release-notes-8.19.15, {elastic-sec} version 8.19.15>>

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -17,6 +17,27 @@
 === 8.19.17
 
 [discrete]
+[[known-issue-8.19.17]]
+==== Known issues
+
+// tag::known-issue[]
+[discrete]
+.ProblemChild and DGA integrations fail to install
+[%collapsible]
+====
+*Details* +
+The https://www.elastic.co/docs/reference/integrations/problemchild[ProblemChild] (Living off the Land Detection) and https://www.elastic.co/docs/reference/integrations/dga[DGA] integration packages fail to install. This is caused by an {es} validation that limits field names in trained models to 100 characters.
+
+*Workaround* +
+Upgrade to {stack} 8.19.18.
+
+*Resolved* +
+This issue is fixed in {stack} 8.19.18.
+
+====
+// end::known-issue[]
+
+[discrete]
 [[bug-fixes-8.19.17]]
 ==== Fixes
 * Fixes a scroll-position jump in the alert details flyout **Table** tab ({kibana-pull}273521[#273521]).

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -1,6 +1,16 @@
 [[release-notes-header-8.19.0]]
 == 8.19
 
+[discrete]
+[[release-notes-8.19.18]]
+=== 8.19.18
+
+[discrete]
+[[bug-fixes-8.19.18]]
+==== Fixes
+* Fixes an issue where the rule editing UI rejected valid semver range version constraints (such as `^8.2.0 || ^9.0.0`) on related integrations [ ({kibana-pull}274133[#274133]).
+* Fixes an issue in the AI Assistant where selecting all conversations and then saving an edit to a single conversation deleted all conversations instead of updating only the edited one ({kibana-pull}274033[#274033]).
+* Fixes `bulk_max_size` output setting validation in {elastic-defend}.
 
 [discrete]
 [[release-notes-8.19.17]]


### PR DESCRIPTION
Resolves https://github.com/elastic/security-docs/issues/7186: adds the 8.19.18 Security and Endpoint release notes.