### PR TITLE
[Security] 8.19.21 release notes

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.19.21, {elastic-sec} version 8.19.21>>
 * <<release-notes-8.19.20, {elastic-sec} version 8.19.20>>
 * <<release-notes-8.19.19, {elastic-sec} version 8.19.19>>
 * <<release-notes-8.19.18, {elastic-sec} version 8.19.18>>

--- a/docs/release-notes/8.19.asciidoc
+++ b/docs/release-notes/8.19.asciidoc
@@ -2,6 +2,28 @@
 == 8.19
 
 [discrete]
+[[release-notes-8.19.21]]
+=== 8.19.21
+
+[discrete]
+[[enhancements-8.19.21]]
+==== Enhancements
+* Adds **Destination IP** as a built-in **Group alerts by** option on the alerts table, and includes aggregatable IP fields in the **Custom field** picker ({kibana-pull}284769[#284769]).
+* Improves {elastic-defend} logs for a down output connection, including the remaining backoff time.
+
+[discrete]
+[[bug-fixes-8.19.21]]
+==== Fixes
+* Fixes an issue where previously applied filters on the **Notes** page were not shown in the filter controls after navigating away and returning, even though the filters were still active ({kibana-pull}286574[#286574]).
+* Fixes an issue where Google Gemini 3.x models rejected requests that included tools with unconstrained string parameters ({kibana-pull}286302[#286302]).
+* Fixes an issue where detection rule exception items that use **IP range** value lists with more than 200 dash-notation entries were dropped during rule execution ({kibana-pull}285178[#285178]).
+* Updates a `curl` dependency in {elastic-defend} to resolve https://github.com/advisories/GHSA-gv3v-x3f3-7fxm[CVE-2024-8096].
+* Updates an OpenSSL dependency in {elastic-defend} to resolve multiple CVEs, including https://github.com/advisories/GHSA-f9v2-4w9p-2cwc[CVE-2026-34182] and https://github.com/advisories/GHSA-5888-36j9-c92p[CVE-2025-66199].
+* Updates a `zlib` dependency in {elastic-defend} to resolve https://github.com/advisories/GHSA-h858-mf2m-8jf4[CVE-2026-27171].
+* Fixes a deadlock between {elastic-defend} malware protection and SSSD on Active Directory-joined Linux hosts that could stall process executions and disable malware protection with the message `Disabled due to potential system deadlock`.
+* Fixes an issue where {elastic-defend} on Linux intermittently failed to enable event collection on hosts with a large number of active network connections.
+
+[discrete]
 [[release-notes-8.19.20]]
 === 8.19.20
 


### PR DESCRIPTION
Resolves https://github.com/elastic/docs-content/issues/7976: adds the 8.19.21 Security and Endpoint release notes.


Made with [Cursor](https://cursor.com)